### PR TITLE
Bump onboarding

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -43,7 +43,7 @@
     "@internal/plugin-instatus": "^0.1.0",
     "@k-phoen/backstage-plugin-grafana": "^0.1.22",
     "@kartverket/backstage-plugin-risk-scorecard": "^1.0.14",
-    "@kartverket/backstage-plugin-dask-onboarding": "^0.1.11",
+    "@kartverket/backstage-plugin-dask-onboarding": "^0.1.13",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "backstage-plugin-xkcd": "^1.0.9",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -48,7 +48,7 @@
     "@backstage/plugin-search-backend-module-techdocs": "^0.1.25",
     "@backstage/plugin-search-backend-node": "^1.2.25",
     "@backstage/plugin-techdocs-backend": "^1.10.7",
-    "@kartverket/backstage-plugin-dask-onboarding-backend": "^0.1.9",
+    "@kartverket/backstage-plugin-dask-onboarding-backend": "^0.1.13",
     "@roadiehq/scaffolder-backend-module-utils": "^1.17.0",
     "app": "link:../app",
     "better-sqlite3": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6760,10 +6760,10 @@
   resolved "https://registry.yarnpkg.com/@kamilkisiela/fast-url-parser/-/fast-url-parser-1.1.4.tgz#9d68877a489107411b953c54ea65d0658b515809"
   integrity sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==
 
-"@kartverket/backstage-plugin-dask-onboarding-backend@^0.1.9":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@kartverket/backstage-plugin-dask-onboarding-backend/-/backstage-plugin-dask-onboarding-backend-0.1.9.tgz#74cb03af0122bd1bf38a19ff82a919b6a6059adc"
-  integrity sha512-KlAhKd2ip8uTfUZsUorlkuuGGPcrCGmY1Qx+mPNI4Z25+M3vCh1qIaZMwkuSpWjMXJoXxd/d95D3C9BO/4Xa0g==
+"@kartverket/backstage-plugin-dask-onboarding-backend@^0.1.13":
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/@kartverket/backstage-plugin-dask-onboarding-backend/-/backstage-plugin-dask-onboarding-backend-0.1.13.tgz#38726a8507394306dd53316eb265ab15a673f3cb"
+  integrity sha512-dqkhLS9G3BPcx8r+jlvVo+kN6oCcPJq6S59P8u1MRa/2LBpXUi9CgLDPF71cwg6jjgPtcrVrlJj9I6gKMfZs1g==
   dependencies:
     "@backstage/backend-common" "^0.21.6"
     "@backstage/config" "^1.2.0"
@@ -6779,10 +6779,10 @@
     winston "^3.2.1"
     yn "^4.0.0"
 
-"@kartverket/backstage-plugin-dask-onboarding@^0.1.11":
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/@kartverket/backstage-plugin-dask-onboarding/-/backstage-plugin-dask-onboarding-0.1.11.tgz#c0d30d7242dbb3b5b13583cf3dd8671734db4a67"
-  integrity sha512-+O/5913Xbr09cPU6KJFV7qwrfXcq1SUM3d4sck6AuqmEARGPxnqcEW8a0CuesMqRG3tySGmiDP1k8kaoXLXuzg==
+"@kartverket/backstage-plugin-dask-onboarding@^0.1.13":
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/@kartverket/backstage-plugin-dask-onboarding/-/backstage-plugin-dask-onboarding-0.1.13.tgz#67d29b5473c71c521e26ece0b151bb770e8b2731"
+  integrity sha512-5G2l+SwvcFdkOIW/jsAY04DTyADHny45T21OMmGe8xxKFkW03oeqCwJl1UACWKHAx2CoCnNbPStAiUUsUHigdQ==
   dependencies:
     "@backstage/core-components" "^0.14.3"
     "@backstage/core-plugin-api" "^1.9.1"
@@ -12153,7 +12153,7 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     "@backstage/theme" "^0.5.6"
     "@internal/plugin-instatus" "^0.1.0"
     "@k-phoen/backstage-plugin-grafana" "^0.1.22"
-    "@kartverket/backstage-plugin-dask-onboarding" "^0.1.11"
+    "@kartverket/backstage-plugin-dask-onboarding" "^0.1.13"
     "@kartverket/backstage-plugin-risk-scorecard" "^1.0.14"
     "@material-ui/core" "^4.12.2"
     "@material-ui/icons" "^4.9.1"


### PR DESCRIPTION
I denne versjonen har jeg fjernet alt som er relatert til test-miljøet under onboarding, da dette ikke eksisterer i DASK-kontekst lenger