### PR TITLE
Norwegian language support

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -51,13 +51,17 @@ import { searchPage } from './components/search/SearchPage';
 import {
   CatalogCreatorPage,
   catalogCreatorPlugin,
+  catalogCreatorNorwegianTranslation,
 } from '@kartverket/backstage-plugin-catalog-creator';
 import { NotificationsPage } from '@backstage/plugin-notifications';
 
 const app = createApp({
   __experimentalTranslations: {
     availableLanguages: ['en', 'no'],
-    resources: [pluginRiScNorwegianTranslation],
+    resources: [
+      pluginRiScNorwegianTranslation,
+      catalogCreatorNorwegianTranslation,
+    ],
   },
   components: {
     SignInPage: props => {

--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
@@ -139,7 +139,7 @@ export const CatalogCreatorPage = () => {
                       sx={{ fontWeight: 'bold', textAlign: 'center' }}
                       severity="success"
                     >
-                      Successfully created a pull request:{' '}
+                      {t('successPage.successfullyCreatedPR')}
                       {repoState?.value?.prUrl ? (
                         <Link
                           href={repoState.value.prUrl}
@@ -150,7 +150,7 @@ export const CatalogCreatorPage = () => {
                           {repoState.value.prUrl}
                         </Link>
                       ) : (
-                        <p>Could not retrieve pull request URL.</p>
+                        <p>{t('successPage.couldNotRetrieveURL')}</p>
                       )}
                     </Alert>
                     <Link
@@ -162,7 +162,7 @@ export const CatalogCreatorPage = () => {
                         doSubmitToGithub('', undefined);
                       }}
                     >
-                      Register a new component?
+                      {t('successPage.registerNew')}
                     </Link>
                   </Flex>
                 </Box>

--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
@@ -28,11 +28,14 @@ import { FormEntity } from '../../model/types';
 import Link from '@mui/material/Link';
 import { getRepoInfo } from '../../utils/getRepoInfo';
 import { InfoBox } from './InfoBox';
+import { catalogCreatorTranslationRef } from '../../utils/translations';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 
 export const CatalogCreatorPage = () => {
   const catalogImportApi = useApi(catalogImportApiRef);
   const githubAuthApi: OAuthApi = useApi(githubAuthApiRef);
   const githubController = new GithubController();
+  const { t } = useTranslationRef(catalogCreatorTranslationRef);
 
   const [url, setUrl] = useState('');
   const [defaultName, setDefaultName] = useState<string>('');
@@ -114,7 +117,7 @@ export const CatalogCreatorPage = () => {
   return (
     <Page themeId="tool">
       <Content>
-        <ContentHeader title="Edit or Create Components">
+        <ContentHeader title={t('contentHeader.title')}>
           <SupportButton />
         </ContentHeader>
         <Flex>

--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
@@ -74,7 +74,11 @@ export const CatalogCreatorPage = () => {
   }, [url, githubAuthApi, catalogImportApi.analyzeUrl, doFetchCatalogInfo]);
 
   const [repoInfo, doGetRepoInfo] = useAsyncFn(async () => {
-    const result = await getRepoInfo(url, githubAuthApi);
+    const result = await getRepoInfo(
+      url,
+      githubAuthApi,
+      t('form.knownErrorAlerts.repoNotFound'),
+    );
     return result;
   }, [url, githubAuthApi]);
 
@@ -88,6 +92,7 @@ export const CatalogCreatorPage = () => {
           catalogInfoState.value || [],
           catalogInfoFormList,
           githubAuthApi,
+          t('form.knownErrorAlerts.couldNotCreatePR'),
         );
       }
       return undefined;
@@ -199,7 +204,7 @@ export const CatalogCreatorPage = () => {
                   !(error || loading || repoState.error) &&
                   showForm && (
                     <Alert sx={{ mx: 2 }} severity="info">
-                      Catalog-info.yaml already exists. Editing existing file.
+                      {t('form.infoAlerts.alreadyExists')}
                     </Alert>
                   )}
 
@@ -208,13 +213,13 @@ export const CatalogCreatorPage = () => {
                   showForm &&
                   !(error || loading || repoState.error) && (
                     <Alert sx={{ mx: 2 }} severity="info">
-                      Catalog-info.yaml does not exist. Creating a new file.
+                      {t('form.infoAlerts.doesNotExist')}
                     </Alert>
                   )}
 
                 {repoInfo.value?.existingPrUrl && !loading && (
                   <Alert sx={{ mx: 2 }} severity="error">
-                    There already exists a pull request:{' '}
+                    {t('form.knownErrorAlerts.PRExists')}
                     <Link
                       href={repoInfo.value.existingPrUrl}
                       sx={{ fontWeight: 'normal' }}

--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
@@ -178,9 +178,9 @@ export const CatalogCreatorPage = () => {
                     <Flex align="end">
                       <div style={{ flexGrow: 1 }}>
                         <TextField
-                          label="Repository URL"
+                          label={t('repositorySearch.label')}
                           size="small"
-                          placeholder="Enter a URL"
+                          placeholder={t('repositorySearch.placeholder')}
                           name="url"
                           value={url}
                           onChange={e => {
@@ -188,7 +188,9 @@ export const CatalogCreatorPage = () => {
                           }}
                         />
                       </div>
-                      <Button type="submit">Fetch!</Button>
+                      <Button type="submit">
+                        {t('repositorySearch.fetchButton')}
+                      </Button>
                     </Flex>
                   </Box>
                 </form>

--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/InfoBox.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/InfoBox.tsx
@@ -1,58 +1,33 @@
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { Box, Card } from '@backstage/ui';
 import Link from '@material-ui/core/Link';
 import Divider from '@mui/material/Divider';
+import { catalogCreatorTranslationRef } from '../../utils/translations';
 
 export const InfoBox = () => {
+  const { t } = useTranslationRef(catalogCreatorTranslationRef);
   return (
     <Card>
       <Box px="2rem">
-        <h2>Edit or Generate Catalog-info.yaml</h2>
+        <h2>{t('infoBox.title')}</h2>
         <Divider sx={{ marginY: '1.5rem' }} />
-        <p>
-          This form helps you create or edit catalog-info.yaml files used by
-          Backstage to discover and manage software components in the catalog.
-          Enter a GitHub repository URL to add it to the developer portal, or
-          provide a link to an existing catalog-info.yaml file to edit it using
-          this form.
-        </p>
-        <p>
-          Once the form is completed with the correct entities, click{' '}
-          <em>Create Pull Request</em> to propose changes or additions to the
-          catalog-info.yaml file in the relevant repository. The changes will
-          take effect only after the pull request is merged and the developer
-          portal updates its catalog.
-        </p>
+        <p>{t('infoBox.p1')}</p>
+        <p>{t('infoBox.p2')}</p>
         <Divider />
-        <h3>What are Entities in Backstage?</h3>
-        The developer portal is built using Backstage, which defines a set of
-        entities used to build the software catalog. These entities are
-        seperated into three groups: core entities, ecosystem entities, and
-        organizational entities. Core entities include Component, API, and
-        Resource. Ecosystem entities include System and Domain. Organizational
-        entities include Group and User. Below is a brief explanation of the
-        core entities.
-        <h4>Component</h4> A Component is a piece of software, such as a
-        service, library or a website. Components will often correspond to a
-        repository. {/* , but a monorepo can contain multiple components. */}
-        Components can provide APIs that other components consume, and often
-        depend on APIs and resources.
+        <h3> {t('infoBox.subtitle')}</h3>
+        <p>{t('infoBox.p3')}</p>
+        <h4>Component</h4> <p>{t('infoBox.componentParagraph')}</p>
         <h4>API</h4>
-        An API entity describes an API that a component provides and that other
-        components consume. Public APIs are the primary ways which components
-        interact. The API specification should be included in the API entity and
-        the file path to this document should be added to the API entity, with
-        the file path to the API definition so that Kartverket.dev can provide
-        detailed information.
+        <p>{t('infoBox.APIParagraph')}</p>
         <h4>Resource</h4>
-        Resource entities represent shared shared resources that a component
-        requires during runtime, such as object storage or other cloud services.
+        <p>{t('infoBox.resourceParagraph')}</p>
         <div style={{ marginTop: '1.5rem', marginBottom: '1.5rem' }}>
           <Link
             href="https://backstage.io/docs/features/software-catalog/"
             target="_blank"
             rel="noreferrer"
           >
-            Learn more about entities and the Backstage catalog.
+            {t('infoBox.linkText')}
           </Link>
         </div>
       </Box>

--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/InfoBox.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/InfoBox.tsx
@@ -16,10 +16,11 @@ export const InfoBox = () => {
         <Divider />
         <h3> {t('infoBox.subtitle')}</h3>
         <p>{t('infoBox.p3')}</p>
-        <h4>Component</h4> <p>{t('infoBox.componentParagraph')}</p>
-        <h4>API</h4>
+        <h4>{t('infoBox.componentTitle')}</h4>{' '}
+        <p>{t('infoBox.componentParagraph')}</p>
+        <h4>{t('infoBox.APITitle')}</h4>
         <p>{t('infoBox.APIParagraph')}</p>
-        <h4>Resource</h4>
+        <h4>{t('infoBox.resourceTitle')}</h4>
         <p>{t('infoBox.resourceParagraph')}</p>
         <div style={{ marginTop: '1.5rem', marginBottom: '1.5rem' }}>
           <Link

--- a/plugins/catalog-creator/src/components/CatalogForm/CatalogForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/CatalogForm.tsx
@@ -295,8 +295,8 @@ export const CatalogForm = ({
                   </div>
                   <div>
                     <FieldHeader
-                      fieldName="Title"
-                      tooltipText="A human-readable title for the component entity, shown in Backstage UI instead of the name when available. Optional."
+                      fieldName={t('form.titleField.fieldName')}
+                      tooltipText={t('form.titleField.tooltipText')}
                     />
                     <Controller
                       name={`entities.${index}.title`}

--- a/plugins/catalog-creator/src/components/CatalogForm/CatalogForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/CatalogForm.tsx
@@ -285,7 +285,12 @@ export const CatalogForm = ({
                         visibility: errors?.entities ? 'visible' : 'hidden',
                       }}
                     >
-                      {errors?.entities?.[index]?.name?.message || '\u00A0'}
+                      {errors?.entities?.[index]?.name?.message
+                        ? t(
+                            errors.entities[index]?.name
+                              ?.message as keyof typeof t,
+                          )
+                        : '\u00A0'}
                     </span>
                   </div>
                   <div>
@@ -400,7 +405,12 @@ export const CatalogForm = ({
                           : 'hidden',
                       }}
                     >
-                      {errors.entities?.[index]?.owner?.message || '\u00A0'}
+                      {errors?.entities?.[index]?.owner?.message
+                        ? t(
+                            errors.entities[index]?.owner
+                              ?.message as keyof typeof t,
+                          )
+                        : '\u00A0'}
                     </span>
                   </div>
 

--- a/plugins/catalog-creator/src/components/CatalogForm/CatalogForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/CatalogForm.tsx
@@ -24,6 +24,8 @@ import { SystemForm } from './Forms/SystemForm';
 import { FieldHeader } from './FieldHeader';
 import Autocomplete from '@mui/material/Autocomplete';
 import MuiTextField from '@mui/material/TextField';
+import { catalogCreatorTranslationRef } from '../../utils/translations';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 
 export type CatalogFormProps = {
   onSubmit: (data: FormEntity[]) => void;
@@ -37,6 +39,7 @@ export const CatalogForm = ({
   defaultName = '',
 }: CatalogFormProps) => {
   const catalogApi = useApi(catalogApiRef);
+  const { t } = useTranslationRef(catalogCreatorTranslationRef);
 
   const fetchOwners = useAsync(async () => {
     const results = await catalogApi.getEntities({
@@ -210,9 +213,9 @@ export const CatalogForm = ({
         })}
       >
         <Box px="2rem">
-          <h2>Catalog-info.yaml Form</h2>
+          <h2>{t('form.title')}</h2>
           <p style={{ fontSize: '0.85rem', color: 'gray' }}>
-            Required fields marked with:{' '}
+            {t('form.requiredFields')}
             <span style={{ color: '#ff0000', fontSize: '1rem' }}>*</span>
           </p>
           {fields.map((entity, index) => {
@@ -236,7 +239,7 @@ export const CatalogForm = ({
                         render={({ field: { value } }) => (
                           <h3 aria-label="entity-header">
                             {' '}
-                            {`${value} Entity`}{' '}
+                            {`${value}${t('form.entity')}`}{' '}
                           </h3>
                         )}
                       />
@@ -253,9 +256,9 @@ export const CatalogForm = ({
 
                   <div style={{ width: '100%' }}>
                     <FieldHeader
-                      fieldName="Name"
+                      fieldName={t('form.name.fieldName')}
                       required
-                      tooltipText="The name of the entity. This name is both meant for human eyes to recognize the entity, and for machines and other components to reference the entity. Must be unique"
+                      tooltipText={t('form.name.tooltipText')}
                     />
                     <Controller
                       name={`entities.${index}.name`}
@@ -320,8 +323,8 @@ export const CatalogForm = ({
                   </div>
                   <div>
                     <FieldHeader
-                      fieldName="Owner"
-                      tooltipText="A reference to the owner (commonly a team), that bears ultimate responsibility for the entity, and has the authority and capability to develop and maintain it"
+                      fieldName={t('form.owner.fieldName')}
+                      tooltipText={t('form.name.tooltipText')}
                       required
                     />
                     <Controller
@@ -374,7 +377,7 @@ export const CatalogForm = ({
                           renderInput={params => (
                             <MuiTextField
                               {...params}
-                              placeholder="Select owner"
+                              placeholder={t('form.owner.placeholder')}
                               InputProps={{
                                 ...params.InputProps,
                                 sx: {
@@ -409,11 +412,11 @@ export const CatalogForm = ({
 
           <Flex direction="column">
             <Text style={{ fontWeight: 'bold', marginTop: '1.5rem' }}>
-              Add Entity
+              {t('form.addEntity.title')}
             </Text>
             <Flex align="end" justify="start">
               <Select
-                label="Select kind"
+                label={t('form.addEntity.label')}
                 value={addEntityKind}
                 onChange={value => setAddEntityKind(value as Kind)}
                 options={Object.values(AllowedEntityKinds).map(
@@ -427,7 +430,7 @@ export const CatalogForm = ({
                 type="button"
                 onClick={() => appendHandler(addEntityKind)}
               >
-                Add Entity
+                {t('form.addEntity.buttonText')}
               </Button>
             </Flex>
           </Flex>
@@ -438,7 +441,7 @@ export const CatalogForm = ({
               type="submit"
               style={{ marginBottom: '0.75rem' }}
             >
-              Create pull request
+              {t('form.createPR')}
             </Button>
           </Flex>
         </Box>

--- a/plugins/catalog-creator/src/components/CatalogForm/Forms/ApiForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/Forms/ApiForm.tsx
@@ -11,6 +11,8 @@ import { Entity } from '@backstage/catalog-model';
 import { FieldHeader } from '../FieldHeader';
 import Autocomplete from '@mui/material/Autocomplete';
 import MuiTextField from '@mui/material/TextField';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { catalogCreatorTranslationRef } from '../../../utils/translations';
 
 export type ApiFormProps = {
   index: number;
@@ -20,13 +22,14 @@ export type ApiFormProps = {
 };
 
 export const ApiForm = ({ index, control, errors, systems }: ApiFormProps) => {
+  const { t } = useTranslationRef(catalogCreatorTranslationRef);
   return (
     <Flex direction="column" justify="start">
       <Flex>
         <div style={{ width: '50%' }}>
           <FieldHeader
-            fieldName="Lifecycle"
-            tooltipText="The lifecycle state of the API"
+            fieldName={t('form.APIForm.lifecycle.fieldName')}
+            tooltipText={t('form.APIForm.lifecycle.tooltipText')}
             required
           />
           <Controller
@@ -45,7 +48,7 @@ export const ApiForm = ({ index, control, errors, systems }: ApiFormProps) => {
                 renderInput={params => (
                   <MuiTextField
                     {...params}
-                    placeholder="Select type"
+                    placeholder={t('form.APIForm.lifecycle.placeholder')}
                     InputProps={{
                       ...params.InputProps,
                       sx: {
@@ -72,8 +75,8 @@ export const ApiForm = ({ index, control, errors, systems }: ApiFormProps) => {
 
         <div style={{ flexGrow: 1, width: '50%' }}>
           <FieldHeader
-            fieldName="Type"
-            tooltipText="The type of the API"
+            fieldName={t('form.APIForm.type.fieldName')}
+            tooltipText={t('form.APIForm.type.tooltipText')}
             required
           />
           <Controller
@@ -92,7 +95,7 @@ export const ApiForm = ({ index, control, errors, systems }: ApiFormProps) => {
                 renderInput={params => (
                   <MuiTextField
                     {...params}
-                    placeholder="Select type"
+                    placeholder={t('form.APIForm.type.placeholder')}
                     InputProps={{
                       ...params.InputProps,
                       sx: {
@@ -120,8 +123,8 @@ export const ApiForm = ({ index, control, errors, systems }: ApiFormProps) => {
 
       <div>
         <FieldHeader
-          fieldName="System"
-          tooltipText="Reference to the system which the API belongs to"
+          fieldName={t('form.APIForm.system.fieldName')}
+          tooltipText={t('form.APIForm.type.tooltipText')}
         />
         <Controller
           name={`entities.${index}.system`}
@@ -164,7 +167,7 @@ export const ApiForm = ({ index, control, errors, systems }: ApiFormProps) => {
               renderInput={params => (
                 <MuiTextField
                   {...params}
-                  placeholder="Select system"
+                  placeholder={t('form.APIForm.type.placeholder')}
                   InputProps={{
                     ...params.InputProps,
                     sx: {
@@ -190,8 +193,8 @@ export const ApiForm = ({ index, control, errors, systems }: ApiFormProps) => {
       </div>
       <div>
         <FieldHeader
-          fieldName="API Definition (path or URL)"
-          tooltipText="Relative path to the API definition file (OpenAPI, AsyncAPI, GraphQL, or gRPC). Required for new APIs. If editing an existing API this field may already be populated, check the existing catalog-info.yaml"
+          fieldName={t('form.APIForm.definition.fieldName')}
+          tooltipText={t('form.APIForm.definition.tooltipText')}
         />
         <Controller
           name={`entities.${index}.definition`}

--- a/plugins/catalog-creator/src/components/CatalogForm/Forms/ApiForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/Forms/ApiForm.tsx
@@ -69,7 +69,9 @@ export const ApiForm = ({ index, control, errors, systems }: ApiFormProps) => {
               visibility: errors?.lifecycle ? 'visible' : 'hidden',
             }}
           >
-            {errors?.lifecycle?.message || '\u00A0'}
+            {errors?.lifecycle?.message
+              ? t(errors?.lifecycle?.message as keyof typeof t)
+              : '\u00A0'}
           </span>
         </div>
 
@@ -116,7 +118,9 @@ export const ApiForm = ({ index, control, errors, systems }: ApiFormProps) => {
               visibility: errors?.entityType ? 'visible' : 'hidden',
             }}
           >
-            {errors?.entityType?.message || '\u00A0'}
+            {errors?.entityType?.message
+              ? t(errors?.entityType?.message as keyof typeof t)
+              : '\u00A0'}
           </span>
         </div>
       </Flex>
@@ -188,7 +192,9 @@ export const ApiForm = ({ index, control, errors, systems }: ApiFormProps) => {
             visibility: errors?.system ? 'visible' : 'hidden',
           }}
         >
-          {errors?.system?.message || '\u00A0'}
+          {errors?.system?.message
+            ? t(errors?.system?.message as keyof typeof t)
+            : '\u00A0'}
         </span>
       </div>
       <div>
@@ -222,7 +228,9 @@ export const ApiForm = ({ index, control, errors, systems }: ApiFormProps) => {
             visibility: errors?.definition ? 'visible' : 'hidden',
           }}
         >
-          {errors?.definition?.message || '\u00A0'}
+          {errors?.definition?.message
+            ? t(errors?.definition?.message as keyof typeof t)
+            : '\u00A0'}
         </span>
       </div>
     </Flex>

--- a/plugins/catalog-creator/src/components/CatalogForm/Forms/ComponentForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/Forms/ComponentForm.tsx
@@ -15,6 +15,8 @@ import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import Autocomplete from '@mui/material/Autocomplete';
 import MuiTextField from '@mui/material/TextField';
 import { FieldHeader } from '../FieldHeader';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { catalogCreatorTranslationRef } from '../../../utils/translations';
 
 export type ComponentFormProps = {
   index: number;
@@ -32,6 +34,7 @@ export const ComponentForm = ({
   systems,
 }: ComponentFormProps) => {
   const catalogApi = useApi(catalogApiRef);
+  const { t } = useTranslationRef(catalogCreatorTranslationRef);
 
   const fetchAPIs = useAsync(async () => {
     const results = await catalogApi.getEntities({
@@ -54,8 +57,8 @@ export const ComponentForm = ({
       <Flex>
         <div style={{ width: '50%' }}>
           <FieldHeader
-            fieldName="Lifecycle"
-            tooltipText="The lifecycle state of the component"
+            fieldName={t('form.componentForm.lifecycle.fieldName')}
+            tooltipText={t('form.componentForm.lifecycle.tooltipText')}
             required
           />
           <Controller
@@ -74,7 +77,7 @@ export const ComponentForm = ({
                 renderInput={params => (
                   <MuiTextField
                     {...params}
-                    placeholder="Select type"
+                    placeholder={t('form.componentForm.lifecycle.placeholder')}
                     InputProps={{
                       ...params.InputProps,
                       sx: {
@@ -148,8 +151,8 @@ export const ComponentForm = ({
       </Flex>
       <div>
         <FieldHeader
-          fieldName="System"
-          tooltipText="Reference to the system which the component belongs to"
+          fieldName={t('form.componentForm.system.fieldName')}
+          tooltipText={t('form.componentForm.system.tooltipText')}
         />
         <Controller
           name={`entities.${index}.system`}
@@ -192,7 +195,7 @@ export const ComponentForm = ({
               renderInput={params => (
                 <MuiTextField
                   {...params}
-                  placeholder="Select system"
+                  placeholder={t('form.componentForm.system.placeholder')}
                   InputProps={{
                     ...params.InputProps,
                     sx: {
@@ -218,8 +221,8 @@ export const ComponentForm = ({
       </div>
       <div>
         <FieldHeader
-          fieldName="Provides APIs"
-          tooltipText="References to all the APIs the component may provide. This does not define the API-entity itself"
+          fieldName={t('form.componentForm.providesAPIs.fieldName')}
+          tooltipText={t('form.componentForm.providesAPIs.tooltipText')}
         />
         <Controller
           name={`entities.${index}.providesApis`}
@@ -270,7 +273,7 @@ export const ComponentForm = ({
               renderInput={params => (
                 <MuiTextField
                   {...params}
-                  placeholder="Select or create API..."
+                  placeholder={t('form.componentForm.providesAPIs.placeholder')}
                   InputProps={{
                     ...params.InputProps,
                     sx: {
@@ -296,8 +299,8 @@ export const ComponentForm = ({
       </div>
       <div>
         <FieldHeader
-          fieldName="Consumes APIs"
-          tooltipText="APIs that are consumed by the component"
+          fieldName={t('form.componentForm.consumesAPIs.fieldName')}
+          tooltipText={t('form.componentForm.consumesAPIs.tooltipText')}
         />
         <Controller
           name={`entities.${index}.consumesApis`}
@@ -332,7 +335,7 @@ export const ComponentForm = ({
               renderInput={params => (
                 <MuiTextField
                   {...params}
-                  placeholder="Select or create API..."
+                  placeholder={t('form.componentForm.consumesAPIs.placeholder')}
                   InputProps={{
                     ...params.InputProps,
                     sx: {
@@ -358,8 +361,8 @@ export const ComponentForm = ({
       </div>
       <div>
         <FieldHeader
-          fieldName="Depends on"
-          tooltipText="References to other components and/or resources that the component depends on"
+          fieldName={t('form.componentForm.dependsOn.fieldName')}
+          tooltipText={t('form.componentForm.dependsOn.tooltipText')}
         />
         <Controller
           name={`entities.${index}.dependsOn`}
@@ -401,7 +404,7 @@ export const ComponentForm = ({
               renderInput={params => (
                 <MuiTextField
                   {...params}
-                  placeholder="Select or create resource or component..."
+                  placeholder={t('form.componentForm.dependsOn.placeholder')}
                   InputProps={{
                     ...params.InputProps,
                     sx: {

--- a/plugins/catalog-creator/src/components/CatalogForm/Forms/ComponentForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/Forms/ComponentForm.tsx
@@ -126,7 +126,7 @@ export const ComponentForm = ({
                 renderInput={params => (
                   <MuiTextField
                     {...params}
-                    placeholder="Select type"
+                    placeholder={t('form.componentForm.type.placeholder')}
                     InputProps={{
                       ...params.InputProps,
                       sx: {

--- a/plugins/catalog-creator/src/components/CatalogForm/Forms/ComponentForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/Forms/ComponentForm.tsx
@@ -98,7 +98,9 @@ export const ComponentForm = ({
               visibility: errors?.lifecycle ? 'visible' : 'hidden',
             }}
           >
-            {errors?.lifecycle?.message || '\u00A0'}
+            {errors?.lifecycle?.message
+              ? t(errors?.lifecycle?.message as keyof typeof t)
+              : '\u00A0'}
           </span>
         </div>
 
@@ -145,7 +147,9 @@ export const ComponentForm = ({
               visibility: errors?.entityType ? 'visible' : 'hidden',
             }}
           >
-            {errors?.entityType?.message || '\u00A0'}
+            {errors?.entityType?.message
+              ? t(errors?.entityType?.message as keyof typeof t)
+              : '\u00A0'}
           </span>
         </div>
       </Flex>
@@ -216,7 +220,9 @@ export const ComponentForm = ({
             visibility: errors?.system ? 'visible' : 'hidden',
           }}
         >
-          {errors?.system?.message || '\u00A0'}
+          {errors?.system?.message
+            ? t(errors?.system?.message as keyof typeof t)
+            : '\u00A0'}
         </span>
       </div>
       <div>
@@ -294,7 +300,9 @@ export const ComponentForm = ({
             visibility: errors?.providesApis ? 'visible' : 'hidden',
           }}
         >
-          {errors?.providesApis?.message || '\u00A0'}
+          {errors?.providesApis?.message
+            ? t(errors?.providesApis?.message as keyof typeof t)
+            : '\u00A0'}
         </span>
       </div>
       <div>
@@ -356,7 +364,9 @@ export const ComponentForm = ({
             visibility: errors?.consumesApis ? 'visible' : 'hidden',
           }}
         >
-          {errors?.consumesApis?.message || '\u00A0'}
+          {errors?.consumesApis?.message
+            ? t(errors?.consumesApis?.message as keyof typeof t)
+            : '\u00A0'}
         </span>
       </div>
       <div>
@@ -425,7 +435,9 @@ export const ComponentForm = ({
             visibility: errors?.dependsOn ? 'visible' : 'hidden',
           }}
         >
-          {errors?.dependsOn?.message || '\u00A0'}
+          {errors?.dependsOn?.message
+            ? t(errors?.dependsOn?.message as keyof typeof t)
+            : '\u00A0'}
         </span>
       </div>
     </Flex>

--- a/plugins/catalog-creator/src/components/CatalogForm/Forms/SystemForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/Forms/SystemForm.tsx
@@ -11,6 +11,8 @@ import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { FieldHeader } from '../FieldHeader';
 import Autocomplete from '@mui/material/Autocomplete';
 import MuiTextField from '@mui/material/TextField';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { catalogCreatorTranslationRef } from '../../../utils/translations';
 
 export type SystemFormProps = {
   index: number;
@@ -21,6 +23,7 @@ export type SystemFormProps = {
 
 export const SystemForm = ({ index, control, errors }: SystemFormProps) => {
   const catalogApi = useApi(catalogApiRef);
+  const { t } = useTranslationRef(catalogCreatorTranslationRef);
   const fetchDomains = useAsync(async () => {
     const results = await catalogApi.getEntities({
       filter: {
@@ -35,8 +38,8 @@ export const SystemForm = ({ index, control, errors }: SystemFormProps) => {
       <Flex>
         <div style={{ flexGrow: 1, width: '50%' }}>
           <FieldHeader
-            fieldName="Type"
-            tooltipText="The type of the system. Optional"
+            fieldName={t('form.systemForm.type.fieldName')}
+            tooltipText={t('form.systemForm.type.tooltipText')}
           />
           <Controller
             name={`entities.${index}.systemType`}
@@ -81,8 +84,8 @@ export const SystemForm = ({ index, control, errors }: SystemFormProps) => {
       </Flex>
       <div>
         <FieldHeader
-          fieldName="Domain"
-          tooltipText="Reference to the domain the system is a part of"
+          fieldName={t('form.systemForm.domain.fieldName')}
+          tooltipText={t('form.systemForm.domain.tooltipText')}
         />
         <Controller
           name={`entities.${index}.domain`}

--- a/plugins/catalog-creator/src/components/CatalogForm/Forms/SystemForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/Forms/SystemForm.tsx
@@ -57,7 +57,7 @@ export const SystemForm = ({ index, control, errors }: SystemFormProps) => {
                 renderInput={params => (
                   <MuiTextField
                     {...params}
-                    placeholder="Select type"
+                    placeholder={t('form.componentForm.type.placeholder')}
                     InputProps={{
                       ...params.InputProps,
                       sx: {

--- a/plugins/catalog-creator/src/components/CatalogForm/Forms/SystemForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/Forms/SystemForm.tsx
@@ -78,7 +78,9 @@ export const SystemForm = ({ index, control, errors }: SystemFormProps) => {
               visibility: errors?.entityType ? 'visible' : 'hidden',
             }}
           >
-            {errors?.entityType?.message || '\u00A0'}
+            {errors?.entityType?.message
+              ? t(errors?.entityType?.message as keyof typeof t)
+              : '\u00A0'}
           </span>
         </div>
       </Flex>
@@ -107,7 +109,9 @@ export const SystemForm = ({ index, control, errors }: SystemFormProps) => {
             visibility: errors?.domain ? 'visible' : 'hidden',
           }}
         >
-          {errors?.domain?.message || '\u00A0'}
+          {errors?.domain?.message
+            ? t(errors?.domain?.message as keyof typeof t)
+            : '\u00A0'}
         </span>
       </div>
     </Flex>

--- a/plugins/catalog-creator/src/controllers/githubController.ts
+++ b/plugins/catalog-creator/src/controllers/githubController.ts
@@ -12,6 +12,7 @@ export class GithubController {
     initialYaml: RequiredYamlFields[],
     catalogInfo: FormEntity[],
     githubAuthApi: OAuthApi,
+    couldNotCreatePRErrorMsg: string,
   ): Promise<Status | undefined> => {
     const emptyRequiredYaml: RequiredYamlFields = {
       apiVersion: 'backstage.io/v1alpha1',
@@ -83,8 +84,7 @@ export class GithubController {
       throw new Error();
     } catch (error: unknown) {
       if (error instanceof Error) {
-        error.message =
-          'Could not create a pull request. Make sure the URL is a github repo and that a pull request does not already exist.';
+        error.message = couldNotCreatePRErrorMsg;
         throw error;
       } else {
         throw new Error('Unkown error when trying to create a PR.');

--- a/plugins/catalog-creator/src/index.ts
+++ b/plugins/catalog-creator/src/index.ts
@@ -1,1 +1,2 @@
 export { catalogCreatorPlugin, CatalogCreatorPage } from './plugin';
+export { catalogCreatorNorwegianTranslation } from './utils/translations';

--- a/plugins/catalog-creator/src/schemas/formSchema.ts
+++ b/plugins/catalog-creator/src/schemas/formSchema.ts
@@ -7,20 +7,20 @@ const baseEntitySchema = z.object({
   name: z
     .string()
     .trim()
-    .min(1, 'Add a name')
-    .refine(s => !s.includes(' '), { message: 'Name cannot contain space' })
+    .min(1, 'form.errors.noName')
+    .refine(s => !s.includes(' '), { message: 'form.errors.nameNoSpace' })
     .refine(
       s =>
         !/^[.!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]|[.!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]$/.test(
           s,
         ),
-      'Name cannot start or end with special characters',
+      'form.errors.ownerNoSpace',
     ),
   owner: z
     .string()
     .trim()
-    .min(1, 'Add an owner')
-    .refine(s => !s.includes(' '), { message: 'Owner cannot contain space' }),
+    .min(1, 'form.errors.noOwner')
+    .refine(s => !s.includes(' '), { message: 'form.errors.ownerNoSpace' }),
   title: z.string().optional(),
 });
 
@@ -31,23 +31,25 @@ export const componentSchema = baseEntitySchema.extend({
       .string()
       .trim()
       .refine(s => !s.includes(' '), {
-        message: 'System cannot contain space',
+        message: 'form.errors.systemNoSpace',
       }),
   ),
 
-  lifecycle: z.enum(AllowedLifecycleStages, { message: 'Choose a lifecycle' }),
+  lifecycle: z.enum(AllowedLifecycleStages, {
+    message: 'form.errors.noLifecycle',
+  }),
   entityType: z
-    .string('Add a type')
+    .string('form.errors.noType')
     .trim()
-    .min(1, 'Add a type')
-    .refine(s => !s.includes(' '), { message: 'Type cannot contain space' }),
+    .min(1, 'form.errors.noType')
+    .refine(s => !s.includes(' '), { message: 'form.errors.typeNoSpace' }),
   subcomponentOf: z.string().optional(),
   providesApis: z
     .array(z.string())
     .refine(
       entries =>
         entries.every(entry => entry.trim().length > 0 && !entry.includes(' ')),
-      { message: 'APIs cannot contain space' },
+      { message: 'form.errors.APIsNoSpace' },
     )
     .optional(),
   consumesApis: z
@@ -55,7 +57,7 @@ export const componentSchema = baseEntitySchema.extend({
     .refine(
       entries =>
         entries.every(entry => entry.trim().length > 0 && !entry.includes(' ')),
-      { message: 'APIs cannot contain space' },
+      { message: 'form.errors.APIsNoSpace' },
     )
     .optional(),
   dependsOn: z
@@ -63,7 +65,7 @@ export const componentSchema = baseEntitySchema.extend({
     .refine(
       entries =>
         entries.every(entry => entry.trim().length > 0 && !entry.includes(' ')),
-      { message: 'Dependencies cannot contain space' },
+      { message: 'form.errors.dependenciesNoSpace' },
     )
     .optional(),
   depencencyOf: z.array(z.string()).optional(),
@@ -72,18 +74,20 @@ export const componentSchema = baseEntitySchema.extend({
 export const apiSchema = baseEntitySchema.extend({
   kind: z.literal('API'),
 
-  lifecycle: z.enum(AllowedLifecycleStages, { message: 'Choose a lifecycle' }),
+  lifecycle: z.enum(AllowedLifecycleStages, {
+    message: 'form.errors.noLifecycle',
+  }),
   entityType: z
-    .string('Add a type')
+    .string('form.errors.noType')
     .trim()
-    .min(1, 'Add a type')
-    .refine(s => !s.includes(' '), { message: 'Type cannot contain space' }),
+    .min(1, 'form.errors.noType')
+    .refine(s => !s.includes(' '), { message: 'form.errors.typeNoSpace' }),
   system: z.optional(
     z
       .string()
       .trim()
       .refine(s => !s.includes(' '), {
-        message: 'System cannot contain space',
+        message: 'form.errors.systemNoSpace',
       }),
   ),
   definition: z.optional(
@@ -91,7 +95,7 @@ export const apiSchema = baseEntitySchema.extend({
       .string()
       .trim()
       .refine(s => !s.includes(' '), {
-        message: 'Definition URL cannot contain space',
+        message: 'form.errors.definitionNoSpace',
       }),
   ),
 });
@@ -107,7 +111,7 @@ export const systemSchema = baseEntitySchema.extend({
       .string()
       .trim()
       .refine(s => !s.includes(' '), {
-        message: 'Type cannot contain space',
+        message: 'form.errors.typeNoSpace',
       }),
   ),
   domain: z.optional(
@@ -115,7 +119,7 @@ export const systemSchema = baseEntitySchema.extend({
       .string()
       .trim()
       .refine(s => !s.includes(' '), {
-        message: 'Domain cannot contain space',
+        message: 'form.errors.domainNoSpace',
       }),
   ),
 

--- a/plugins/catalog-creator/src/utils/getRepoInfo.ts
+++ b/plugins/catalog-creator/src/utils/getRepoInfo.ts
@@ -1,7 +1,12 @@
 import { OAuthApi } from '@backstage/core-plugin-api';
+// import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { Octokit } from '@octokit/rest';
 
-export async function getRepoInfo(url: string, githubAuthApi: OAuthApi) {
+export async function getRepoInfo(
+  url: string,
+  githubAuthApi: OAuthApi,
+  // t: ReturnType<typeof useTranslationRef>['t'],
+) {
   const match = url.match(/github\.com\/([^\/]+)\/([^\/]+)/);
 
   if (!match) {
@@ -28,7 +33,7 @@ export async function getRepoInfo(url: string, githubAuthApi: OAuthApi) {
     returnObject.default_branch = response.data.default_branch;
   } catch (error: unknown) {
     if (error instanceof Error) {
-      error.message = `Could not find the GitHub repository: ${url}.`;
+      error.message = `Could not find the GitHub repository: ${url}`;
       throw error;
     } else {
       throw new Error(

--- a/plugins/catalog-creator/src/utils/getRepoInfo.ts
+++ b/plugins/catalog-creator/src/utils/getRepoInfo.ts
@@ -1,11 +1,10 @@
 import { OAuthApi } from '@backstage/core-plugin-api';
-// import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { Octokit } from '@octokit/rest';
 
 export async function getRepoInfo(
   url: string,
   githubAuthApi: OAuthApi,
-  // t: ReturnType<typeof useTranslationRef>['t'],
+  canNotFindRepoErrorMsg: string,
 ) {
   const match = url.match(/github\.com\/([^\/]+)\/([^\/]+)/);
 
@@ -33,7 +32,7 @@ export async function getRepoInfo(
     returnObject.default_branch = response.data.default_branch;
   } catch (error: unknown) {
     if (error instanceof Error) {
-      error.message = `Could not find the GitHub repository: ${url}`;
+      error.message = `${canNotFindRepoErrorMsg}${url}`;
       throw error;
     } else {
       throw new Error(

--- a/plugins/catalog-creator/src/utils/translations.ts
+++ b/plugins/catalog-creator/src/utils/translations.ts
@@ -109,6 +109,27 @@ export const catalogCreatorMessages = {
         placeholder: 'Select domain',
       },
     },
+    errors: {
+      noName: 'Add a name',
+      nameNoSpace: 'Name cannot contain space',
+      nameNoSpecialChar: 'Name cannot start or end with special characters',
+
+      noOwner: 'Add an owner',
+      ownerNoSpace: 'Name cannot contain space',
+
+      systemNoSpace: 'System cannot contain space',
+      noLifecycle: 'Choose a lifecycle',
+
+      noType: 'Add a type',
+      typeNoSpace: 'Type cannot contain space',
+
+      APIsNoSpace: 'APIs cannot contain space',
+      dependenciesNoSpace: 'Dependencies cannot contain space',
+
+      definitionNoSpace: 'Definition URL cannot contain space',
+
+      domainNoSpace: 'Domain cannot contain space',
+    },
 
     infoAlerts: {
       alreadyExists: 'Catalog-info.yaml already exists. Editing existing file.',
@@ -148,6 +169,11 @@ export const catalogCreatorMessages = {
           requires during runtime, such as object storage or other cloud
           services.`,
     linkText: `Learn more about entities and the Backstage catalog.`,
+  },
+  successPage: {
+    successfullyCreatedPR: 'Successfully created a pull request: ',
+    couldNotRetrieveURL: 'Could not retrieve pull request URL.',
+    registerNew: 'Register a new component?',
   },
 } as const;
 
@@ -245,6 +271,41 @@ export const catalogCreatorNorwegianTranslation = createTranslationResource({
             'Referanse til domenet som systemet tilhører.',
           'form.systemForm.domain.placeholder': 'Velg domene',
 
+          'form.infoAlerts.alreadyExists':
+            'Catalog-info.yaml finnes fra før, du redigerer filen.',
+          'form.infoAlerts.doesNotExist':
+            'Catalog-info.yaml finnes ikke, du oppretter en ny fil.',
+
+          'form.knownErrorAlerts.repoNotFound':
+            'Kunne ikke finne GitHub-kodelager med URL: ',
+          'form.knownErrorAlerts.PRExists':
+            'Det finnes allerede en pull request: ',
+          'form.knownErrorAlerts.couldNotCheckIfPRExists':
+            'Kunne ikke sjekke om PR finnes fra før for GitHub-kodelager med URL: ',
+          'form.knownErrorAlerts.couldNotCreatePR':
+            'Kunne ikke lage en pull request. Sjekk at URL er et GitHub-kodelager og at det ikke finnes en eksisterende pull request.',
+
+          'form.errors.noName': 'Legg til navn',
+          'form.errors.nameNoSpace': 'Navn kan ikke inneholde mellomrom',
+          'form.errors.nameNoSpecialChar':
+            'Navn kan ikke inneholde spesialtegn',
+
+          'form.errors.noOwner': 'Legg til eier',
+          'form.errors.ownerNoSpace': 'Eier kan ikke inneholde mellomrom',
+
+          'form.errors.systemNoSpace': 'System kan ikke inneholde mellomrom',
+
+          'form.errors.noLifecycle': 'Velg et livsyklusstadie',
+
+          'form.errors.noType': 'Legg til en type',
+          'form.errors.typeNoSpace': 'Type kan ikke inneholde mellomrom',
+
+          'form.errors.APIsNoSpace': 'APIer kan ikke inneholde mellomrom',
+          'form.errors.dependenciesNoSpace':
+            'Avhengigheter kan ikke inneholde mellomrom',
+          'form.errors.definitionNoSpace': 'URL kan ikke inneholde mellomrom',
+          'form.errors.domainNoSpace': 'Domene kan ikke inneholde mellomrom',
+
           'infoBox.title': 'Rediger eller lag catalog-info.yaml',
           'infoBox.p1':
             'Dette skjemaet hjelper deg med å opprette eller redigere catalog-info.yaml-filer som brukes av Backstage for å oppdage og administrere programvarekomponenter i katalogen. Skriv inn en GitHub-kodelager-URL for å legge den til i utviklerportalen, eller oppgi en lenke til en eksisterende catalog-info.yaml-fil for å redigere den ved hjelp av dette skjemaet.',
@@ -261,19 +322,10 @@ export const catalogCreatorNorwegianTranslation = createTranslationResource({
             'Resource-entiteter representerer delte ressurser som en komponent trenger under kjøring, for eksempel objektlagring eller andre skytjenester.',
           'infoBox.linkText': 'Lær mer om entiteter og Backstage-katalogen.',
 
-          'form.infoAlerts.alreadyExists':
-            'Catalog-info.yaml finnes fra før, du redigerer filen.',
-          'form.infoAlerts.doesNotExist':
-            'Catalog-info.yaml finnes ikke, du oppretter en ny fil.',
-
-          'form.knownErrorAlerts.repoNotFound':
-            'Kunne ikke finne GitHub-kodelager med URL: ',
-          'form.knownErrorAlerts.PRExists':
-            'Det finnes allerede en pull request: ',
-          'form.knownErrorAlerts.couldNotCheckIfPRExists':
-            'Kunne ikke sjekke om PR finnes fra før for GitHub-kodelager med URL: ',
-          'form.knownErrorAlerts.couldNotCreatePR':
-            'Kunne ikke lage en pull request. Sjekk at URL er et GitHub-kodelager og at det ikke finnes en eksisterende pull request.',
+          'successPage.successfullyCreatedPR': 'Opprettet en pull request: ',
+          'successPage.couldNotRetrieveURL':
+            'Klarte ikke hente URL for pull request.',
+          'successPage.registerNew': 'Registrer en ny component?',
         },
       }),
   },

--- a/plugins/catalog-creator/src/utils/translations.ts
+++ b/plugins/catalog-creator/src/utils/translations.ts
@@ -117,7 +117,11 @@ export const catalogCreatorMessages = {
 
     knownErrorAlerts: {
       repoNotFound: 'Could not find the GitHub repository: ',
+      couldNotCheckIfPRExists:
+        'Could not check if the pull request already exists for: ',
       PRExists: 'There already exists a pull request: ',
+      couldNotCreatePR:
+        'Could not create a pull request. Make sure the URL is a github repo and that a pull request does not already exist.',
     },
   },
   infoBox: {
@@ -266,6 +270,10 @@ export const catalogCreatorNorwegianTranslation = createTranslationResource({
             'Kunne ikke finne GitHub-kodelager med URL: ',
           'form.knownErrorAlerts.PRExists':
             'Det finnes allerede en pull request: ',
+          'form.knownErrorAlerts.couldNotCheckIfPRExists':
+            'Kunne ikke sjekke om PR finnes fra før for GitHub-kodelager med URL: ',
+          'form.knownErrorAlerts.couldNotCreatePR':
+            'Kunne ikke lage en pull request. Sjekk at URL er et GitHub-kodelager og at det ikke finnes en eksisterende pull request.',
         },
       }),
   },

--- a/plugins/catalog-creator/src/utils/translations.ts
+++ b/plugins/catalog-creator/src/utils/translations.ts
@@ -1,0 +1,27 @@
+import {
+  createTranslationRef,
+  createTranslationResource,
+} from '@backstage/core-plugin-api/alpha';
+
+export const catalogCreatorMessages = {
+  contentHeader: {
+    title: 'Edit or Create Components',
+  },
+} as const;
+
+export const catalogCreatorTranslationRef = createTranslationRef({
+  id: 'catalog.creator',
+  messages: catalogCreatorMessages,
+});
+
+export const catalogCreatorNorwegianTranslation = createTranslationResource({
+  ref: catalogCreatorTranslationRef,
+  translations: {
+    no: () =>
+      Promise.resolve({
+        default: {
+          'contentHeader.title': 'Rediger eller lag komponenter',
+        },
+      }),
+  },
+});

--- a/plugins/catalog-creator/src/utils/translations.ts
+++ b/plugins/catalog-creator/src/utils/translations.ts
@@ -23,6 +23,11 @@ export const catalogCreatorMessages = {
       tooltipText:
         'The name of the entity. This name is both meant for human eyes to recognize the entity, and for machines and other components to reference the entity. Must be unique',
     },
+    titleField: {
+      fieldName: 'Title',
+      tooltipText:
+        'A human-readable title for the component entity, shown in Backstage UI instead of the name when available. Optional.',
+    },
     owner: {
       fieldName: 'Owner',
       tooltipText:
@@ -201,6 +206,10 @@ export const catalogCreatorNorwegianTranslation = createTranslationResource({
           'form.name.fieldName': 'Navn',
           'form.name.tooltipText':
             'Navnet på entiteten. Dette navnet er både ment for at mennesker skal kunne kjenne igjen entiteten, men også for maskiner og andre komponenter for å kunne referrere til entiteten. Det må være unikt.',
+
+          'form.titleField.fieldName': 'Tittel',
+          'form.titleField.tooltipText':
+            'En tittel for entiteten, vist i utviklerportalen i stedet for navn når det er tilgjengelig. Det er ikke obligatorisk.',
 
           'form.owner.fieldName': 'Eier',
           'form.owner.tooltipText':

--- a/plugins/catalog-creator/src/utils/translations.ts
+++ b/plugins/catalog-creator/src/utils/translations.ts
@@ -161,15 +161,18 @@ export const catalogCreatorMessages = {
        These entities are seperated into three groups: core entities, ecosystem entities, and organizational entities.
         Core entities include Component, API, and Resource. Ecosystem entities include System and Domain.
          Organizational entities include Group and User. Below is a brief explanation of the core entities.`,
+    componentTitle: 'Component',
     componentParagraph: `A Component is a piece of software, such as a service, library or a
           website. Components will often correspond to a repository. Components can provide APIs that other components consume, and often
           depend on APIs and resources.`,
+    APITitle: 'API',
     APIParagraph: `An API entity describes an API that a component provides and that
           other components consume. Public APIs are the primary ways which
           components interact. The API specification should be included in the
           API entity and the file path to this document should be added to the
           API entity, with the file path to the API definition so that
           the developer portal can provide detailed information.`,
+    resourceTitle: 'Resource',
     resourceParagraph: `Resource entities represent shared shared resources that a component
           requires during runtime, such as object storage or other cloud
           services.`,
@@ -323,10 +326,13 @@ export const catalogCreatorNorwegianTranslation = createTranslationResource({
           'infoBox.subtitle': 'Hva er entiteter i Backstage?',
           'infoBox.p3':
             'Utviklerportalen er bygget med Backstage, som definerer et sett med entiteter som brukes til å bygge programvarekatalogen. Disse entitetene er delt inn i tre grupper: kjerneentiteter, økosystementiteter og organisatoriske entiteter. Kjerneentiteter inkluderer Component, API og Resource. Økosystementiteter inkluderer System og Domain. Organisatoriske entiteter inkluderer Group og User. Nedenfor finner du en kort forklaring av kjerneentiteter.',
+          'infoBox.componentTitle': 'Component',
           'infoBox.componentParagraph':
             'En Component er et stykke programvare, for eksempel en tjeneste, et bibliotek eller et nettsted. Komponenter tilsvarer ofte et eget kodelager. Komponenter kan tilby API-er som andre komponenter bruker, og avhenger ofte av API-er og ressurser selv.',
+          'infoBox.APITitle': 'API',
           'infoBox.APIParagraph':
             'En API-entitet beskriver et API som en komponent tilbyr, og som andre komponenter bruker. Offentlige API-er er den primære måten komponenter samhandler på. API-spesifikasjonen bør inkluderes i API-entiteter, og filbanen til dette dokumentet bør legges til i API-entiteter slik at utviklerportalen kan vise detaljert informasjon.',
+          'infoBox.resourceTitle': 'Resource',
           'infoBox.resourceParagraph':
             'Resource-entiteter representerer delte ressurser som en komponent trenger under kjøring, for eksempel objektlagring eller andre skytjenester.',
           'infoBox.linkText': 'Lær mer om entiteter og Backstage-katalogen.',

--- a/plugins/catalog-creator/src/utils/translations.ts
+++ b/plugins/catalog-creator/src/utils/translations.ts
@@ -7,6 +7,144 @@ export const catalogCreatorMessages = {
   contentHeader: {
     title: 'Edit or Create Components',
   },
+  repositorySearch: {
+    label: 'Repository URL',
+    placeholder: 'Enter a URL',
+    fetchButton: 'Fetch!',
+  },
+
+  form: {
+    title: 'Catalog-info.yaml Form',
+    requiredFields: 'Required fields marked with: ',
+    entity: ' Entity',
+
+    name: {
+      fieldName: 'Name',
+      tooltipText:
+        'The name of the entity. This name is both meant for human eyes to recognize the entity, and for machines and other components to reference the entity. Must be unique',
+    },
+    owner: {
+      fieldName: 'Owner',
+      tooltipText:
+        'A reference to the owner (commonly a team), that bears ultimate responsibility for the entity, and has the authority and capability to develop and maintain it',
+      placeholder: 'Select an owner',
+    },
+
+    addEntity: {
+      title: 'Add Entity',
+      label: 'Select kind',
+      buttonText: 'Add entity',
+    },
+    createPR: 'Create pull request',
+
+    componentForm: {
+      lifecycle: {
+        fieldName: 'Lifecycle',
+        tooltipText: 'The lifecycle state of the component.',
+        placeholder: 'Select lifecycle state',
+      },
+      type: {
+        fieldName: 'Type',
+        tooltipText: 'The type of the component.',
+        placeholder: 'Select type',
+      },
+      system: {
+        fieldName: 'System',
+        tooltipText: 'Reference to the system which the component belongs to.',
+        placeholder: 'Select system',
+      },
+      providesAPIs: {
+        fieldName: 'Provides APIs',
+        tooltipText:
+          'References to all the APIs the component may provide. This does not define the API-entity itself.',
+        placeholder: 'Select or add API...',
+      },
+
+      consumesAPIs: {
+        fieldName: 'Consumes APIs',
+        tooltipText: 'APIs that are consumed by the component.',
+        placeholder: 'Select or add API...',
+      },
+      dependsOn: {
+        fieldName: 'Depends on',
+        tooltipText:
+          'References to other components and/or resources that the component depends on.',
+        placeholder: 'Select or add resource or component...',
+      },
+    },
+
+    APIForm: {
+      lifecycle: {
+        fieldName: 'Lifecycle',
+        tooltipText: 'The lifecycle state of the API.',
+        placeholder: 'Select lifecycle state',
+      },
+      type: {
+        fieldName: 'Type',
+        tooltipText: 'The type of the API.',
+        placeholder: 'Select type',
+      },
+      system: {
+        fieldName: 'System',
+        tooltipText: 'Reference to the system which the API belongs to.',
+        placeholder: 'Select system',
+      },
+
+      definition: {
+        fieldName: 'API Definition (path or URL)',
+        tooltipText:
+          'Relative path to the API definition file (OpenAPI, AsyncAPI, GraphQL, or gRPC). Required for new APIs. If editing an existing API this field may already be populated, check the existing catalog-info.yaml',
+      },
+    },
+
+    systemForm: {
+      type: {
+        fieldName: 'Type',
+        tooltipText: 'The type of the system.',
+        placeholder: 'Select type',
+      },
+      domain: {
+        fieldName: 'Domain',
+        tooltipText: 'Reference to the domain which the system i s a part of.',
+        placeholder: 'Select domain',
+      },
+    },
+
+    infoAlerts: {
+      alreadyExists: 'Catalog-info.yaml already exists. Editing existing file.',
+      doesNotExist: 'Catalog-info.yaml does not exist. Creating a new file.',
+    },
+
+    knownErrorAlerts: {
+      repoNotFound: 'Could not find the GitHub repository: ',
+      PRExists: 'There already exists a pull request: ',
+    },
+  },
+  infoBox: {
+    title: 'Edit or Generate Catalog-info.yaml',
+    p1: `This form helps you create or edit catalog-info.yaml files used by Backstage to discover and manage software components in the catalog. Enter a GitHub repository URL to add it to the developer portal,
+           or provide a link to an existing catalog-info.yaml file to edit it using this form.`,
+    p2: `Once the form is completed with the correct entities, click "Create Pull Request" to propose changes or additions to the catalog-info.yaml file in the relevant repository. 
+           The changes will take effect only after the pull request is merged and the developer portal updates its catalog.`,
+    subtitle: 'What are Entities in Backstage?',
+    p3: `The developer portal is built using Backstage, which defines a set of entities used to build the software catalog.
+       These entities are seperated into three groups: core entities, ecosystem entities, and organizational entities.
+        Core entities include Component, API, and Resource. Ecosystem entities include System and Domain.
+         Organizational entities include Group and User. Below is a brief explanation of the core entities.`,
+    componentParagraph: `A Component is a piece of software, such as a service, library or a
+          website. Components will often correspond to a repository. Components can provide APIs that other components consume, and often
+          depend on APIs and resources.`,
+    APIParagraph: `An API entity describes an API that a component provides and that
+          other components consume. Public APIs are the primary ways which
+          components interact. The API specification should be included in the
+          API entity and the file path to this document should be added to the
+          API entity, with the file path to the API definition so that
+          the developer portal can provide detailed information.`,
+    resourceParagraph: `Resource entities represent shared shared resources that a component
+          requires during runtime, such as object storage or other cloud
+          services.`,
+    linkText: `Learn more about entities and the Backstage catalog.`,
+  },
 } as const;
 
 export const catalogCreatorTranslationRef = createTranslationRef({
@@ -21,6 +159,113 @@ export const catalogCreatorNorwegianTranslation = createTranslationResource({
       Promise.resolve({
         default: {
           'contentHeader.title': 'Rediger eller lag komponenter',
+
+          'repositorySearch.label': 'Kodelager URL',
+          'repositorySearch.placeholder': 'Skriv inn en URL',
+          'repositorySearch.fetchButton': 'Hent!',
+
+          'form.title': 'Catalog-info.yaml skjema',
+          'form.requiredFields': 'Obligatoriske felter er markert med: ',
+          'form.entity': '-entitet',
+
+          'form.name.fieldName': 'Navn',
+          'form.name.tooltipText':
+            'Navnet på entiteten. Dette navnet er både ment for at mennesker skal kunne kjenne igjen entiteten, men også for maskiner og andre komponenter for å kunne referrere til entiteten. Det må være unikt.',
+
+          'form.owner.fieldName': 'Eier',
+          'form.owner.tooltipText':
+            'En refereanse til eieren (ofte et team) som har ansvaret for entiteten og har autorisasjon og kunnskapen til å utvikle og vedlikeholdet den.',
+          'form.owner.placeholder': 'Velg en eier',
+
+          'form.addEntity.title': 'Legg til entitet',
+          'form.addEntity.label': 'Velg entitet',
+          'form.addEntity.buttonText': 'Legg til entitet',
+
+          'form.createPR': 'Lag pull request',
+
+          'form.componentForm.lifecycle.fieldName': 'Livssyklus',
+          'form.componentForm.lifecycle.tooltipText':
+            'Livssyklusstadiet til en komponent.',
+          'form.componentForm.lifecycle.placeholder': 'Velg livssyklusstadie',
+
+          'form.componentForm.type.fieldName': 'Type',
+          'form.componentForm.type.tooltipText': 'Typen til komponenten.',
+          'form.componentForm.type.placeholder': 'Velg type',
+
+          'form.componentForm.system.fieldName': 'System',
+          'form.componentForm.system.tooltipText':
+            'Referanse til systemet som komponenten tilhører.',
+          'form.componentForm.system.placeholder': 'Velg system',
+
+          'form.componentForm.providesAPIs.fieldName': 'Tilbyr APIer',
+          'form.componentForm.providesAPIs.tooltipText':
+            'Referanse til alle APIer komponenten tilbyr. Et API som ikke finnes i listen må defineres i denne eller i en annen catalog-info.yaml.',
+          'form.componentForm.providesAPIs.placeholder':
+            'Velg eller legg til APIer...',
+
+          'form.componentForm.consumesAPIs.fieldName': 'Bruker APIer',
+          'form.componentForm.consumesAPIs.tooltipText':
+            'Referanse til alle APIer komponenten tilbyr. Et API som ikke finnes i listen må defineres i denne eller i en annen catalog-info.yaml.',
+          'form.componentForm.consumesAPIs.placeholder':
+            'Velg eller legg til APIer...',
+
+          'form.componentForm.dependsOn.fieldName': 'Avhenger av',
+          'form.componentForm.dependsOn.tooltipText':
+            'Referanse til komponenten eller ressurser som komponenten er avhengig av. En komponent eller ressurs som ikke finnes i listen må defineres i denne eller i en annen catalog-info.yaml.',
+          'form.componentForm.dependsOn.placeholder':
+            'Velg eller legg til komponenter eller ressurser...',
+
+          'form.APIForm.lifecycle.fieldName': 'Livssyklus',
+          'form.APIForm.lifecycle.tooltipText': 'Livssyklusstadiet til et API.',
+          'form.APIForm.lifecycle.placeholder': 'Velg livssyklusstadie',
+
+          'form.APIForm.type.fieldName': 'Type',
+          'form.APIForm.type.tooltipText': 'Typen til APIet.',
+          'form.APIForm.type.placeholder': 'Velg type',
+
+          'form.APIForm.system.fieldName': 'System',
+          'form.APIForm.system.tooltipText':
+            'Referanse til systemet som APIet tilhører.',
+          'form.APIForm.system.placeholder': 'Velg system',
+
+          'form.APIForm.definition.fieldName': 'Definisjon',
+          'form.APIForm.definition.tooltipText':
+            'Relativ filsti til API definisjonfilen (openAPI AsyncAPI, GraphQL, eller gRPC). Obligatorisk for nye APIer. Hvis du redigerer et eksisterende API kan det hende at dette feltet er fylt ut med tekst som ikke vises. Se catalog-info.yaml filen med API definisjonen.',
+
+          'form.systemForm.type.fieldName': 'Type',
+          'form.systemForm.type.tooltipText': 'Systemets type.',
+          'form.systemForm.type.placeholder': 'Velg system',
+
+          'form.systemForm.domain.fieldName': 'Domene',
+          'form.systemForm.domain.tooltipText':
+            'Referanse til domenet som systemet tilhører.',
+          'form.systemForm.domain.placeholder': 'Velg domene',
+
+          'infoBox.title': 'Rediger eller lag catalog-info.yaml',
+          'infoBox.p1':
+            'Dette skjemaet hjelper deg med å opprette eller redigere catalog-info.yaml-filer som brukes av Backstage for å oppdage og administrere programvarekomponenter i katalogen. Skriv inn en GitHub-kodelager-URL for å legge den til i utviklerportalen, eller oppgi en lenke til en eksisterende catalog-info.yaml-fil for å redigere den ved hjelp av dette skjemaet.',
+          'infoBox.p2':
+            'Når skjemaet er fylt ut med de riktige entitetene, klikker du på Opprett Pull Request for å foreslå endringer eller tillegg til catalog-info.yaml-filen i det aktuelle kodelageret. Endringene trer i kraft først når pull request-en er slått sammen, og utviklerportalen har oppdatert katalogen sin.',
+          'infoBox.subtitle': 'Hva er entiteter i Backstage?',
+          'infoBox.p3':
+            'Utviklerportalen er bygget med Backstage, som definerer et sett med entiteter som brukes til å bygge programvarekatalogen. Disse entitetene er delt inn i tre grupper: kjerneentiteter, økosystementiteter og organisatoriske entiteter. Kjerneentiteter inkluderer Component, API og Resource. Økosystementiteter inkluderer System og Domain. Organisatoriske entiteter inkluderer Group og User. Nedenfor finner du en kort forklaring av kjerneentiteter.',
+          'infoBox.componentParagraph':
+            'En Component er et stykke programvare, for eksempel en tjeneste, et bibliotek eller et nettsted. Komponenter tilsvarer ofte et eget kodelager. Komponenter kan tilby API-er som andre komponenter bruker, og avhenger ofte av API-er og ressurser selv.',
+          'infoBox.APIParagraph':
+            'En API-entitet beskriver et API som en komponent tilbyr, og som andre komponenter bruker. Offentlige API-er er den primære måten komponenter samhandler på. API-spesifikasjonen bør inkluderes i API-entiteter, og filbanen til dette dokumentet bør legges til i API-entiteter slik at utviklerportalen kan vise detaljert informasjon.',
+          'infoBox.resourceParagraph':
+            'Resource-entiteter representerer delte ressurser som en komponent trenger under kjøring, for eksempel objektlagring eller andre skytjenester.',
+          'infoBox.linkText': 'Lær mer om entiteter og Backstage-katalogen.',
+
+          'form.infoAlerts.alreadyExists':
+            'Catalog-info.yaml finnes fra før, du redigerer filen.',
+          'form.infoAlerts.doesNotExist':
+            'Catalog-info.yaml finnes ikke, du oppretter en ny fil.',
+
+          'form.knownErrorAlerts.repoNotFound':
+            'Kunne ikke finne GitHub-kodelager med URL: ',
+          'form.knownErrorAlerts.PRExists':
+            'Det finnes allerede en pull request: ',
         },
       }),
   },


### PR DESCRIPTION
## 🔒 Bakgrunn
Catalog-creator var kun på engelsk og hadde ikke oversettelser for norsk.


## 🔑 Løsning
Bruke Backstage internationalization som bygger på i18next til å definere tekst i UI-et og hva de skal oversettes til. 


## 📸 Bilder
<img width="1022" height="1001" alt="Screenshot 2025-10-28 at 16 12 45" src="https://github.com/user-attachments/assets/75273303-8fde-417b-a360-305bb680d4a2" />

