### PR TITLE
Revert "DASK-versjon: Konverter 'æøå' til håndterbare bokstaver for onboardingsflyten"

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -43,7 +43,7 @@
     "@internal/plugin-instatus": "^0.1.0",
     "@k-phoen/backstage-plugin-grafana": "^0.1.22",
     "@kartverket/backstage-plugin-risk-scorecard": "^1.0.13",
-    "@kartverket/backstage-plugin-dask-onboarding": "^0.1.12",
+    "@kartverket/backstage-plugin-dask-onboarding": "^0.1.11",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "backstage-plugin-xkcd": "^1.0.9",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -47,7 +47,7 @@
     "@backstage/plugin-search-backend-module-techdocs": "^0.1.25",
     "@backstage/plugin-search-backend-node": "^1.2.25",
     "@backstage/plugin-techdocs-backend": "^1.10.7",
-    "@kartverket/backstage-plugin-dask-onboarding-backend": "^0.1.10",
+    "@kartverket/backstage-plugin-dask-onboarding-backend": "^0.1.9",
     "@roadiehq/scaffolder-backend-module-utils": "^1.17.0",
     "app": "link:../app",
     "better-sqlite3": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6475,10 +6475,10 @@
   resolved "https://registry.yarnpkg.com/@kamilkisiela/fast-url-parser/-/fast-url-parser-1.1.4.tgz#9d68877a489107411b953c54ea65d0658b515809"
   integrity sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==
 
-"@kartverket/backstage-plugin-dask-onboarding-backend@^0.1.10":
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/@kartverket/backstage-plugin-dask-onboarding-backend/-/backstage-plugin-dask-onboarding-backend-0.1.10.tgz#c68797ad9a194216f9b60f3eb67f5b8dfb2c4aab"
-  integrity sha512-Fnjeo11cUgdeOedlUVNTV9+ySaZ8KKUC5hSTD5SbOc3ZNXNX5UUh6/qypxDxsBa05fymxsAeiUwi9VurcVmIUA==
+"@kartverket/backstage-plugin-dask-onboarding-backend@^0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@kartverket/backstage-plugin-dask-onboarding-backend/-/backstage-plugin-dask-onboarding-backend-0.1.9.tgz#74cb03af0122bd1bf38a19ff82a919b6a6059adc"
+  integrity sha512-KlAhKd2ip8uTfUZsUorlkuuGGPcrCGmY1Qx+mPNI4Z25+M3vCh1qIaZMwkuSpWjMXJoXxd/d95D3C9BO/4Xa0g==
   dependencies:
     "@backstage/backend-common" "^0.21.6"
     "@backstage/config" "^1.2.0"
@@ -6494,10 +6494,10 @@
     winston "^3.2.1"
     yn "^4.0.0"
 
-"@kartverket/backstage-plugin-dask-onboarding@^0.1.12":
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/@kartverket/backstage-plugin-dask-onboarding/-/backstage-plugin-dask-onboarding-0.1.12.tgz#5fe5856668ebb9aa869079dfb974ff79f4e30a92"
-  integrity sha512-oA8Cpk0DSNd81FuIFy7eMIA4aW3qvbzdyUjlzcqmAWXMkwsflOO3N7MB9KQJFtdP0Bai0zksFZYyyrpVUZGZTw==
+"@kartverket/backstage-plugin-dask-onboarding@^0.1.11":
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/@kartverket/backstage-plugin-dask-onboarding/-/backstage-plugin-dask-onboarding-0.1.11.tgz#c0d30d7242dbb3b5b13583cf3dd8671734db4a67"
+  integrity sha512-+O/5913Xbr09cPU6KJFV7qwrfXcq1SUM3d4sck6AuqmEARGPxnqcEW8a0CuesMqRG3tySGmiDP1k8kaoXLXuzg==
   dependencies:
     "@backstage/core-components" "^0.14.3"
     "@backstage/core-plugin-api" "^1.9.1"
@@ -11868,7 +11868,7 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     "@backstage/theme" "^0.5.6"
     "@internal/plugin-instatus" "^0.1.0"
     "@k-phoen/backstage-plugin-grafana" "^0.1.22"
-    "@kartverket/backstage-plugin-dask-onboarding" "^0.1.12"
+    "@kartverket/backstage-plugin-dask-onboarding" "^0.1.11"
     "@kartverket/backstage-plugin-risk-scorecard" "^1.0.13"
     "@material-ui/core" "^4.12.2"
     "@material-ui/icons" "^4.9.1"


### PR DESCRIPTION
Sandbox fungerer ikke som det skal på /dask-onboarding. Sjekker om det var siste deploy som gjorde det