### PR TITLE
Update app-config.production.yaml

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -88,6 +88,6 @@ cors:
   origin: ${APP_CONFIG_app_baseUrl}
 
 sikkerhetsmetrikker:
-  enable: false
-  baseUrl: https://sikkerhetsmetrikker.dev.skip.statkart.no
+  enable: true
+  baseUrl: https://sikkerhetsmetrikker.atgcp1-dev.kartverket-intern.cloud
   clientId: ${SIKKERHETSMETRIKKER_CLIENT_ID}


### PR DESCRIPTION
Skrur på pre-prosessering av security-champions-grupper til å transformere GitHub-bruker til riktig KV-mail for å mappe Security Champion til en `User` i Backstage. Oppdaterer også `baseUrl`.