### PR TITLE
Tweak msgraph org user filter

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -62,7 +62,8 @@ catalog:
         tenantId: 7f74c8a2-43ce-46b2-b0e8-b6306cba73a3
         queryMode: 'advanced'
         user:
-          filter: accountEnabled eq true and userType eq 'member'
+          filter: accountEnabled eq true and userType eq 'member' and startsWith(companyName, 'Staten')
+          select: ['accountEnabled', 'displayName', 'givenName', 'id', 'mail', 'mailNickname', 'surname', 'companyName', 'userType']
         group:
           filter: >
             startswith(displayName, 'AAD - TF')


### PR DESCRIPTION
Had an issue where some users didn't get synchronized into backstage. The new filter will be more picky about importing active users. Fixed missing users by adding email in entra id.
Can find missing users with the ps query: `Get-EntraUser -Filter "accountenabled eq true and usertype eq 'member'" -top 1500 | Select-Object DisplayName, Mail, CompanyName | Where-Object { $_.CompanyName -like "*Staten*" } | Where-Object { -not $_.Mail }
`