### PR TITLE
Oppdater tooltip-tekst for MTTH etter ny beregning

### DIFF
--- a/plugins/security-metrics/src/components/RepositoriesTable/RepositoriesTable.tsx
+++ b/plugins/security-metrics/src/components/RepositoriesTable/RepositoriesTable.tsx
@@ -57,7 +57,7 @@ export const RepositoriesTable = ({ data, notPermittedComponents }: Props) => {
             <TableCell>
               <Box display="flex" alignItems="center" gap={1}>
                 MTTH
-                <Tooltip title="Mean time to handle: gjennomsnittlig antall dager det tar å håndtere en sårbarhet (løse/akseptere risiko) etter at den ble oppdaget">
+                <Tooltip title="Mean time to handle: gjennomsnittlig antall dager siden en sårbarhet ble oppdaget, fram til den blir løst eller akseptert – eller til dagens dato hvis den fortsatt er åpen">
                   <InfoIcon fontSize="small" />
                 </Tooltip>
               </Box>

--- a/plugins/security-metrics/src/components/VulnerabilityCounts/VulnerabilityCountsOverview.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityCounts/VulnerabilityCountsOverview.tsx
@@ -59,7 +59,7 @@ export const VulnerabilityCountsOverview = ({ data, averageDays }: Props) => {
               <Typography variant="body2" sx={{ color: 'text.secondary' }}>
                 MTTH: {Math.round(averageDays)} dager
               </Typography>
-              <Tooltip title="Mean time to handle: gjennomsnittlig antall dager det tar å håndtere en sårbarhet (løse/akseptere risiko) etter at den ble oppdage">
+              <Tooltip title="Mean time to handle: gjennomsnittlig antall dager siden en sårbarhet ble oppdaget, fram til den blir løst eller akseptert – eller til dagens dato hvis den fortsatt er åpen">
                 <InfoIcon fontSize="small" sx={{ color: 'text.secondary' }} />
               </Tooltip>
             </Stack>


### PR DESCRIPTION
## 🔒 Bakgrunn
Backend endrer hvordan MTTH beregnes, ved å inkludere åpne sårbarheter med dagens dato som sluttdato. Tooltip-teksten i frontend beskrev kun håndtering av løste/aksepterte sårbarheter og måtte derfor justeres

## 🔑 Løsning

- Oppdatert tooltip-tekst i RepositoriesTable og VulnerabilityCountsOverview
- Ny tekst forklarer at MTTH beregnes fra den ble oppdaget til sårbarheten løses/aksepteres – eller til dagens dato dersom den fortsatt er åpen
