### PR TITLE
test: fjerne google-innlogging

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -75,10 +75,6 @@ catalog:
 auth:
   environment: production
   providers:
-    google:
-      production:
-        clientId: ${GOOGLE_OAUTH_CLIENT_ID}
-        clientSecret: ${GOOGLE_OAUTH_CLIENT_SECRET}
     microsoft:
       production:
         clientId: ${ENTRA_WEB_APP_ID}

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -89,13 +89,6 @@ sikkerhetsmetrikker:
   backendBaseUrl: https://api.sikkerhetsmetrikker.plugin.atgcp1-dev.kartverket-intern.cloud/api
   securityMetricsBackendClientId: 'dummy_value'
 
-auth:
-  providers:
-    google:
-      development:
-        clientId: ${GOOGLE_OAUTH_CLIENT_ID}
-        clientSecret: ${GOOGLE_OAUTH_CLIENT_SECRET}
-
 kubernetes:
   serviceLocatorMethod:
     type: 'multiTenant'


### PR DESCRIPTION
Fjerner google auth for å se om man egentlig ikke trenger det.
Google auth brukes for risk-pluginen, også vil vi sjekke om vi ikke trenger denne likevel 😊