### PR TITLE
Remove old posthog

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -51,7 +51,7 @@ backend:
     img-src: ["'self'", 'data:', 'imgs.xkcd.com']
     frame-src:
       [
-        'sandbox.kartverket.dev',
+        'backstage.atgcp1-dev.kartverket-intern.cloud',
         'kartverket.dev',
         'fedifeed.com',
         'monitoring.kartverket.cloud',
@@ -61,7 +61,7 @@ backend:
     script-src:
       [
         "'self'",
-        'sandbox.kartverket.dev',
+        'backstage.atgcp1-dev.kartverket-intern.cloud',
         'skip.instatus.com',
         "'unsafe-eval'",
         "'unsafe-inline'",

--- a/package.json
+++ b/package.json
@@ -69,8 +69,7 @@
   },
   "dependencies": {
     "@mui/material": "5.16.4",
-    "@types/react": "^18",
-    "posthog-js": "^1.268.0"
+    "@types/react": "^18"
   },
   "packageManager": "yarn@4.9.1+sha512.f95ce356460e05be48d66401c1ae64ef84d163dd689964962c6888a9810865e39097a5e9de748876c2e0bf89b232d583c33982773e9903ae7a76257270986538"
 }

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -1,12 +1,7 @@
 import '@backstage/cli/asset-types';
 import App from './App';
-import posthog from 'posthog-js';
 import '@backstage/ui/css/styles.css';
 import { createRoot } from 'react-dom/client';
-
-posthog.init('phc_5i5QBLfgf4FXS4hJlnkrLsAzQERS8PALDPmF2YVFQsB', {
-  api_host: 'https://eu.posthog.com',
-});
 
 const container = document.getElementById('root');
 const root = createRoot(container!);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11053,13 +11053,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@posthog/core@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@posthog/core@npm:1.1.0"
-  checksum: 10c0/313dba3fe575bbb2fb9eae85b89d8c2bd67d6d1b83b932d2835b5abe10404e1accd443ffa55fd58bd2741e8cd9e74585303519bc5d06c20cff228ad1f5ad8b9a
-  languageName: node
-  linkType: hard
-
 "@protobufjs/aspromise@npm:^1.1.1, @protobufjs/aspromise@npm:^1.1.2":
   version: 1.1.2
   resolution: "@protobufjs/aspromise@npm:1.1.2"
@@ -36685,27 +36678,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"posthog-js@npm:^1.268.0":
-  version: 1.268.0
-  resolution: "posthog-js@npm:1.268.0"
-  dependencies:
-    "@posthog/core": "npm:1.1.0"
-    core-js: "npm:^3.38.1"
-    fflate: "npm:^0.4.8"
-    preact: "npm:^10.19.3"
-    web-vitals: "npm:^4.2.4"
-  peerDependencies:
-    "@rrweb/types": 2.0.0-alpha.17
-    rrweb-snapshot: 2.0.0-alpha.17
-  peerDependenciesMeta:
-    "@rrweb/types":
-      optional: true
-    rrweb-snapshot:
-      optional: true
-  checksum: 10c0/ddc1429c300b2684a8159a2bb30707968b24776bfdeca962e85eabf59ceb8c4c4d0809977cf20494ad375d0936c4c72c1d5be314d0221dda9bc8fcf4fb7dbb45
-  languageName: node
-  linkType: hard
-
 "preact@npm:^10.19.3":
   version: 10.26.5
   resolution: "preact@npm:10.26.5"
@@ -39445,7 +39417,6 @@ __metadata:
     "@playwright/test": "npm:^1.32.3"
     "@types/react": "npm:^18"
     lerna: "npm:^7.3.0"
-    posthog-js: "npm:^1.268.0"
     prettier: "npm:^3.5.3"
     typescript: "npm:~5.8.3"
   languageName: unknown


### PR DESCRIPTION
Bakgrunn:
Etter https://github.com/kartverket/kartverket.dev/pull/388 dukker denne feilmeldingen opp:
```
[PostHog.js] `posthog` was already loaded elsewhere. This may cause issues.
```

Løsning:
Vi har en tidligere Implementasjon av Posthog ```index.tsx```.
Fjerner denne gamle implementasjonen siden jeg mener den ikke har blitt brukt til noe (?).