### PR TITLE
Fix caching on fetch catalog-creator

### DIFF
--- a/plugins/catalog-creator/src/utils/getCatalogInfo.ts
+++ b/plugins/catalog-creator/src/utils/getCatalogInfo.ts
@@ -30,6 +30,9 @@ export async function getCatalogInfo(
       repo: repo,
       path: path,
       ref: ref,
+      headers: {
+        'If-None-Match': '',
+      },
     });
 
     const fileContent = Buffer.from(

--- a/plugins/catalog-creator/src/utils/getRepoInfo.ts
+++ b/plugins/catalog-creator/src/utils/getRepoInfo.ts
@@ -23,6 +23,9 @@ export async function getRepoInfo(url: string, githubAuthApi: OAuthApi) {
     const response = await octokit.rest.repos.get({
       owner: owner,
       repo: repo,
+      headers: {
+        'If-None-Match': '',
+      },
     });
 
     returnObject.default_branch = response.data.default_branch;
@@ -42,6 +45,9 @@ export async function getRepoInfo(url: string, githubAuthApi: OAuthApi) {
       owner: owner,
       repo: repo,
       state: 'open',
+      headers: {
+        'If-None-Match': '',
+      },
     });
 
     const matchingPr = response.data.find(


### PR DESCRIPTION
## 🔒 Bakgrunn
Respons fra octokit ble cachet selv når repo endret seg.

## 🔑 Løsning
La til headers på octokit-kall for å fjerne caching.

## Hvordan teste?
- Skriv inn et repo som har en pr og trykk fetch (sånn at man får feilmelding)
- Fjern pr'en uten å refreshe siden og trykk fetch igjen, hvis det funker skal man da få opp formet og ikke feilmelding.
- Kan også sjekkes i nettverkstabben at kallene ikke caches.

Før:
<img width="1446" height="214" alt="image" src="https://github.com/user-attachments/assets/9c75dc5f-a7b3-469a-ae91-06322d3f8e01" />

Etter: 
<img width="1432" height="198" alt="image" src="https://github.com/user-attachments/assets/a541366a-83fe-4b11-b573-8b03af0a3688" />




