### PR TITLE
Add more info to sysdig-alerts

### DIFF
--- a/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
@@ -42,9 +42,9 @@ export type PharosSpecificInfo = {
 
 export type SysdigSpecificInfo = {
   htmlUrl: string;
-  container_name: string;
+  containers: string[];
   namespace: string;
-  cluster: string[];
+  clusters: string[];
   isExploitable: Boolean;
   isRunning: Boolean;
   packages: string;

--- a/plugins/security-metrics/src/components/Views/SingleComponentPage.tsx
+++ b/plugins/security-metrics/src/components/Views/SingleComponentPage.tsx
@@ -83,6 +83,7 @@ export const SingleComponentPage = () => {
             <VulnerabilityTable
               vulnerabilities={data.vulnerabilities}
               componentName={componentName}
+              initialRowsPerPage={10}
             />
           ) : (
             <>
@@ -98,6 +99,7 @@ export const SingleComponentPage = () => {
                 <VulnerabilityTable
                   vulnerabilities={data.vulnerabilities}
                   componentName={componentName}
+                  initialRowsPerPage={10}
                 />
               )}
               {selectedTab === TabEnum.RUNTIME_VULNERABILITIES && (

--- a/plugins/security-metrics/src/components/VulnerabilityTable/RuntimeVulnerabilityTable.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/RuntimeVulnerabilityTable.tsx
@@ -9,44 +9,115 @@ type Props = {
   componentName: string;
 };
 
+const makeLocationString = (cluster: string, namespace: string) => {
+  return `${cluster} ${namespace}`;
+};
+
+const getClusters = (vuln: Vulnerability): string[] => {
+  const clusters = vuln.scannerSpecificInfo.sysdigInfo?.clusters;
+  if (!clusters) return [];
+  return Array.isArray(clusters) ? clusters : [clusters];
+};
+
+const getNamespace = (vuln: Vulnerability): string => {
+  return vuln.scannerSpecificInfo.sysdigInfo?.namespace ?? 'Ukjent namespace';
+};
+
+const getLocations = (vuln: Vulnerability): string[] => {
+  const namespace = getNamespace(vuln);
+  return getClusters(vuln).map(cluster =>
+    makeLocationString(cluster, namespace),
+  );
+};
+
 export const RuntimeVulnerabilityTable = ({
   vulnerabilities,
   componentName,
 }: Props) => {
-  const getClusters = (v: Vulnerability) => {
-    const cluster = v.scannerSpecificInfo.sysdigInfo?.clusters;
-    if (!cluster) return [];
-    return Array.isArray(cluster) ? cluster : [cluster];
-  };
+  const mergedById = vulnerabilities.reduce(
+    (acc, vuln) => {
+      const id = vuln.vulnerabilityId;
+      if (!acc[id]) {
+        acc[id] = {
+          vuln,
+          locations: new Set<string>(),
+        };
+      }
+      getLocations(vuln).forEach(loc => acc[id].locations.add(loc));
+      return acc;
+    },
+    {} as Record<
+      string,
+      {
+        vuln: Vulnerability;
+        locations: Set<string>;
+      }
+    >,
+  );
 
-  const clusters = Array.from(
-    new Set(vulnerabilities.flatMap(getClusters)),
-  ).sort();
+  const vulnsWithLocationSets = Object.values(mergedById).map(
+    ({ vuln, locations }) => {
+      const locationList = Array.from(locations).sort();
+      return {
+        vuln,
+        locationList,
+        locationKey: locationList.join(' | '),
+      };
+    },
+  );
 
-  const clusterSummaries = clusters.map(clusterName => {
-    const list = vulnerabilities.filter(vulnerability =>
-      getClusters(vulnerability).includes(clusterName),
-    );
-    return { clusterName, list };
-  });
+  const groupsByLocationSet = vulnsWithLocationSets.reduce(
+    (acc, item) => {
+      if (!acc[item.locationKey]) {
+        acc[item.locationKey] = {
+          sharedLocations: item.locationList,
+          vulns: [] as Vulnerability[],
+        };
+      }
+      acc[item.locationKey].vulns.push(item.vuln);
+      return acc;
+    },
+    {} as Record<
+      string,
+      {
+        sharedLocations: string[];
+        vulns: Vulnerability[];
+      }
+    >,
+  );
+
+  const multiLocationGroups = Object.values(groupsByLocationSet)
+    .filter(g => g.sharedLocations.length > 1)
+    .sort((a, b) => {
+      if (b.sharedLocations.length !== a.sharedLocations.length) {
+        return b.sharedLocations.length - a.sharedLocations.length;
+      }
+      return a.sharedLocations
+        .join(', ')
+        .localeCompare(b.sharedLocations.join(', '));
+    });
 
   return (
     <Box>
-      {clusterSummaries.length === 0 ? (
+      {multiLocationGroups.length === 0 ? (
         <Box display="flex" m={2} gap={1}>
-          <Typography fontWeight={500}>Ingen sårbarheter funnet</Typography>
+          <Typography fontWeight={500}>
+            Ingen sårbarheter som finnes i flere miljøer/namespaces
+          </Typography>
           <ThumbUpIcon color="success" fontSize="medium" />
         </Box>
       ) : (
-        clusterSummaries.map(({ clusterName, list }) => (
-          <Box key={clusterName}>
-            <Typography fontWeight="bold" variant="h6" m={2}>
-              {clusterName} ({list.length} sårbarhet
-              {list.length === 1 ? '' : 'er'})
+        multiLocationGroups.map(group => (
+          <Box key={group.sharedLocations.join('|')} mb={3}>
+            <Typography fontWeight="bold" m={2}>
+              {group.sharedLocations.join(', ')} ({group.vulns.length} sårbarhet
+              {group.vulns.length === 1 ? '' : 'er'})
             </Typography>
+
             <VulnerabilityTable
-              vulnerabilities={list}
+              vulnerabilities={group.vulns}
               componentName={componentName}
+              initialRowsPerPage={5}
             />
           </Box>
         ))

--- a/plugins/security-metrics/src/components/VulnerabilityTable/RuntimeVulnerabilityTable.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/RuntimeVulnerabilityTable.tsx
@@ -14,7 +14,7 @@ export const RuntimeVulnerabilityTable = ({
   componentName,
 }: Props) => {
   const getClusters = (v: Vulnerability) => {
-    const cluster = v.scannerSpecificInfo.sysdigInfo?.cluster;
+    const cluster = v.scannerSpecificInfo.sysdigInfo?.clusters;
     if (!cluster) return [];
     return Array.isArray(cluster) ? cluster : [cluster];
   };

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/SysdigContent.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/SysdigContent.tsx
@@ -29,16 +29,26 @@ export const SysdigContent = ({ vulnerability }: SysdigContentProps) => {
       </Link>
       <br />
       <strong>Container name: </strong>
-      {info.container_name}
+      {Array.isArray(info?.containers)
+        ? info!.containers.join(', ')
+        : info?.containers}
       <br />
       <strong>Cluster: </strong>
-      {Array.isArray(info?.cluster) ? info!.cluster.join(', ') : info?.cluster}
+      {Array.isArray(info?.clusters)
+        ? info!.clusters.join(', ')
+        : info?.clusters}
+      <br />
+      <strong>Namespace: </strong>
+      {info.namespace}
+      <br />
+      <strong>Package names: </strong>
+      {info.packages}
       <br />
       <strong>Is exploitable: </strong>
       {info.isExploitable ? 'Yes' : 'No'}
       <br />
-      <strong>Package names: </strong>
-      {info.packages}
+      <strong>Is running: </strong>
+      {info.isRunning ? 'Yes' : 'No'}
     </Typography>
   );
 };

--- a/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTable.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTable.tsx
@@ -20,20 +20,21 @@ import Box from '@mui/material/Box';
 type Props = {
   vulnerabilities: Vulnerability[];
   componentName: string;
+  initialRowsPerPage: number;
 };
 
 export const VulnerabilityTable = ({
   vulnerabilities,
   componentName,
+  initialRowsPerPage,
 }: Props) => {
   const [sortType, setSortType] = useState<SortableHeader>('Alvorlighetsgrad');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
 
   const paginationProps = usePaginationProps(
-    vulnerabilities?.length ?? 0,
+    vulnerabilities.length,
     0,
-    5,
-    [5, 10, 25, 50],
+    initialRowsPerPage,
   );
   const { page, rowsPerPage } = paginationProps;
 

--- a/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTable.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTable.tsx
@@ -29,7 +29,12 @@ export const VulnerabilityTable = ({
   const [sortType, setSortType] = useState<SortableHeader>('Alvorlighetsgrad');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
 
-  const paginationProps = usePaginationProps(vulnerabilities.length);
+  const paginationProps = usePaginationProps(
+    vulnerabilities?.length ?? 0,
+    0,
+    5,
+    [5, 10, 25, 50],
+  );
   const { page, rowsPerPage } = paginationProps;
 
   return (

--- a/plugins/security-metrics/src/typesFrontend.ts
+++ b/plugins/security-metrics/src/typesFrontend.ts
@@ -22,9 +22,9 @@ export type PharosSpecificInfo = {
 
 export type SysdigSpecificInfo = {
   htmlUrl: string;
-  container_name: string;
+  containers: string[];
   namespace: string;
-  cluster: string[];
+  clusters: string[];
   isExploitable: Boolean;
   isRunning: Boolean;
   packages: string;
@@ -57,16 +57,6 @@ export type Vulnerability = {
   acceptedBy: string;
   scannerSpecificInfo: ScannerSpecificInfo;
 };
-
-export interface SysdigInfo {
-  container_name: string;
-  namespace: string;
-  htmlUrl: URL;
-  cluster: string[];
-  isExploitable: boolean;
-  packages: string[];
-  severityCount: SeverityCount;
-}
 
 export type SecretAlert = {
   createdAt: string;


### PR DESCRIPTION
## 🔒 Bakgrunn

Koblet til https://github.com/kartverket/sikkerhetsmetrikker/pull/839

## 🔑 Løsning
- Tilpasser typene til endringer i SMAPI (ref https://github.com/kartverket/sikkerhetsmetrikker/pull/839)
- Legger til namespace i sysdig-info
- Restrukturerer måten "sårbarheter i kjøretidsmiljø" vises
    - I stedet for å gruppere bare mellom like clustre, grupperes sårbarheter som eksisterer i samme clustre og namespaces sammen.

TODO
- [ ] Feil namespace for ulike clusters fra SMAPI?

## 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| Bilde | Bilde |