### PR TITLE
Update config.d.ts

### DIFF
--- a/packages/app/src/config/config.d.ts
+++ b/packages/app/src/config/config.d.ts
@@ -1,9 +1,5 @@
 export interface Config {
-    /**
-     @visibility frontend
-     */
-    isUsingMock: boolean
-    auth: {
+   auth: {
         providers: {
             /**
              * NOTE: Visibility applies recursively downward


### PR DESCRIPTION
Backstage fails to start in production when isUsingMock is referenced in config.d.ts, but not defined in the merged app-config.