### PR TITLE
Delete solved notifications

### DIFF
--- a/packages/backend/src/plugins/extensions/catalogNotificationsModule.ts
+++ b/packages/backend/src/plugins/extensions/catalogNotificationsModule.ts
@@ -128,7 +128,7 @@ export const catalogNotificationsModule = createBackendModule({
                 continue;
               }
               if (!missingRelation) {
-                logger.error('Missing missing relation relation');
+                logger.error(`No missing relation found at index ${i}`);
                 continue;
               }
 


### PR DESCRIPTION
## 🔒 Bakgrunn
Notifications ble ikke slettet etter at tilhørende feil ble rettet opp i.

## 🔑 Løsning
- Søker i notifications db for å finne alle scopes, sammenligner med scopes fra missingrelation query. 
- Fjerner så notifikasjoner som ikke har scopes i missingrelation lengre, da de skal være fikset.
- Fjernet throwing, så det ikke stopper resten av notifikasjonene og cleanupen. 

