### PR TITLE
Add more sysdig alert info and fix runtime view

### DIFF
--- a/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
@@ -42,12 +42,11 @@ export type PharosSpecificInfo = {
 
 export type SysdigSpecificInfo = {
   htmlUrl: string;
-  container_name: string;
-  namespace: string;
-  cluster: string[];
+  containerNames: string[];
+  locations: { cluster: string; namespace: string }[];
   isExploitable: Boolean;
   isRunning: Boolean;
-  packages: string;
+  packages: string[];
 };
 
 export type ScannerSpecificInfo = {

--- a/plugins/security-metrics/src/components/Views/SingleComponentPage.tsx
+++ b/plugins/security-metrics/src/components/Views/SingleComponentPage.tsx
@@ -83,6 +83,7 @@ export const SingleComponentPage = () => {
             <VulnerabilityTable
               vulnerabilities={data.vulnerabilities}
               componentName={componentName}
+              initialRowsPerPage={10}
             />
           ) : (
             <>
@@ -98,6 +99,7 @@ export const SingleComponentPage = () => {
                 <VulnerabilityTable
                   vulnerabilities={data.vulnerabilities}
                   componentName={componentName}
+                  initialRowsPerPage={10}
                 />
               )}
               {selectedTab === TabEnum.RUNTIME_VULNERABILITIES && (

--- a/plugins/security-metrics/src/components/VulnerabilityTable/RuntimeVulnerabilityTable.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/RuntimeVulnerabilityTable.tsx
@@ -1,6 +1,11 @@
 import { VulnerabilityTable } from './VulnerabilityTable';
 import Typography from '@mui/material/Typography';
-import { Vulnerability } from '../../typesFrontend';
+import {
+  ClusterMap,
+  ClusterSummary,
+  NamespaceMap,
+  Vulnerability,
+} from '../../typesFrontend';
 import { Box } from '@mui/system';
 import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 
@@ -9,26 +14,81 @@ type Props = {
   componentName: string;
 };
 
+const sortById = (a: Vulnerability, b: Vulnerability) =>
+  a.vulnerabilityId.localeCompare(b.vulnerabilityId);
+
+const buildClusterMap = (vulnerabilities: Vulnerability[]): ClusterMap => {
+  const clusters: ClusterMap = new Map();
+
+  vulnerabilities.forEach(vulnerability => {
+    const info = vulnerability.scannerSpecificInfo.sysdigInfo;
+    if (!info) return;
+
+    info.locations.forEach(loc => {
+      const perNamespace =
+        clusters.get(loc.cluster) ??
+        (clusters.set(loc.cluster, new Map()), clusters.get(loc.cluster)!);
+      const list =
+        perNamespace.get(loc.namespace) ??
+        (perNamespace.set(loc.namespace, []), perNamespace.get(loc.namespace)!);
+
+      if (!list.some(x => x.vulnerabilityId === vulnerability.vulnerabilityId))
+        list.push(vulnerability);
+    });
+  });
+
+  return clusters;
+};
+
+const groupNamespacesWithSameVulnerabilities = (
+  namespaceMap: NamespaceMap,
+): { namespaces: string[]; vulnerabilities: Vulnerability[] }[] => {
+  const groupsByCve = new Map<
+    string,
+    { namespaces: string[]; vulnerabilities: Vulnerability[] }
+  >();
+
+  Array.from(namespaceMap.entries()).forEach(([namespace, vulnerabilities]) => {
+    const key = [...vulnerabilities]
+      .sort(sortById)
+      .map(v => v.vulnerabilityId)
+      .join('|');
+    const group =
+      groupsByCve.get(key) ??
+      (groupsByCve.set(key, {
+        namespaces: [],
+        vulnerabilities: [...vulnerabilities].sort(sortById),
+      }),
+      groupsByCve.get(key)!);
+    group.namespaces.push(namespace);
+  });
+
+  return Array.from(groupsByCve.values())
+    .map(group => ({
+      namespaces: group.namespaces.sort((a, b) => a.localeCompare(b)),
+      vulnerabilities: group.vulnerabilities,
+    }))
+    .sort((a, b) => a.namespaces[0].localeCompare(b.namespaces[0]));
+};
+
+const buildClusterSummaries = (
+  vulnerabilities: Vulnerability[],
+): ClusterSummary[] => {
+  const clusterMap = buildClusterMap(vulnerabilities);
+
+  return Array.from(clusterMap.entries())
+    .map(([clusterName, namespaceMap]) => ({
+      clusterName,
+      groups: groupNamespacesWithSameVulnerabilities(namespaceMap),
+    }))
+    .sort((a, b) => a.clusterName.localeCompare(b.clusterName));
+};
+
 export const RuntimeVulnerabilityTable = ({
-  vulnerabilities,
+  vulnerabilities: allVulnerabilities,
   componentName,
 }: Props) => {
-  const getClusters = (v: Vulnerability) => {
-    const cluster = v.scannerSpecificInfo.sysdigInfo?.cluster;
-    if (!cluster) return [];
-    return Array.isArray(cluster) ? cluster : [cluster];
-  };
-
-  const clusters = Array.from(
-    new Set(vulnerabilities.flatMap(getClusters)),
-  ).sort();
-
-  const clusterSummaries = clusters.map(clusterName => {
-    const list = vulnerabilities.filter(vulnerability =>
-      getClusters(vulnerability).includes(clusterName),
-    );
-    return { clusterName, list };
-  });
+  const clusterSummaries = buildClusterSummaries(allVulnerabilities);
 
   return (
     <Box>
@@ -38,16 +98,27 @@ export const RuntimeVulnerabilityTable = ({
           <ThumbUpIcon color="success" fontSize="medium" />
         </Box>
       ) : (
-        clusterSummaries.map(({ clusterName, list }) => (
+        clusterSummaries.map(({ clusterName, groups }) => (
           <Box key={clusterName}>
-            <Typography fontWeight="bold" variant="h6" m={2}>
-              {clusterName} ({list.length} sårbarhet
-              {list.length === 1 ? '' : 'er'})
+            <Typography fontWeight="bold" m={1} mt={2}>
+              {clusterName}
             </Typography>
-            <VulnerabilityTable
-              vulnerabilities={list}
-              componentName={componentName}
-            />
+
+            {groups.map(({ namespaces, vulnerabilities }) => (
+              <Box key={namespaces.join(',')}>
+                <Typography m={1} mt={2} mb={2}>
+                  Namespace{namespaces.length === 1 ? ': ' : 's: '}
+                  {namespaces.join(', ')} ({vulnerabilities.length} sårbarhet
+                  {vulnerabilities.length === 1 ? '' : 'er'})
+                </Typography>
+
+                <VulnerabilityTable
+                  vulnerabilities={vulnerabilities}
+                  componentName={componentName}
+                  initialRowsPerPage={5}
+                />
+              </Box>
+            ))}
           </Box>
         ))
       )}

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/SysdigContent.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/SysdigContent.tsx
@@ -14,7 +14,16 @@ export const SysdigContent = ({ vulnerability }: SysdigContentProps) => {
   if (!info) {
     return <ErrorBanner />;
   }
-  const link = new URL(info?.htmlUrl).href;
+
+  const link = new URL(info.htmlUrl).href;
+
+  const clusterToNamespaces = info.locations.reduce<
+    Record<string, Set<string>>
+  >((acc, location) => {
+    if (!acc[location.cluster]) acc[location.cluster] = new Set();
+    if (location.namespace) acc[location.cluster]!.add(location.namespace);
+    return acc;
+  }, {});
 
   return (
     <Typography>
@@ -28,17 +37,21 @@ export const SysdigContent = ({ vulnerability }: SysdigContentProps) => {
         {link.length > 80 ? link.slice(0, 30).concat('...') : link}
       </Link>
       <br />
-      <strong>Container name: </strong>
-      {info.container_name}
-      <br />
-      <strong>Cluster: </strong>
-      {Array.isArray(info?.cluster) ? info!.cluster.join(', ') : info?.cluster}
-      <br />
       <strong>Is exploitable: </strong>
       {info.isExploitable ? 'Yes' : 'No'}
       <br />
-      <strong>Package names: </strong>
-      {info.packages}
+      <strong>Packages: </strong>
+      {info.packages.join(', ')}
+      <br />
+      <strong>Containers: </strong>
+      {info.containerNames.join(', ')}
+      <br />
+      <strong>Locations: </strong>
+      {Object.entries(clusterToNamespaces).map(([cluster, nsSet]) => (
+        <Typography key={cluster}>
+          {cluster}: {Array.from(nsSet).join(', ')}
+        </Typography>
+      ))}
     </Typography>
   );
 };

--- a/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTable.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTable.tsx
@@ -20,16 +20,22 @@ import Box from '@mui/material/Box';
 type Props = {
   vulnerabilities: Vulnerability[];
   componentName: string;
+  initialRowsPerPage: number;
 };
 
 export const VulnerabilityTable = ({
   vulnerabilities,
   componentName,
+  initialRowsPerPage,
 }: Props) => {
   const [sortType, setSortType] = useState<SortableHeader>('Alvorlighetsgrad');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
 
-  const paginationProps = usePaginationProps(vulnerabilities.length);
+  const paginationProps = usePaginationProps(
+    vulnerabilities.length,
+    0,
+    initialRowsPerPage,
+  );
   const { page, rowsPerPage } = paginationProps;
 
   return (

--- a/plugins/security-metrics/src/hooks/usePagination.ts
+++ b/plugins/security-metrics/src/hooks/usePagination.ts
@@ -15,7 +15,7 @@ export const usePaginationProps = (
   count: number,
   initialPage: number = 0,
   initialRowsPerPage: number = 10,
-  rowsPerPageOptions: number[] = [10, 25, 50],
+  rowsPerPageOptions: number[] = [5, 10, 25, 50],
 ): TablePaginationProps => {
   const [page, setPage] = useState(initialPage);
   const [rowsPerPage, setRowsPerPage] = useState(initialRowsPerPage);

--- a/plugins/security-metrics/src/typesFrontend.ts
+++ b/plugins/security-metrics/src/typesFrontend.ts
@@ -22,12 +22,11 @@ export type PharosSpecificInfo = {
 
 export type SysdigSpecificInfo = {
   htmlUrl: string;
-  container_name: string;
-  namespace: string;
-  cluster: string[];
+  containerNames: string[];
+  locations: { cluster: string; namespace: string }[];
   isExploitable: Boolean;
   isRunning: Boolean;
-  packages: string;
+  packages: string[];
 };
 
 export type ScannerSpecificInfo = {
@@ -58,16 +57,6 @@ export type Vulnerability = {
   acceptedBy: string;
   scannerSpecificInfo: ScannerSpecificInfo;
 };
-
-export interface SysdigInfo {
-  container_name: string;
-  namespace: string;
-  htmlUrl: URL;
-  cluster: string[];
-  isExploitable: boolean;
-  packages: string[];
-  severityCount: SeverityCount;
-}
 
 export type SecretAlert = {
   createdAt: string;
@@ -166,3 +155,14 @@ export type SecretsOverview = {
   componentName: string;
   alerts: SecretAlert[];
 };
+
+export type ClusterSummary = {
+  clusterName: string;
+  groups: {
+    namespaces: string[];
+    vulnerabilities: Vulnerability[];
+  }[];
+};
+
+export type NamespaceMap = Map<string, Vulnerability[]>;
+export type ClusterMap = Map<string, NamespaceMap>;


### PR DESCRIPTION
## 🔒 Bakgrunn

Avhengig av https://github.com/kartverket/sikkerhetsmetrikker/pull/858

## 🔑 Løsning

- Tilpasser typene til endringer i SMAPI (ref https://github.com/kartverket/sikkerhetsmetrikker/pull/858)
- Legger til mer info om namespace for hver sysdig-alert
- Restrukturerer måten "sårbarheter i kjøretidsmiljø" vises, med gruppering på cluster og namespace

## 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| <img width="1204" height="543" alt="Screenshot 2025-10-30 at 10 47 34" src="https://github.com/user-attachments/assets/78b48e8c-9bd2-4140-a6d9-92f0e738ba68" /> | <img width="1207" height="707" alt="Screenshot 2025-10-30 at 10 45 13" src="https://github.com/user-attachments/assets/86a5af5b-1cb0-4148-a4fb-0709e078cfcf" /> |