### PR TITLE
[Backstage-Utviklerportal] Legg til matrikkel.no som et domene backstage kan lese fra

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -42,6 +42,11 @@ backend:
   #   keys:
   #     - secret: ${BACKEND_SECRET}
   baseUrl: http://localhost:7007
+
+  reading:
+    allow:
+      - host: matrikkel.no
+
   listen:
     port: 7007
     # Uncomment the following host directive to bind to specific interfaces


### PR DESCRIPTION
## 🔒 Bakgrunn
Vi får ikke inn eksterne WSDL API spesifikasjoner som ligger på sider utenfor github.

## 🔑 Løsning
Whitelist domener som backstage kan lese fra sånn at den kan hente schemaet fra matrikkelen.no og grunnbok.no Det er testet lokalt på security champion api. 

**For at dette skal fungere i produksjon må også SKIP åpne for trafikk mot disse domenene.**

## ❓ Utfordringer
Vet ikke om dette kan føre med seg noen risikoer? Dette står under API kind på backstage som vi følger:

Note that to be able to read from targets that are outside of the normal integration points such as github.com, you'll need to explicitly allow it by adding an entry in the backend.reading.allow list.

