### PR TITLE
Fix security metrics component fetching

### DIFF
--- a/plugins/security-metrics/src/hooks/useFetchRepositoryNames.ts
+++ b/plugins/security-metrics/src/hooks/useFetchRepositoryNames.ts
@@ -43,7 +43,7 @@ export const useFetchComponentNamesByGroup = (rootGroupRef: Entity) => {
         item.kind === REPOSITORY_ENTITY_KIND &&
         !isExperimentalLifecycle(item.spec?.lifecycle)
       ) {
-        repositoryEntities.push(item.metadata.title ?? item.metadata.name);
+        repositoryEntities.push(item.metadata.name);
       } else if (HIGHER_LEVEL_ENTITIES.includes(item.kind)) {
         item.relations?.forEach(relation => {
           if (


### PR DESCRIPTION
## 🔒 Bakgrunn

Mangler komponenter (bla.a. rosa/Homomorfisk RoS-aggregering) i sikkerhetsmetrikker-plugin-oversikt fordi tittel blir sendt til SMAPI dersom den finnes. Får ikke hentet ut metrikker basert på tittel siden bare navn lagres i backstage-metadata-tabellen i SMAPI.

## 🔑 Løsning

Fjerner at tittel blir sendt

## 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| Bilde | Bilde |