### PR TITLE
Add 'wsdl' to API types

### DIFF
--- a/plugins/catalog-creator/src/types/types.ts
+++ b/plugins/catalog-creator/src/types/types.ts
@@ -24,7 +24,7 @@ export enum ApiTypes {
   asyncapi = 'asyncapi',
   graphql = 'graphql',
   grpc = 'grpc',
-  wsld = 'wsdl',
+  wsdl = 'wsdl',
 }
 
 export enum SystemTypes {


### PR DESCRIPTION
## 🔒 Bakgrunn
Matrikkel og grunnbok eksponerer soap-apier som defineres av wsdl'er

## 🔑 Løsning
Legg til `wsdl` som ny type

Disclaimer - jeg har ikke kjørt opp appen lokalt, men får gjerne litt hjelp på hvordan og om det er mer config som skal endres.  