### PR TITLE
Bump @kartverket/backstage-plugin-risk-scorecard to v3.5.3

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -48,7 +48,7 @@
     "@internal/plugin-instatus": "^0.1.0",
     "@kartverket/backstage-plugin-dask-onboarding": "^0.1.22",
     "@kartverket/backstage-plugin-opencost": "^0.1.7",
-    "@kartverket/backstage-plugin-risk-scorecard": "^3.5.0",
+    "@kartverket/backstage-plugin-risk-scorecard": "^3.5.3",
     "@kartverket/backstage-plugin-security-metrics-frontend": "3.17.5",
     "@kartverket/plugin-security-champion": "^0.1.7",
     "@material-ui/core": "^4.12.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8566,9 +8566,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kartverket/backstage-plugin-risk-scorecard@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "@kartverket/backstage-plugin-risk-scorecard@npm:3.5.0"
+"@kartverket/backstage-plugin-risk-scorecard@npm:^3.5.3":
+  version: 3.5.3
+  resolution: "@kartverket/backstage-plugin-risk-scorecard@npm:3.5.3"
   dependencies:
     "@backstage/core-components": "backstage:^"
     "@backstage/core-plugin-api": "backstage:^"
@@ -8599,7 +8599,7 @@ __metadata:
     react-dom: ^18.0.0
     react-router: ^6.3.0
     react-router-dom: ^6.3.0
-  checksum: 10c0/d6fa27f541bc22ee2b685c85261356be7bb7d79703b783eea598a8c259e352778fe77ccbed86507106f4903d589a61259ada44f804ab1d039b12bb421e900a37
+  checksum: 10c0/65c13b4ec5edf41adf5f6f6cc98e2b56656252685494629671091f0c6d81541a125b72a4ad13993e63d52eac10ce018bad796882d1d15fea5aeaeff30bc71fde
   languageName: node
   linkType: hard
 
@@ -20407,7 +20407,7 @@ __metadata:
     "@internal/plugin-instatus": "npm:^0.1.0"
     "@kartverket/backstage-plugin-dask-onboarding": "npm:^0.1.22"
     "@kartverket/backstage-plugin-opencost": "npm:^0.1.7"
-    "@kartverket/backstage-plugin-risk-scorecard": "npm:^3.5.0"
+    "@kartverket/backstage-plugin-risk-scorecard": "npm:^3.5.3"
     "@kartverket/backstage-plugin-security-metrics-frontend": "npm:3.17.5"
     "@kartverket/plugin-security-champion": "npm:^0.1.7"
     "@material-ui/core": "npm:^4.12.2"


### PR DESCRIPTION
## Summary
- Updates @kartverket/backstage-plugin-risk-scorecard from v3.5.0 to v3.5.3
- Updates yarn.lock with corresponding dependency changes
