### PR TITLE
Update service account name

### DIFF
--- a/terraform/backstage_serviceaccount.tf
+++ b/terraform/backstage_serviceaccount.tf
@@ -1,14 +1,14 @@
 # Creates the service account used by the backstage pod to read the techdocs bucket
 
-resource "google_service_account" "reader" {
-  account_id   = "techdocs-reader"
-  display_name = "TechDocs Reader"
+resource "google_service_account" "backstage" {
+  account_id   = "backstage"
+  display_name = "Backstage service account"
   project      = var.gcp_project_id
 }
 
 resource "google_service_account_iam_binding" "kubernetes" {
   role               = "roles/iam.workloadIdentityUser"
-  service_account_id = google_service_account.reader.name
+  service_account_id = google_service_account.backstage.name
   members = [
     "serviceAccount:${var.kubernetes_gcp_project_id}.svc.id.goog[${var.kubernetes_namespace}/${var.kubernetes_service_account_name}]"
   ]
@@ -16,8 +16,10 @@ resource "google_service_account_iam_binding" "kubernetes" {
 
 resource "google_service_account_iam_binding" "kubernetes_token" {
   role               = "roles/iam.serviceAccountTokenCreator"
-  service_account_id = google_service_account.reader.name
+  service_account_id = google_service_account.backstage.name
   members = [
-    "serviceAccount:${var.kubernetes_gcp_project_id}.svc.id.goog[${var.kubernetes_namespace}/${var.kubernetes_service_account_name}]"
+    "serviceAccount:${var.kubernetes_gcp_project_id}.svc.id.goog[${var.kubernetes_namespace}/${var.kubernetes_service_account_name}]",
+    "user:august.dahl@kartverket.no",
+    "user:jonas.wagle@kartverket.no",
   ]
 }

--- a/terraform/bucket.tf
+++ b/terraform/bucket.tf
@@ -17,6 +17,6 @@ resource "google_storage_bucket_iam_binding" "service_accounts" {
   role   = "roles/storage.admin"
   members = [
     "serviceAccount:${google_service_account.writer.email}",
-    "serviceAccount:${google_service_account.reader.email}",
+    "serviceAccount:${google_service_account.backstage.email}",
   ]
 }


### PR DESCRIPTION
due to the way WIF works on gke we need to use the same service account for cloudsqlproxy as for other gcp things