### PR TITLE
Bump risk scorecard and add proxy config

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -44,6 +44,9 @@ proxy:
     target: "http://opencost.opencost.svc.cluster.local:9090"
   '/lighthouse':
     target: http://lighthouse-audit-service.lighthouse-audit-service.svc.cluster.local:3003
+  '/risc-proxy':
+    target: https://ros-plugin.atgcp1-dev.kartverket-intern.cloud
+    allowedHeaders: ['Authorization', 'GCP-Access-Token']
 
 lighthouse:
   baseUrl: /api/proxy/lighthouse

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -78,6 +78,9 @@ proxy:
       target: https://monitoring.kartverket.dev
       headers:
         Authorization: Bearer ${GRAFANA_TOKEN}
+    'risc-proxy':
+      target: http://localhost:8080
+      allowedHeaders: ['Authorization', 'GCP-Access-Token']
 
 lighthouse:
   baseUrl: http://localhost:7007/api/proxy/lighthouse
@@ -88,10 +91,6 @@ auth:
       development:
         clientId: ${GOOGLE_OAUTH_CLIENT_ID}
         clientSecret: ${GOOGLE_OAUTH_CLIENT_SECRET}
-
-riskAssessment:
-  baseUrl: https://ros-plugin.atgcp1-dev.kartverket-intern.cloud
-  path: .security/risc
 
 kubernetes:
   serviceLocatorMethod:

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -42,7 +42,7 @@
     "@backstage/theme": "^0.5.6",
     "@internal/plugin-instatus": "^0.1.0",
     "@k-phoen/backstage-plugin-grafana": "^0.1.22",
-    "@kartverket/backstage-plugin-risk-scorecard": "^1.0.13",
+    "@kartverket/backstage-plugin-risk-scorecard": "^1.0.14",
     "@kartverket/backstage-plugin-dask-onboarding": "^0.1.11",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",


### PR DESCRIPTION
Bumps `@kartverket/backstage-plugin-risk-scorecard -> 1.0.14` and adds required proxy configuration to app-configs.