### PR TITLE
URL peker ikke alltid til fil ved redigering av komponenter

### DIFF
--- a/packages/app/src/components/catalog/EntityCatalogCreatorWrapper.tsx
+++ b/packages/app/src/components/catalog/EntityCatalogCreatorWrapper.tsx
@@ -6,7 +6,7 @@ export const EntityCatalogCreatorWrapper = () => {
 
   // Extract git URL from entity metadata
   const sourceLocation =
-    entity.metadata.annotations?.['backstage.io/source-location'];
+    entity.metadata.annotations?.['backstage.io/managed-by-origin-location'];
 
   // Remove 'url:' prefix if it exists in source-location
   let gitUrl = sourceLocation;
@@ -14,11 +14,5 @@ export const EntityCatalogCreatorWrapper = () => {
     gitUrl = gitUrl.substring(4);
   }
 
-  // Only remove /tree/main if it's at the end without any additional path
-  // This preserves file-specific URLs but cleans up repository root URLs
-  if (gitUrl && gitUrl.match(/\/tree\/main\/?$/)) {
-    gitUrl = gitUrl.replace(/\/tree\/main\/?$/, '');
-  }
-
-  return <CatalogCreatorPage gitUrl={gitUrl} />;
+  return <CatalogCreatorPage originLocation={gitUrl} />;
 };

--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
@@ -19,10 +19,12 @@ import { catalogCreatorTranslationRef } from '../../utils/translations';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 
 export interface CatalogCreatorPageProps {
-  gitUrl?: string;
+  originLocation?: string;
 }
 
-export const CatalogCreatorPage = ({ gitUrl }: CatalogCreatorPageProps) => {
+export const CatalogCreatorPage = ({
+  originLocation,
+}: CatalogCreatorPageProps) => {
   const githubAuthApi: OAuthApi = useApi(githubAuthApiRef);
   const theme = useTheme();
 
@@ -49,10 +51,10 @@ export const CatalogCreatorPage = ({ gitUrl }: CatalogCreatorPageProps) => {
   const { t } = useTranslationRef(catalogCreatorTranslationRef);
 
   useEffect(() => {
-    if (gitUrl && !url) {
-      setUrl(gitUrl);
+    if (originLocation && !url) {
+      setUrl(originLocation);
     }
-  }, [gitUrl, url, setUrl]);
+  }, [originLocation, url, setUrl]);
 
   const handleFormSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -90,9 +92,10 @@ export const CatalogCreatorPage = ({ gitUrl }: CatalogCreatorPageProps) => {
           ) : (
             <Card style={{ position: 'relative', overflow: 'visible' }}>
               <RepositoryForm
-                url={gitUrl || url}
+                url={originLocation || url}
                 onUrlChange={setUrl}
                 onSubmit={handleFormSubmit}
+                disableTextField={originLocation !== undefined}
               />
               <StatusMessages
                 hasExistingCatalogFile={hasExistingCatalogFile}

--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/RepositoryForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/RepositoryForm.tsx
@@ -6,12 +6,14 @@ interface RepositoryFormProps {
   url: string;
   onUrlChange: (url: string) => void;
   onSubmit: (e: React.FormEvent) => void;
+  disableTextField: boolean;
 }
 
 export const RepositoryForm = ({
   url,
   onUrlChange,
   onSubmit,
+  disableTextField,
 }: RepositoryFormProps) => {
   const { t } = useTranslationRef(catalogCreatorTranslationRef);
 
@@ -27,9 +29,10 @@ export const RepositoryForm = ({
               name="url"
               value={url}
               onChange={onUrlChange}
+              isDisabled={disableTextField}
             />
           </div>
-          <Button type="submit"> {t('repositorySearch.fetchButton')}</Button>
+          <Button type="submit"> {t('repositorySearch.fetchButton')} </Button>
         </Flex>
       </Box>
     </form>


### PR DESCRIPTION
## 🔒 Bakgrunn
En bug hvor filer som ikke hadde main som hovedbranch ikke ville passere regexen og fjerne tree/main i urlen. Dette gjorde at disse kompon
<img width="411" height="105" alt="Screenshot 2025-11-26 at 15 36 28" src="https://github.com/user-attachments/assets/5d1d3774-5f5e-4d94-909f-b6c77bda8333" />
entene ikke kunne redigeres fra komponentsiden i catalog-creator.

I tillegg kunne man i dette teksfeltet skrive inn usynlig tekst hvor det siste tegnet ville dukke opp.

<img width="1202" height="318" alt="image" src="https://github.com/user-attachments/assets/65235ee0-2399-4832-8d5d-e7aae574a3ba" />



## 🔑 Løsning
Gå vekk fra å bruke regex, men hent managed by origin location på entiteten som er det backstage bruker for å hente filen. Det burde sikre høy suksessrate på å finne yaml filen da dette er lokasjonen backstage henter den fra.

filformatet blir da med blob/main/catalog-info.yaml

Løsningen for å kunne legge til usynlig tekst er å disable tekstfeltet hvis man får lokasjonsstringen fra backstage.


## 📸 Bilder
<img width="598" height="143" alt="Screenshot 2025-11-26 at 15 40 09" src="https://github.com/user-attachments/assets/c414e638-63f0-4772-9773-d2c666f327a8" />



| 