### PR TITLE
chore: use vulnerability ID info instead of vulnerability ID

### DIFF
--- a/plugins/security-metrics/src/components/VulnerabilityTable/AcceptRisk/AcceptDialog.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/AcceptRisk/AcceptDialog.tsx
@@ -10,6 +10,7 @@ import Button from '@mui/material/Button';
 import { useAcceptVulnerabilityQuery } from '../../../hooks/useAcceptVulnerabilityQuery';
 import { SpinnerButton } from './SpinnerButton';
 import Box from '@mui/material/Box';
+import { findBestId } from '../../utils';
 
 interface Props {
   componentName: string;
@@ -33,11 +34,12 @@ export const AcceptDialog = ({
   setComment,
 }: Props) => {
   const acceptMutation = useAcceptVulnerabilityQuery(componentName);
+  const vulnerabilityId = findBestId(vulnerability);
   const handleSave = async () => {
     acceptMutation.mutate(
       {
         componentName,
-        vulnerabilityId: vulnerability.vulnerabilityId,
+        vulnerabilityId: vulnerabilityId,
         comment,
         acceptedBy,
       },
@@ -49,9 +51,7 @@ export const AcceptDialog = ({
 
   return (
     <Dialog open={openAcceptDialog} onClose={() => handleCloseAcceptDialog}>
-      <DialogTitle>
-        Aksepter sårbarhet {vulnerability.vulnerabilityId}
-      </DialogTitle>
+      <DialogTitle>Aksepter sårbarhet {vulnerabilityId}</DialogTitle>
       <DialogContent sx={{ overflowY: 'visible' }}>
         <Stack spacing={2}>
           <TextField

--- a/plugins/security-metrics/src/components/VulnerabilityTable/RuntimeVulnerabilityTable.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/RuntimeVulnerabilityTable.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../typesFrontend';
 import { Box } from '@mui/system';
 import ThumbUpIcon from '@mui/icons-material/ThumbUp';
+import { findBestId } from '../utils';
 
 type Props = {
   vulnerabilities: Vulnerability[];
@@ -15,7 +16,7 @@ type Props = {
 };
 
 const sortById = (a: Vulnerability, b: Vulnerability) =>
-  a.vulnerabilityId.localeCompare(b.vulnerabilityId);
+  findBestId(a).localeCompare(findBestId(b));
 
 const buildClusterMap = (vulnerabilities: Vulnerability[]): ClusterMap => {
   const clusters: ClusterMap = new Map();
@@ -32,7 +33,7 @@ const buildClusterMap = (vulnerabilities: Vulnerability[]): ClusterMap => {
         perNamespace.get(loc.namespace) ??
         (perNamespace.set(loc.namespace, []), perNamespace.get(loc.namespace)!);
 
-      if (!list.some(x => x.vulnerabilityId === vulnerability.vulnerabilityId))
+      if (!list.some(x => findBestId(x) === findBestId(vulnerability)))
         list.push(vulnerability);
     });
   });
@@ -51,7 +52,7 @@ const groupNamespacesWithSameVulnerabilities = (
   Array.from(namespaceMap.entries()).forEach(([namespace, vulnerabilities]) => {
     const key = [...vulnerabilities]
       .sort(sortById)
-      .map(v => v.vulnerabilityId)
+      .map(v => findBestId(v))
       .join('|');
     const group =
       groupsByCve.get(key) ??


### PR DESCRIPTION
## 🔑 Løsning
Fjerne bruk av vulnerbilityId i frontenden ettersom vi nå heller vil bruke vulnerabilityIdInfo, men vi kan ikke slette vulnerabilityID da vi bruker den for å akseptere sårbarheter. 