### PR TITLE
Oppdaterer sikkerhetsmetrikker-plugin til versjon 3.6.0

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -50,7 +50,7 @@
     "@kartverket/backstage-plugin-dask-onboarding": "^0.1.18",
     "@kartverket/backstage-plugin-opencost": "^0.1.7",
     "@kartverket/backstage-plugin-risk-scorecard": "^2.0.3",
-    "@kartverket/backstage-plugin-security-metrics-frontend": "3.5.0",
+    "@kartverket/backstage-plugin-security-metrics-frontend": "3.6.0",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "backstage-plugin-xkcd": "^1.0.9",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -49,7 +49,7 @@
     "@backstage/plugin-search-backend-node": "^1.3.2",
     "@backstage/plugin-techdocs-backend": "^1.10.13",
     "@kartverket/backstage-plugin-dask-onboarding-backend": "^0.1.13",
-    "@kartverket/backstage-plugin-security-metrics-backend": "3.5.0",
+    "@kartverket/backstage-plugin-security-metrics-backend": "3.6.0",
     "app": "link:../app",
     "better-sqlite3": "^9.0.0",
     "dockerode": "^3.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8501,9 +8501,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kartverket/backstage-plugin-security-metrics-backend@npm:3.5.0":
-  version: 3.5.0
-  resolution: "@kartverket/backstage-plugin-security-metrics-backend@npm:3.5.0"
+"@kartverket/backstage-plugin-security-metrics-backend@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@kartverket/backstage-plugin-security-metrics-backend@npm:3.6.0"
   dependencies:
     "@azure/msal-node": "npm:^2.10.0"
     "@backstage/backend-common": "npm:^0.25.0"
@@ -8518,13 +8518,13 @@ __metadata:
     node-fetch: "npm:^3.3.2"
     winston: "npm:^3.15.0"
     yn: "npm:^5.0.0"
-  checksum: 10c0/70bbba7581397089ed6beacbade2a8329da47f3a3cf86d3fc1a0548d05ecf3b55a54e08986094dd204d74d784014d6db5a00e67a20df44dbd7e4e17312ebfb57
+  checksum: 10c0/e2b63eac90fcff108ba2edaf5addf6608b521ed10d241a8c7d690c831506b087c092288f8b113d041fb00de497a4861f9f10e4749b98278241f32f02738d7fef
   languageName: node
   linkType: hard
 
-"@kartverket/backstage-plugin-security-metrics-frontend@npm:3.5.0":
-  version: 3.5.0
-  resolution: "@kartverket/backstage-plugin-security-metrics-frontend@npm:3.5.0"
+"@kartverket/backstage-plugin-security-metrics-frontend@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@kartverket/backstage-plugin-security-metrics-frontend@npm:3.6.0"
   dependencies:
     "@backstage/catalog-client": "npm:^1.7.1"
     "@backstage/catalog-model": "npm:^1.7.0"
@@ -8547,7 +8547,7 @@ __metadata:
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: ^6.26.2
-  checksum: 10c0/24c9ada8c1d0e86a3757633e0c3f6a3d57619e8599345fa27e4e176afac20fcfc722efdaf41900add70a5f1909f1a88d88c7f1c9fe534990051c24e1874a4b88
+  checksum: 10c0/44122def52db9bb0e04874ecb73faef29a16a26f6c377f3916d59bae2c6b18c9567acde5b4ba2ab967d9bbd47a5e2404c0e6ce637f8996a3e883b0ef02c2b922
   languageName: node
   linkType: hard
 
@@ -17465,7 +17465,7 @@ __metadata:
     "@kartverket/backstage-plugin-dask-onboarding": "npm:^0.1.18"
     "@kartverket/backstage-plugin-opencost": "npm:^0.1.7"
     "@kartverket/backstage-plugin-risk-scorecard": "npm:^2.0.3"
-    "@kartverket/backstage-plugin-security-metrics-frontend": "npm:3.5.0"
+    "@kartverket/backstage-plugin-security-metrics-frontend": "npm:3.6.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@playwright/test": "npm:^1.32.3"
@@ -18205,7 +18205,7 @@ __metadata:
     "@backstage/plugin-search-backend-node": "npm:^1.3.2"
     "@backstage/plugin-techdocs-backend": "npm:^1.10.13"
     "@kartverket/backstage-plugin-dask-onboarding-backend": "npm:^0.1.13"
-    "@kartverket/backstage-plugin-security-metrics-backend": "npm:3.5.0"
+    "@kartverket/backstage-plugin-security-metrics-backend": "npm:3.6.0"
     "@types/dockerode": "npm:^3.3.0"
     "@types/express": "npm:^4.17.6"
     "@types/express-serve-static-core": "npm:^4.17.5"


### PR DESCRIPTION
Vi har oppdatert sikkerhetsmetrikker-plugin med ny UI og laget et kort som kan hente ut og vise Security-champion info.