### PR TITLE
Revert "Remove unused winston."

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -57,7 +57,8 @@
     "express-promise-router": "^4.1.0",
     "jwt-decode": "^4.0.0",
     "node-gyp": "^9.0.0",
-    "pg": "^8.11.3"
+    "pg": "^8.11.3",
+    "winston": "^3.2.1"
   },
   "devDependencies": {
     "@backstage/cli": "backstage:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18316,6 +18316,7 @@ __metadata:
     jwt-decode: "npm:^4.0.0"
     node-gyp: "npm:^9.0.0"
     pg: "npm:^8.11.3"
+    winston: "npm:^3.2.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This reverts commit b3d5fd75a0c624cc3044291b78566d81dcc3a190.

fjerning av denne pakken gjør at jwks.json ikke legger ut nøkler lenger. Det skaper problemer for skvis