### PR TITLE
Handle no components fetch

### DIFF
--- a/plugins/security-metrics/src/components/Views/GroupPage.tsx
+++ b/plugins/security-metrics/src/components/Views/GroupPage.tsx
@@ -21,6 +21,7 @@ import { SystemsTable } from '../SystemsTable/SystemsTable';
 import { useMetricsQuery } from '../../hooks/useMetricsQuery';
 import { useFetchComponentNamesByGroup } from '../../hooks/useFetchRepositoryNames';
 import NoAccessAlert from '../NoAccessAlert';
+import Alert from '@mui/material/Alert';
 
 enum TabEnum {
   COMPONENT = 0,
@@ -47,6 +48,14 @@ export const GroupPage = () => {
         errorMessage={error ? error.message : componentNamesError?.message}
       />
     );
+
+  if (componentNames.length === 0) {
+    return (
+      <Alert severity="warning">
+        Kan ikke hente sikkerhetsmetrikker for entiteter uten komponenter.
+      </Alert>
+    );
+  }
 
   if (componentNamesIsLoading || isPending) return <Progress />;
 

--- a/plugins/security-metrics/src/components/Views/SystemPage.tsx
+++ b/plugins/security-metrics/src/components/Views/SystemPage.tsx
@@ -22,6 +22,7 @@ import {
 } from '../../mapping/getGroupedData';
 import { RepositorySummary } from '../../typesFrontend';
 import NoAccessAlert from '../NoAccessAlert';
+import Alert from '@mui/material/Alert';
 
 export function getComponentNamesFromSystem(system: Entity) {
   const rels = system.relations ?? [];
@@ -49,6 +50,14 @@ export const SystemPage = () => {
         errorMessage={error.message}
       />
     );
+
+  if (componentNames.length === 0) {
+    return (
+      <Alert severity="warning">
+        Kan ikke hente sikkerhetsmetrikker for entiteter uten komponenter.
+      </Alert>
+    );
+  }
 
   if (isPending) return <Progress />;
 


### PR DESCRIPTION
# Bakgrunn🔒
Dersom en gruppe eller et system ikke inneholder noen komponenter vil man prøve å fetche en tom liste med komponenter, som er forvirrende for brukeren.

# Løsning🔑
Dersom man ikke får error men heller henter en tom liste med komponenter vil man heller vise et varslingsbanner om at man ikke kan hente metrikker for en entitet for noe som ikke inneholder komponenter. 

# Bilder 📸
| Før | Etter |
|-----|-----|
| <img width="817" height="727" alt="image" src="https://github.com/user-attachments/assets/67e81f3d-1096-4d0c-a097-a1233cff9a70" /> | <img width="817" height="727" alt="image" src="https://github.com/user-attachments/assets/d878431c-d919-47b2-8da3-13de4359a657" /> | 