### PR TITLE
[Sikkerhet] Oppdaterer med catalog-info.yaml til versjon 3.0

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,6 +9,7 @@ spec:
   type: "website"
   lifecycle: "production"
   owner: "skip"
+  system: "utviklerportal"
   providesApis:
   - "kartverket.dev-api"
 ---


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage, samtidig som `beskrivelse.yaml` nå går til `version: 3.0`.
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.