### PR TITLE
add sikkerhetsmetrikker block in app-config.yaml

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -85,6 +85,10 @@ proxy:
 lighthouse:
   baseUrl: http://localhost:7007/api/proxy/lighthouse
 
+sikkerhetsmetrikker:
+  backendBaseUrl: https://api.sikkerhetsmetrikker.plugin.atgcp1-dev.kartverket-intern.cloud/api
+  securityMetricsBackendClientId: 'dummy_value'
+
 auth:
   providers:
     google:


### PR DESCRIPTION
This change contains a dummy value so that local development can be done without our plugin complaining that these fields can't be found. The plugin won't work, but local development on kartverket.dev that is independent of our plugin should not be affected anymore.

The silver lining with all of this is that it has been a  great learning opportunity for us 😅 