### PR TITLE
Add security metrics plugin packages

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -9,7 +9,7 @@ backend:
   # callers. When its value is "http://localhost:7007", it's strictly private
   # and can't be reached by others.
   baseUrl: ${APP_CONFIG_backend_baseUrl}
-  sikmet-backend-baseurl: https://api.sikkerhetsmetrikker.plugin.atgcp1-dev.kartverket-intern.cloud/api
+  sikmet-backend-baseurl: http://plugin-backend.sikkerhetsmetrikker-main:8080/api
   # The listener can also be expressed as a single <host>:<port> string. In this case we bind to
   # all interfaces, the most permissive setting. The right value depends on your specific deployment.
   listen: ':7007'

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -9,6 +9,7 @@ backend:
   # callers. When its value is "http://localhost:7007", it's strictly private
   # and can't be reached by others.
   baseUrl: ${APP_CONFIG_backend_baseUrl}
+  sikmet-backend-baseurl: https://api.sikkerhetsmetrikker.plugin.atgcp1-dev.kartverket-intern.cloud/api
   # The listener can also be expressed as a single <host>:<port> string. In this case we bind to
   # all interfaces, the most permissive setting. The right value depends on your specific deployment.
   listen: ':7007'

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -32,6 +32,7 @@ backend:
   #   keys:
   #     - secret: ${BACKEND_SECRET}
   baseUrl: http://localhost:7007
+  sikmet-backend-baseurl: https://api.sikkerhetsmetrikker.plugin.atgcp1-dev.kartverket-intern.cloud/api
   listen:
     port: 7007
     # Uncomment the following host directive to bind to specific interfaces

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -14,6 +14,11 @@
     "lint": "backstage-cli package lint"
   },
   "dependencies": {
+    "@backstage-community/plugin-explore": "^0.4.21",
+    "@backstage-community/plugin-github-actions": "^0.6.16",
+    "@backstage-community/plugin-lighthouse": "^0.4.20",
+    "@backstage-community/plugin-linguist": "^0.1.20",
+    "@backstage-community/plugin-tech-radar": "^0.7.4",
     "@backstage/app-defaults": "^1.5.6",
     "@backstage/catalog-model": "^1.5.0",
     "@backstage/cli": "^0.26.9",
@@ -30,6 +35,7 @@
     "@backstage/plugin-devtools": "^0.1.15",
     "@backstage/plugin-home": "^0.7.5",
     "@backstage/plugin-kubernetes": "^0.11.11",
+    "@backstage/plugin-opencost": "0.2.5",
     "@backstage/plugin-org": "^0.6.26",
     "@backstage/plugin-permission-react": "^0.4.23",
     "@backstage/plugin-scaffolder": "^1.21.0",
@@ -42,8 +48,9 @@
     "@backstage/theme": "^0.5.6",
     "@internal/plugin-instatus": "^0.1.0",
     "@k-phoen/backstage-plugin-grafana": "^0.1.22",
-    "@kartverket/backstage-plugin-risk-scorecard": "^1.0.14",
     "@kartverket/backstage-plugin-dask-onboarding": "^0.1.14",
+    "@kartverket/backstage-plugin-risk-scorecard": "^1.0.14",
+    "@kartverket/backstage-plugin-security-metrics-frontend": "^0.1.0",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "backstage-plugin-xkcd": "^1.0.9",
@@ -54,13 +61,7 @@
     "react-dom": "^17.0.2",
     "react-router": "^6.3.0",
     "react-router-dom": "^6.3.0",
-    "react-use": "^17.2.4",
-    "@backstage/plugin-opencost": "0.2.5",
-    "@backstage-community/plugin-explore": "^0.4.21",
-    "@backstage-community/plugin-github-actions": "^0.6.16",
-    "@backstage-community/plugin-lighthouse": "^0.4.20",
-    "@backstage-community/plugin-linguist": "^0.1.20",
-    "@backstage-community/plugin-tech-radar": "^0.7.4"
+    "react-use": "^17.2.4"
   },
   "devDependencies": {
     "@backstage/test-utils": "^1.5.6",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -50,7 +50,6 @@
     "@k-phoen/backstage-plugin-grafana": "^0.1.22",
     "@kartverket/backstage-plugin-risk-scorecard": "^1.1.0",
     "@kartverket/backstage-plugin-dask-onboarding": "^0.1.14",
-    "@kartverket/backstage-plugin-risk-scorecard": "^1.0.14",
     "@kartverket/backstage-plugin-security-metrics-frontend": "^0.1.0",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -62,6 +62,7 @@ import { EntityLighthouseContent } from '@backstage-community/plugin-lighthouse'
 import { EntityKubernetesContent } from '@backstage/plugin-kubernetes';
 import { EntityGrafanaAlertsCard, EntityGrafanaDashboardsCard, EntityOverviewDashboardViewer, isAlertSelectorAvailable, isDashboardSelectorAvailable, isOverviewDashboardAvailable } from '@k-phoen/backstage-plugin-grafana';
 import { RiScPage } from '@kartverket/backstage-plugin-risk-scorecard';
+import { SecurityMetricsPage }  from '@kartverket/backstage-plugin-security-metrics-frontend';
 
 const techdocsContent = (
   <EntityTechdocsContent>
@@ -210,9 +211,13 @@ const serviceEntityPage = (
       {techdocsContent}
     </EntityLayout.Route>
 
-  <EntityLayout.Route path="/risc" title="ROS">
-      <RiScPage />
-  </EntityLayout.Route>
+    <EntityLayout.Route path="/risc" title="ROS">
+        <RiScPage />
+    </EntityLayout.Route>
+
+    <EntityLayout.Route path="/securityMetrics" title="Sikkerhetsmetrikker">
+        <SecurityMetricsPage />
+    </EntityLayout.Route>
 
   </EntityLayout>
 );
@@ -248,6 +253,10 @@ const websiteEntityPage = (
 
     <EntityLayout.Route path="/risc" title="Risk Scorecard">
         <RiScPage />
+    </EntityLayout.Route>
+
+    <EntityLayout.Route path="/securityMetrics" title="Sikkerhetsmetrikker">
+        <SecurityMetricsPage />
     </EntityLayout.Route>
 
   </EntityLayout>
@@ -413,6 +422,10 @@ const systemPage = (
         ]}
         unidirectional={false}
       />
+    </EntityLayout.Route>
+
+    <EntityLayout.Route path="/securityMetrics" title="Sikkerhetsmetrikker">
+        <SecurityMetricsPage />
     </EntityLayout.Route>
   </EntityLayout>
 );

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -49,6 +49,7 @@
     "@backstage/plugin-search-backend-node": "^1.2.25",
     "@backstage/plugin-techdocs-backend": "^1.10.7",
     "@kartverket/backstage-plugin-dask-onboarding-backend": "^0.1.13",
+    "@kartverket/backstage-plugin-security-metrics-backend": "^0.1.0",
     "@roadiehq/scaffolder-backend-module-utils": "^1.17.0",
     "app": "link:../app",
     "better-sqlite3": "^9.0.0",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -62,5 +62,8 @@ backend.add(import('@backstage/plugin-search-backend-module-techdocs/alpha'));
 // TechDocs
 backend.add(import('@backstage/plugin-techdocs-backend/alpha'));
 
+// Security metrics
+backend.add(import('@kartverket/backstage-plugin-security-metrics-backend'));
+
 
 backend.start();


### PR DESCRIPTION
Add first versions of the frontend and backend packages for the security metrics plugin. Add address to backend in app-configs. Add security-metrics plugin tab for some backstage entity pages. 