### PR TITLE
Legg til manglende skråstrek i proxy-config

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -78,7 +78,7 @@ proxy:
       target: https://monitoring.kartverket.dev
       headers:
         Authorization: Bearer ${GRAFANA_TOKEN}
-    'risc-proxy':
+    '/risc-proxy':
       target: http://localhost:8080
       allowedHeaders: ['Authorization', 'GCP-Access-Token']
 


### PR DESCRIPTION
Endepunktet ser ikke ut til å fungere på kartverket.dev, merker samtidig at det mangler en skråstrek i proxy-definisjonen her. Lett å se når man sammenlikner med de andre proxydefinisjonene