### PR TITLE
[catalog creator] Keep inputs when submitting

### DIFF
--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
@@ -35,6 +35,15 @@ export const CatalogCreatorPage = () => {
   const [defaultName, setDefaultName] = useState<string>('');
 
   const [formState, setFormState] = useState<RequiredYamlFields[] | null>(null);
+  const [analysisResultState, setAnalysisRestultState] =
+    useState<AnalyzeResult | null>(null);
+
+  const scrollToTop = () => {
+    const article = document.querySelector('article');
+    if (article && article.parentElement) {
+      article.parentElement.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  };
 
   const [catalogInfoState, doFetchCatalogInfo] = useAsyncFn(
     async (catInfoUrl: string | null) => {
@@ -55,11 +64,13 @@ export const CatalogCreatorPage = () => {
     } else {
       doFetchCatalogInfo(null);
     }
+    setAnalysisRestultState(result);
     return result;
   }, [url, githubAuthApi, catalogImportApi.analyzeUrl, doFetchCatalogInfo]);
 
   const [repoState, doSubmitToGithub] = useAsyncFn(
     async (submitUrl: string, catalogInfoFormList?: FormEntity[]) => {
+      scrollToTop();
       if (catalogInfoFormList !== undefined) {
         return await githubController.submitCatalogInfoToGithub(
           submitUrl,
@@ -124,6 +135,7 @@ export const CatalogCreatorPage = () => {
                       setUrl('');
                       setDefaultName('');
                       setFormState(null);
+                      setAnalysisRestultState(null);
                       doSubmitToGithub('', undefined);
                     }}
                   >
@@ -140,6 +152,8 @@ export const CatalogCreatorPage = () => {
                   doAnalyzeUrl();
                   getDefaultNameFromUrl();
                   doSubmitToGithub('', undefined);
+                  setFormState(null);
+                  setAnalysisRestultState(null);
                 }}
               >
                 <Box px="2rem">
@@ -163,7 +177,11 @@ export const CatalogCreatorPage = () => {
               </form>
 
               {analysisResult.value?.type === 'locations' &&
-                !(catalogInfoState.error || repoState.error) && (
+                !(
+                  catalogInfoState.error ||
+                  repoState.error ||
+                  analysisResultState === null
+                ) && (
                   <Alert sx={{ mx: 2 }} severity="info">
                     Catalog-info.yaml already exists. Editing existing file.
                   </Alert>
@@ -195,7 +213,7 @@ export const CatalogCreatorPage = () => {
                 </div>
               ) : (
                 <>
-                  {formState !== null && (
+                  {(formState !== null || analysisResultState !== null) && (
                     <div style={{ position: 'relative' }}>
                       {repoState.loading && (
                         <div

--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
@@ -23,7 +23,7 @@ import { useAsyncFn } from 'react-use';
 import Alert from '@mui/material/Alert';
 import CircularProgress from '@mui/material/CircularProgress';
 import { useState } from 'react';
-import { FormEntity, RequiredYamlFields } from '../../model/types';
+import { FormEntity } from '../../model/types';
 import Link from '@mui/material/Link';
 
 export const CatalogCreatorPage = () => {
@@ -34,9 +34,7 @@ export const CatalogCreatorPage = () => {
   const [url, setUrl] = useState('');
   const [defaultName, setDefaultName] = useState<string>('');
 
-  const [formState, setFormState] = useState<RequiredYamlFields[] | null>(null);
-  const [analysisResultState, setAnalysisRestultState] =
-    useState<AnalyzeResult | null>(null);
+  const [showForm, setShowForm] = useState<boolean>(false);
 
   const scrollToTop = () => {
     const article = document.querySelector('article');
@@ -51,7 +49,7 @@ export const CatalogCreatorPage = () => {
         return null;
       }
       const result = await getCatalogInfo(catInfoUrl, githubAuthApi);
-      setFormState(result);
+
       return result;
     },
     [url, githubAuthApi],
@@ -64,7 +62,7 @@ export const CatalogCreatorPage = () => {
     } else {
       doFetchCatalogInfo(null);
     }
-    setAnalysisRestultState(result);
+    setShowForm(true);
     return result;
   }, [url, githubAuthApi, catalogImportApi.analyzeUrl, doFetchCatalogInfo]);
 
@@ -134,8 +132,8 @@ export const CatalogCreatorPage = () => {
                     onClick={() => {
                       setUrl('');
                       setDefaultName('');
-                      setFormState(null);
-                      setAnalysisRestultState(null);
+                      setShowForm(false);
+
                       doSubmitToGithub('', undefined);
                     }}
                   >
@@ -152,8 +150,7 @@ export const CatalogCreatorPage = () => {
                   doAnalyzeUrl();
                   getDefaultNameFromUrl();
                   doSubmitToGithub('', undefined);
-                  setFormState(null);
-                  setAnalysisRestultState(null);
+                  setShowForm(false);
                 }}
               >
                 <Box px="2rem">
@@ -177,11 +174,8 @@ export const CatalogCreatorPage = () => {
               </form>
 
               {analysisResult.value?.type === 'locations' &&
-                !(
-                  catalogInfoState.error ||
-                  repoState.error ||
-                  analysisResultState === null
-                ) && (
+                !(catalogInfoState.error || repoState.error) &&
+                showForm && (
                   <Alert sx={{ mx: 2 }} severity="info">
                     Catalog-info.yaml already exists. Editing existing file.
                   </Alert>
@@ -213,7 +207,7 @@ export const CatalogCreatorPage = () => {
                 </div>
               ) : (
                 <>
-                  {(formState !== null || analysisResultState !== null) && (
+                  {showForm && catalogInfoState.value !== undefined && (
                     <div style={{ position: 'relative' }}>
                       {repoState.loading && (
                         <div
@@ -240,7 +234,7 @@ export const CatalogCreatorPage = () => {
                             data,
                           )
                         }
-                        currentYaml={formState}
+                        currentYaml={catalogInfoState.value!}
                         defaultName={defaultName}
                       />
                     </div>


### PR DESCRIPTION
## 🔒 Bakgrunn
Hvis bruker submitter formet og får feilmelding vil alle inputs forsvinne. 


## 🔑 Løsning
- Lagt til states for innhold i form og resultat av analyzeUrl.
- Laster ikke inn form på nytt ved submission, beholder derfor inputs. 
- Lagt til egen visuell loading state til submission, der formen er tilstede.

<img width="506" height="987" alt="image" src="https://github.com/user-attachments/assets/c39652aa-6a4e-477c-b191-d3b1f0850dc0" />



 