### PR TITLE
Plugin-dump: Validering på input-felt

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -47,7 +47,7 @@
     "@backstage/theme": "^0.5.7",
     "@internal/plugin-instatus": "^0.1.0",
     "@k-phoen/backstage-plugin-grafana": "^0.1.22",
-    "@kartverket/backstage-plugin-dask-onboarding": "^0.1.15",
+    "@kartverket/backstage-plugin-dask-onboarding": "^0.1.17",
     "@kartverket/backstage-plugin-risk-scorecard": "^1.5.1",
     "@kartverket/backstage-plugin-security-metrics-frontend": "3.0.0",
     "@material-ui/core": "^4.12.2",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -47,7 +47,7 @@
     "@backstage/theme": "^0.5.7",
     "@internal/plugin-instatus": "^0.1.0",
     "@k-phoen/backstage-plugin-grafana": "^0.1.22",
-    "@kartverket/backstage-plugin-dask-onboarding": "^0.1.14",
+    "@kartverket/backstage-plugin-dask-onboarding": "^0.1.15",
     "@kartverket/backstage-plugin-risk-scorecard": "^1.5.1",
     "@kartverket/backstage-plugin-security-metrics-frontend": "3.0.0",
     "@material-ui/core": "^4.12.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8232,9 +8232,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kartverket/backstage-plugin-dask-onboarding@npm:^0.1.14":
-  version: 0.1.14
-  resolution: "@kartverket/backstage-plugin-dask-onboarding@npm:0.1.14"
+"@kartverket/backstage-plugin-dask-onboarding@npm:^0.1.17":
+  version: 0.1.17
+  resolution: "@kartverket/backstage-plugin-dask-onboarding@npm:0.1.17"
   dependencies:
     "@backstage/core-components": "npm:^0.14.3"
     "@backstage/core-plugin-api": "npm:^1.9.1"
@@ -8247,7 +8247,7 @@ __metadata:
     styled-components: "npm:^6.1.8"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/ebcb0aa60abd4840d7bfc7ff07513b246cabe75c2f6d044e90392ef0e1f97c314817a5696fa23f35f34d16988225b9f9e15f88d9e3ec2bb445b540a714756911
+  checksum: 10c0/eaa62637ad113f918e08cbe727f0b63dd48e7947ef81df83dc50deab8d3e211418161b0117ade62ca4ea720be9f1c70011f7d79225f426100284d9fd317042a5
   languageName: node
   linkType: hard
 
@@ -15465,7 +15465,7 @@ __metadata:
     "@backstage/theme": "npm:^0.5.7"
     "@internal/plugin-instatus": "npm:^0.1.0"
     "@k-phoen/backstage-plugin-grafana": "npm:^0.1.22"
-    "@kartverket/backstage-plugin-dask-onboarding": "npm:^0.1.14"
+    "@kartverket/backstage-plugin-dask-onboarding": "npm:^0.1.17"
     "@kartverket/backstage-plugin-risk-scorecard": "npm:^1.5.1"
     "@kartverket/backstage-plugin-security-metrics-frontend": "npm:3.0.0"
     "@material-ui/core": "npm:^4.12.2"


### PR DESCRIPTION
Vi la på [validering av input-felt](https://github.com/kartverket/dask-backstage/pull/50) for en stund tilbake, men glemte å oppdatere versjonen. Kan vurdere en lur måte å sende en PR hit for hver gang det merges, da det lett kan glemmes.

