### PR TITLE
Vis sikkerhetsmetrikker og RISC-plugin for “Library”-komponenter

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -325,6 +325,9 @@ const componentPage = (
     <EntitySwitch.Case if={isComponentType('ops')}>
       {opsEntityPage}
     </EntitySwitch.Case>
+    <EntitySwitch.Case if={isComponentType('library')}>
+      {opsEntityPage}
+    </EntitySwitch.Case>
 
     <EntitySwitch.Case>{defaultEntityPage}</EntitySwitch.Case>
   </EntitySwitch>


### PR DESCRIPTION
Vi ønsker å vise sikkerhetsmetrikker-plugin og RISC-plugin for komponenttypen *Library*, på samme måte som for komponenttypen *Ops*. Dette gjør det mulig å se sikkerhetsmetrikker og lage kodenære ROS på repoer som er *Library*.

Det kan være litt misvisende å kalle på ```opsEntityPage``` når det gjelder *Library*, men siden vi ønsker nøyaktig samme logikk som for *Ops*-komponenter, gjenbruker vi koden i stedet for å replikere den.