### PR TITLE
Update risc-proxy-url

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -46,7 +46,7 @@ proxy:
     '/lighthouse':
       target: http://lighthouse-audit-service.lighthouse-audit-service.svc.cluster.local:3003
     '/risc-proxy':
-      target: https://ros-plugin.atgcp1-dev.kartverket-intern.cloud
+      target: http://ros-plugin-backend.ros-plugin:8080
       allowedHeaders: ['Authorization', 'GCP-Access-Token']
 
 lighthouse:


### PR DESCRIPTION
Update URL for risc-proxy to use the URL of the kubernetes service.