### PR TITLE
Oppdater dask-plugins og fjern debugging på hjemskjerm

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -48,7 +48,7 @@
     "@backstage/theme": "^0.5.1",
     "@internal/plugin-instatus": "^0.1.0",
     "@k-phoen/backstage-plugin-grafana": "^0.1.22",
-    "@kartverket/backstage-plugin-dask-onboarding": "^0.1.3",
+    "@kartverket/backstage-plugin-dask-onboarding": "^0.1.5",
     "@kartverket/backstage-plugin-risk-scorecard": "^1.0.11",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import {
   HomePageToolkit,
   HomePageCompanyLogo,
@@ -22,8 +22,6 @@ import databricksLogo from './logos/Databricks.png';
 import githubLogo from './logos/Github.png';
 import daskLogo from './logos/DASK.png';
 import skipLogo from './logos/SKIP.png';
-import { useApi, identityApiRef } from '@backstage/core-plugin-api';
-import { jwtDecode } from 'jwt-decode';
 
 const useStyles = makeStyles(theme => ({
   searchBarInput: {
@@ -53,62 +51,12 @@ const useLogoStyles = makeStyles(theme => ({
   },
 }));
 
-type UserGroups = {
-  groups: string[]
-};
-
-type UserGroup = {
-  area: string;
-  role: string;
-};
-
 export const HomePage = () => {
   const classes = useStyles();
-  const identityApi = useApi(identityApiRef);
   
   const { svg, path, container } = useLogoStyles();
   const theme = useTheme();
   const mode = theme.palette.type === 'dark' ? 'light' : 'dark';
-  // TODO: DASK WILL DELETE AFTER DEBUGGING
-  async function getIdentity() {
-    const token = await identityApi.getCredentials();
-    return token
-  }
-
-  function decodeToken(token: string): UserGroups | null {
-    try {
-      const decoded = jwtDecode<UserGroups>(token);
-      console.log('Decoded Token:', decoded);
-      return decoded;
-    } catch (error) {
-      console.error('Invalid token:', error);
-      return null;
-    }
-  }
-  const [groupAreaMap, setGroupAreaMap] = useState<UserGroup[]>([]);
-
-  useEffect(() => {
-    const fetchToken = async () => {
-      const result = await getIdentity();
-      console.log('Token:', result.token)
-      if (result.token) {
-        const decoded = decodeToken(result.token);        
-        if (decoded?.groups) {
-          const groupsMap = decoded.groups.map((group: string) => {
-            const [area, role] = group.split(':');
-            return { area, role };
-          });
-          setGroupAreaMap(groupsMap);
-        }
-      }
-    };
-
-    fetchToken();
-  }, []);
-
-  useEffect(() => {
-    console.log('Updated groupAreaMap:', groupAreaMap);
-  }, [groupAreaMap]);
 
   return (
     <SearchContextProvider>

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -43,7 +43,7 @@
     "@backstage/plugin-search-backend-module-techdocs": "^0.1.17",
     "@backstage/plugin-search-backend-node": "^1.2.17",
     "@backstage/plugin-techdocs-backend": "^1.9.6",
-    "@kartverket/backstage-plugin-dask-onboarding-backend": "^0.1.3",
+    "@kartverket/backstage-plugin-dask-onboarding-backend": "^0.1.4",
     "@roadiehq/scaffolder-backend-module-utils": "^1.13.2",
     "app": "link:../app",
     "better-sqlite3": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6664,10 +6664,10 @@
   resolved "https://registry.yarnpkg.com/@kamilkisiela/fast-url-parser/-/fast-url-parser-1.1.4.tgz#9d68877a489107411b953c54ea65d0658b515809"
   integrity sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==
 
-"@kartverket/backstage-plugin-dask-onboarding-backend@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@kartverket/backstage-plugin-dask-onboarding-backend/-/backstage-plugin-dask-onboarding-backend-0.1.3.tgz#7a8d8e32b3a8bab480d063b5b62cc2a15507bfd0"
-  integrity sha512-HsSBy+n3wR7kuOhHP2tHTB9hit+ok+GX8LF9ZvzEEiNcEmtAC8LTiQw8Ad0Tms3UQ2s7h9pn3USgSyae8ays7w==
+"@kartverket/backstage-plugin-dask-onboarding-backend@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@kartverket/backstage-plugin-dask-onboarding-backend/-/backstage-plugin-dask-onboarding-backend-0.1.4.tgz#daf067937d390ab8049969393a0602cc367a4d73"
+  integrity sha512-MKm70zAORrfoOIEvTchc8OIV/iwQE9SkWd6PY4BTw3bg4vjwGGDt9xx+2kRJX9R+f4aGRZohSN8Ybg09lGn4tA==
   dependencies:
     "@backstage/backend-common" "^0.21.6"
     "@backstage/config" "^1.2.0"
@@ -6683,10 +6683,10 @@
     winston "^3.2.1"
     yn "^4.0.0"
 
-"@kartverket/backstage-plugin-dask-onboarding@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@kartverket/backstage-plugin-dask-onboarding/-/backstage-plugin-dask-onboarding-0.1.3.tgz#cfc2a8ed594bb76ccc9345d4ac992ccc70123cad"
-  integrity sha512-VX01ZzGtG3tiART0ulacy0Fr9mQ6ZHfr8zWtcSFlNqcEDaHYAStgUlPoxt57mpncRTuDU51prcgJaPyStP4tOg==
+"@kartverket/backstage-plugin-dask-onboarding@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@kartverket/backstage-plugin-dask-onboarding/-/backstage-plugin-dask-onboarding-0.1.5.tgz#9497ec8c5818351bd1a71bbb385706a58c0bd1d2"
+  integrity sha512-oNm+/dkdnoGqrqcR58tYcufK4TPn5V2/nakstAeWcsSlAnxnVELmGmAOYQHclp+9pDbyKOEQYQy/hHeGkc67nw==
   dependencies:
     "@backstage/core-components" "^0.14.3"
     "@backstage/core-plugin-api" "^1.9.1"
@@ -6694,13 +6694,14 @@
     "@material-ui/core" "^4.12.2"
     "@material-ui/icons" "^4.9.1"
     "@material-ui/lab" "4.0.0-alpha.61"
+    jwt-decode "^4.0.0"
     react-use "^17.2.4"
     styled-components "^6.1.8"
 
-"@kartverket/backstage-plugin-risk-scorecard@^1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@kartverket/backstage-plugin-risk-scorecard/-/backstage-plugin-risk-scorecard-1.0.8.tgz#f2b236f31a2a8b3c6c5e17621837212a1a3bcf08"
-  integrity sha512-5UgcTST9nSVIsqx4+oezg+hIX4Ry1D/Mqk4wLcOqcr74xW+hVOSuTnym6x8KTspIaiBfBt9k4yZKL7mfouuJNw==
+"@kartverket/backstage-plugin-risk-scorecard@^1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@kartverket/backstage-plugin-risk-scorecard/-/backstage-plugin-risk-scorecard-1.0.11.tgz#d145cdeab110420930d282d936c567e4e7e7eed4"
+  integrity sha512-AoRlujPck6APk67HJHIfq/gbjxqNjp3OneqvBDjNt/L/cMmUQcc+LcuaI27dd7uGv8VowWH1szEO+SO2hhQSHQ==
   dependencies:
     "@backstage/core-components" "^0.13.9"
     "@backstage/core-plugin-api" "^1.8.1"
@@ -11834,8 +11835,8 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     "@backstage/theme" "^0.5.1"
     "@internal/plugin-instatus" "^0.1.0"
     "@k-phoen/backstage-plugin-grafana" "^0.1.22"
-    "@kartverket/backstage-plugin-dask-onboarding" "^0.1.3"
-    "@kartverket/backstage-plugin-risk-scorecard" "^1.0.8"
+    "@kartverket/backstage-plugin-dask-onboarding" "^0.1.5"
+    "@kartverket/backstage-plugin-risk-scorecard" "^1.0.11"
     "@material-ui/core" "^4.12.2"
     "@material-ui/icons" "^4.9.1"
     backstage-plugin-xkcd "^1.0.9"
@@ -24919,7 +24920,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -24993,7 +25003,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -25006,6 +25016,13 @@ strip-ansi@5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@6.0, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -26903,7 +26920,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -26916,6 +26933,15 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Oppdaterer plugins for dask-onboarding, der vi har tatt i bruk backstage-tokenet for å hente ut teams og tilhørende divisjoner. 

Fjerner i samme slengen debuggingen på forsiden som trengtes for å se hvordan tokenet kunne dekodes korrekt.