### PR TITLE
Bump dask-backend-plugin

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -49,7 +49,7 @@
     "@backstage/plugin-search-backend-module-techdocs": "^0.3.3",
     "@backstage/plugin-search-backend-node": "^1.3.5",
     "@backstage/plugin-techdocs-backend": "^1.11.3",
-    "@kartverket/backstage-plugin-dask-onboarding-backend": "^0.1.13",
+    "@kartverket/backstage-plugin-dask-onboarding-backend": "^0.1.14",
     "@kartverket/backstage-plugin-security-metrics-backend": "3.7.1",
     "app": "link:../app",
     "better-sqlite3": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9236,9 +9236,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kartverket/backstage-plugin-dask-onboarding-backend@npm:^0.1.13":
-  version: 0.1.13
-  resolution: "@kartverket/backstage-plugin-dask-onboarding-backend@npm:0.1.13"
+"@kartverket/backstage-plugin-dask-onboarding-backend@npm:^0.1.14":
+  version: 0.1.14
+  resolution: "@kartverket/backstage-plugin-dask-onboarding-backend@npm:0.1.14"
   dependencies:
     "@backstage/backend-common": "npm:^0.21.6"
     "@backstage/config": "npm:^1.2.0"
@@ -9253,7 +9253,7 @@ __metadata:
     octokit: "npm:^3.1.2"
     winston: "npm:^3.2.1"
     yn: "npm:^4.0.0"
-  checksum: 10c0/63adb19e8a0b3709aee06e63bd93ddcd067b66a86c4f332ab9036b83404cd526f1d2abcad0b95e888f9ce3f67f50e70fdb9e9ba39f3cc45c5fb57dec975c7e97
+  checksum: 10c0/e5810006907e54e5a9d306baad45700ef6942a4317260fadc7abe2373a6f1d0e70d81cb81b26ec1cb8ce63010886a29657a5a8fc58738af496da128990c29d11
   languageName: node
   linkType: hard
 
@@ -19093,7 +19093,7 @@ __metadata:
     "@backstage/plugin-search-backend-module-techdocs": "npm:^0.3.3"
     "@backstage/plugin-search-backend-node": "npm:^1.3.5"
     "@backstage/plugin-techdocs-backend": "npm:^1.11.3"
-    "@kartverket/backstage-plugin-dask-onboarding-backend": "npm:^0.1.13"
+    "@kartverket/backstage-plugin-dask-onboarding-backend": "npm:^0.1.14"
     "@kartverket/backstage-plugin-security-metrics-backend": "npm:3.7.1"
     "@types/dockerode": "npm:^3.3.0"
     "@types/express": "npm:^4.17.6"


### PR DESCRIPTION
Oppdaterer dask-backend-plugin. Oppdateringen går ut på å filtrere vekk uønskede Entra ID-grupper (Team Lead, Tech Lead og Product Owner). PR [her](https://github.com/kartverket/dask-backstage/pull/64)