### PR TITLE
feat: use new ID info from SMAPI

### DIFF
--- a/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
@@ -66,8 +66,15 @@ export type Repository = {
   averageTimeToSolveVulnerabilityDays?: number;
 };
 
+export type VulnerabilityIdInfo = {
+  type: string;
+  id: string;
+  url?: string;
+};
+
 export type Vulnerability = {
   vulnerabilityId: string;
+  vulnerabilityIdInfo: VulnerabilityIdInfo[];
   severity: Severity;
   scanners: Scanner[];
   summary: string;

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/CodeQLContent.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/CodeQLContent.tsx
@@ -2,23 +2,12 @@ import Typography from '@mui/material/Typography';
 
 import { Vulnerability } from '../../../typesFrontend';
 import { Link } from '@backstage/core-components';
-import { getCweURL } from '../../utils';
 import { ErrorBanner } from '../../ErrorBanner';
+import { IdsWithUrls } from './IdsWithUrls';
 
 interface CodeQLContentProps {
   vulnerability: Vulnerability;
 }
-
-const getCweInfo = (id: string) => {
-  return (
-    <Typography>
-      <strong>{id.length > 1 ? 'CWE-links: ' : 'CWE-link: '}</strong>
-      <span key={id}>
-        <Link to={getCweURL(id)}>{id}</Link>
-      </span>
-    </Typography>
-  );
-};
 
 export const CodeQLContent = ({ vulnerability }: CodeQLContentProps) => {
   const info = vulnerability.scannerSpecificInfo.codeQLInfo;
@@ -29,8 +18,9 @@ export const CodeQLContent = ({ vulnerability }: CodeQLContentProps) => {
 
   return (
     <Typography>
-      {getCweInfo(vulnerability.vulnerabilityId)}
-      <strong>CodeQL-link: </strong>
+      <IdsWithUrls vulnerabilityIdInfo={vulnerability.vulnerabilityIdInfo} />
+      <br />
+      <strong>GitHub-link: </strong>
       <Link to={link}>
         {link.length > 80 ? link.slice(0, 30).concat('...') : link}
       </Link>

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/DependabotContent.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/DependabotContent.tsx
@@ -2,8 +2,8 @@ import Typography from '@mui/material/Typography';
 
 import { Vulnerability } from '../../../typesFrontend';
 import { Link } from '@backstage/core-components';
-import { getCveURL } from '../../utils';
 import { ErrorBanner } from '../../ErrorBanner';
+import { IdsWithUrls } from './IdsWithUrls';
 
 interface DependabotContentProps {
   vulnerability: Vulnerability;
@@ -20,12 +20,9 @@ export const DependabotContent = ({
 
   return (
     <Typography>
-      <strong>CVE-link: </strong>
-      <Link to={getCveURL(vulnerability.vulnerabilityId)}>
-        {vulnerability.vulnerabilityId}
-      </Link>
+      <IdsWithUrls vulnerabilityIdInfo={vulnerability.vulnerabilityIdInfo} />
       <br />
-      <strong>Dependabot-link: </strong>
+      <strong>GitHub-link: </strong>
       <Link to={link}>
         {link.length > 80 ? link.slice(0, 30).concat('...') : link}
       </Link>

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/IdsWithUrls.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/IdsWithUrls.tsx
@@ -1,0 +1,32 @@
+import { Link } from '@backstage/core-components';
+import { VulnerabilityIdInfo } from '../../../typesFrontend';
+
+export interface IdsWithURLsProps {
+  vulnerabilityIdInfo: VulnerabilityIdInfo[];
+}
+
+export const IdsWithUrls = ({ vulnerabilityIdInfo }: IdsWithURLsProps) => {
+  const idInfoWithUrl = vulnerabilityIdInfo.filter(
+    id => id.url !== undefined && id.url !== null,
+  );
+
+  if (idInfoWithUrl.length === 0) {
+    return (
+      <>
+        <strong>ID(s): </strong>
+        {vulnerabilityIdInfo.map(vulnerability => vulnerability.id).join(', ')}
+      </>
+    );
+  }
+  return (
+    <>
+      <strong>Link(s): </strong>
+      {idInfoWithUrl.map(id => (
+        <>
+          {idInfoWithUrl.length > 1 && <br />}
+          <Link to={id.url!}>{id.id}</Link>
+        </>
+      ))}
+    </>
+  );
+};

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/PharosContent.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/PharosContent.tsx
@@ -2,8 +2,8 @@ import Typography from '@mui/material/Typography';
 
 import { Vulnerability } from '../../../typesFrontend';
 import { Link } from '@backstage/core-components';
-import { getCveURL } from '../../utils';
 import { ErrorBanner } from '../../ErrorBanner';
+import { IdsWithUrls } from './IdsWithUrls';
 
 interface PharosContentProps {
   vulnerability: Vulnerability;
@@ -18,12 +18,9 @@ export const PharosContent = ({ vulnerability }: PharosContentProps) => {
 
   return (
     <Typography>
-      <strong>CVE-link: </strong>
-      <Link to={getCveURL(vulnerability.vulnerabilityId)}>
-        {vulnerability.vulnerabilityId}
-      </Link>
+      <IdsWithUrls vulnerabilityIdInfo={vulnerability.vulnerabilityIdInfo} />
       <br />
-      <strong>Pharos-link: </strong>
+      <strong>GitHub-link: </strong>
       <Link to={link}>
         {link.length > 80 ? link.slice(0, 30).concat('...') : link}
       </Link>

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/SysdigContent.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/SysdigContent.tsx
@@ -2,8 +2,8 @@ import Typography from '@mui/material/Typography';
 
 import { Vulnerability } from '../../../typesFrontend';
 import { Link } from '@backstage/core-components';
-import { getCveURL } from '../../utils';
 import { ErrorBanner } from '../../ErrorBanner';
+import { IdsWithUrls } from './IdsWithUrls';
 
 interface SysdigContentProps {
   vulnerability: Vulnerability;
@@ -27,10 +27,7 @@ export const SysdigContent = ({ vulnerability }: SysdigContentProps) => {
 
   return (
     <Typography>
-      <strong>CVE-link: </strong>
-      <Link to={getCveURL(vulnerability.vulnerabilityId)}>
-        {vulnerability.vulnerabilityId}
-      </Link>
+      <IdsWithUrls vulnerabilityIdInfo={vulnerability.vulnerabilityIdInfo} />
       <br />
       <strong>Sysdig-link: </strong>
       <Link to={link}>

--- a/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTableRow.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTableRow.tsx
@@ -14,6 +14,7 @@ import Button from '@mui/material/Button';
 import { TableRowCollapse } from './TableRowCollapse';
 import { AcceptDialog } from './AcceptRisk/AcceptDialog';
 import { isRecent } from '../../utils/isRecent';
+import { findBestId } from '../utils';
 
 const StyledTableRow = styled(TableRow)<{ accepted?: boolean }>(
   ({ theme, accepted }) => ({
@@ -56,9 +57,7 @@ export const VulnerabilityTableRow = ({
   const [comment, setComment] = useState('');
   const [acceptedBy, setAcceptedBy] = useState('');
 
-  const singleId = Array.isArray(vulnerability.vulnerabilityId)
-    ? vulnerability.vulnerabilityId.join(',')
-    : vulnerability.vulnerabilityId;
+  const shownId = findBestId(vulnerability);
 
   const handleOpenAcceptDialog = () => {
     setOpenAcceptDialog(true);
@@ -74,7 +73,7 @@ export const VulnerabilityTableRow = ({
         <TableCell>
           <TableCell>
             <Stack direction="row" alignItems="center" spacing={1}>
-              <Typography component="span">{singleId.toUpperCase()}</Typography>
+              <Typography component="span">{shownId}</Typography>
 
               {isRecent(vulnerability.dateFirstSeen, 7) && (
                 <Typography

--- a/plugins/security-metrics/src/components/utils.ts
+++ b/plugins/security-metrics/src/components/utils.ts
@@ -1,15 +1,11 @@
-import { Scanner, Severity, TrendSeverityCounts } from '../typesFrontend';
+import {
+  Scanner,
+  Severity,
+  TrendSeverityCounts,
+  Vulnerability,
+} from '../typesFrontend';
 import { SCANNER_COLORS, SEVERITY_COLORS } from '../colors';
 import { Entity } from '@backstage/catalog-model';
-
-export const getCveURL = (id: String): string => {
-  return `https://nvd.nist.gov/vuln/detail/${id}`;
-};
-
-export const getCweURL = (id: String): string => {
-  const cweId = id.toString().split('-')[1];
-  return `https://cwe.mitre.org/data/definitions/${cweId}.html`;
-};
 
 export const getStandardSeverityFormat = (severity: Severity) => {
   switch (severity) {
@@ -125,4 +121,23 @@ export const getRepositoryNames = (entities: Entity[]): string[] => {
       return match ? match[1] : undefined;
     })
     .filter((name): name is string => Boolean(name));
+};
+
+export const findBestId = (vulnerability: Vulnerability) => {
+  const cveId = vulnerability.vulnerabilityIdInfo.filter(
+    vulnerabilityId => vulnerabilityId.type === 'CVE',
+  );
+  const cweIds = vulnerability.vulnerabilityIdInfo.filter(
+    vulnerabilityId => vulnerabilityId.type === 'cwe',
+  );
+  const otherIds = vulnerability.vulnerabilityIdInfo.filter(
+    vulnerabilityId =>
+      vulnerabilityId.type !== 'cwe' && vulnerabilityId.type !== 'CVE',
+  );
+
+  let shownId = [];
+  if (cveId.length !== 0) shownId = cveId;
+  else if (cweIds.length !== 0) shownId = cweIds;
+  else shownId = otherIds;
+  return shownId[0].id;
 };

--- a/plugins/security-metrics/src/typesFrontend.ts
+++ b/plugins/security-metrics/src/typesFrontend.ts
@@ -46,8 +46,15 @@ export type Repository = {
   averageTimeToSolveVulnerabilityDays?: number;
 };
 
+export type VulnerabilityIdInfo = {
+  type: string;
+  id: string;
+  url?: string;
+};
+
 export type Vulnerability = {
   vulnerabilityId: string;
+  vulnerabilityIdInfo: VulnerabilityIdInfo[];
   severity: Severity;
   scanners: Scanner[];
   summary: string;


### PR DESCRIPTION
## 🔒 Bakgrunn
Det ble opplevd at dependabot-sårbarheter ikke ble sendt gjennom dersom de ikke hadde en CVE ID. Det viser seg at da blir alle sårbarheter grupper på github-repo-id, som ikke gir så mye mening for brukeren og fjerner alle bortsett fra en ID, og det muliggjorde heller ikke vil lenking til CVE-nettsiden.

## 🔑 Løsning
Løsningen har blitt å sende et IdInfo-objekt som inkluderer ID, type og url dersom det er en kjent måte å hente den på for en type ID. Da kan man motta flere ulike IDer, så det er lagd en funksjon som henter ut den prioriterte IDen (først CVE, så cwe, så annet). Man viser alle IDer med url dersom man har de, ellers viser man alle IDer uten url dersom man ikke har noen urler. Har også endret navnet på "[scanner]-link" til "Github-link" for scannere som ikke er Sysdig. 

## 📸 Bilder
Første rad viser hvordan man får opp "ID" som punkt i dependabot-kortet om man har en ID som ikke har medfølgende lenke. Om man har medfølgende lenke blir de brukt i stedet og da står det "Links". Andre rad viser hvordan det ikke heter CVE-link i pharos-kortet når man ikke har CVE, men den har også fått korrekt lenke medsendt fra SMAPI. 
| Før    | Etter |
| ----- | ----- |
| <img width="993" height="780" alt="image" src="https://github.com/user-attachments/assets/0312a03b-4acb-468a-b0bf-48e713cc5c32" /> | <img width="993" height="780" alt="image" src="https://github.com/user-attachments/assets/8f7c5eec-05ea-42aa-95e1-b7e706d3465c" /> |
|<img width="993" height="326" alt="image" src="https://github.com/user-attachments/assets/f971e549-eb75-4644-9656-13585df1e31b" />|<img width="993" height="326" alt="image" src="https://github.com/user-attachments/assets/cf487d11-c83d-4576-9223-939aba0f2ce8" />|

## ✅ Hvordan teste
Kjør opp [denne PRen](https://github.com/kartverket/sikkerhetsmetrikker/pull/835) i SMAPI og test at man får opp cwe- og ds-lenker fra CodeQl og Pharos, respektivt. Gode repoer å teste med er sikkerhetsmetrikker for pharos og slr-aas for dependabot. 