### PR TITLE
[Sikkerhet] Oppdaterer med catalog-info.yaml til versjon 3.0

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 3.0
 organization: IT
 product: Kartverket.dev
 repo_types: [InternalClient,InternalApi]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,11 +1,55 @@
-apiVersion: backstage.io/v1alpha1
-kind: Component
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
 metadata:
-  name: backstage
-  description: An example of a Backstage application.
-  annotations:
-    backstage.io/techdocs-ref: dir:.
+  name: "kartverket.dev"
+  tags:
+  - "internal"
 spec:
-  type: website
-  owner: john@example.com
-  lifecycle: experimental
+  type: "website"
+  lifecycle: "production"
+  owner: "skip"
+  providesApis:
+  - "kartverket.dev-api"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_kartverket.dev"
+  title: "Security Champion kartverket.dev"
+spec:
+  type: "security_champion"
+  parent: "it_security_champions"
+  members:
+  - "eliihen"
+  children:
+  - "resource:kartverket.dev"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "kartverket.dev"
+  links:
+  - url: "https://github.com/kartverket/kartverket.dev"
+    title: "kartverket.dev på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_kartverket.dev"
+  dependencyOf:
+  - "component:kartverket.dev"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "API"
+metadata:
+  name: "kartverket.dev-api"
+  tags:
+  - "internal"
+spec:
+  type: "openapi"
+  lifecycle: "production"
+  owner: "skip"
+  definition: |
+    openapi: "3.0.0"
+    info:
+        title: kartverket.dev API
+    paths:


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage, samtidig som `beskrivelse.yaml` nå går til `version: 3.0`.
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.