### PR TITLE
add activeDirectory block in app-config.production

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -93,3 +93,9 @@ sikkerhetsmetrikker:
   enable: true
   baseUrl: https://sikkerhetsmetrikker.atgcp1-dev.kartverket-intern.cloud
   clientId: ${SIKKERHETSMETRIKKER_CLIENT_ID}
+
+activeDirectory:
+  clientId: ${ENTRA_WEB_APP_ID}
+  clientSecret: ${ENTRA_WEB_CLIENT_SECRET}
+  tenantId: ${ENTRA_TENANT_ID}
+  scope: '978bd794-4ce3-4664-9139-6801625c8915/.default'


### PR DESCRIPTION
We think we have forgotten an important block in `app-config.production.yaml` 😨 

Screenshot from argo
![image](https://github.com/user-attachments/assets/fe0843c1-340a-4800-a7a5-f9b27876c153)
We are not quite sure where 'env' is defined but is it correct to assume that if we add the block to `app-config.production.yaml` it will be available?
 
When the next packages are released we will clean this up, and avoid repeating the same environment variables several times. We will also add the scope (which points to our backend) as a separate environment variable under the `sikkerhetsmetrikker` block