### PR TITLE
[Catalog Creator (plugin)]Api text change

### DIFF
--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/EditOrGenerateCatalogInfoBox.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/EditOrGenerateCatalogInfoBox.tsx
@@ -24,11 +24,16 @@ export const EditOrGenerateCatalogInfoBox = ({
         <Divider />
         <h2> {t('infoBox.subtitle')}</h2>
         <p>{t('infoBox.p3')}</p>
-        <h4>{t('infoBox.componentTitle')}</h4>{' '}
+        <h3>{t('infoBox.systemTitle')}</h3>{' '}
+        <p>{t('infoBox.systemParagraph')}</p>
+        <h3>{t('infoBox.componentTitle')}</h3>{' '}
         <p>{t('infoBox.componentParagraph')}</p>
-        <h4>{t('infoBox.APITitle')}</h4>
+        <h3>{t('infoBox.APITitle')}</h3>
         <p>{t('infoBox.APIParagraph')}</p>
-        <h4>{t('infoBox.resourceTitle')}</h4>
+        <p>
+          <i>{t('infoBox.APIremark')}</i>
+        </p>
+        <h3>{t('infoBox.resourceTitle')}</h3>
         <p>{t('infoBox.resourceParagraph')}</p>
         {docsLink && (
           <div className={style.learnMoreLink}>

--- a/plugins/catalog-creator/src/utils/translations.ts
+++ b/plugins/catalog-creator/src/utils/translations.ts
@@ -202,22 +202,18 @@ export const catalogCreatorMessages = {
        These entities are seperated into three groups: core entities, ecosystem entities, and organizational entities.
         Core entities include Component, API, and Resource. Ecosystem entities include System and Domain.
          Organizational entities include Group and User. Below is a brief explanation of the core entities.`,
+    systemTitle: 'System',
+    systemParagraph:
+      'A system is a collection of components that work together to fulfil a clear purpose within a specific domain. Together, they deliver complete functionality.',
     componentTitle: 'Component',
-    componentParagraph: `A Component is a piece of software, such as a service, library or a
-          website. Components will often correspond to a repository. Components can provide APIs that other components consume, and often
-          depend on APIs and resources.`,
-    APITitle: 'API',
-    APIParagraph: `An API entity describes an API that a component provides and that
-          other components consume. Public APIs are the primary ways which
-          components interact. The API specification should be included in the
-          API entity and the file path to this document should be added to the
-          API entity, with the file path to the API definition so that
-          the developer portal can provide detailed information.`,
+    componentParagraph: `A component is an independent part of a system — for example a service, a library, or an app. It often has its own repository and can be developed, built, and deployed separately from the rest of the system.`,
+    APITitle: 'API ',
+    APIParagraph: `An API describes the interface a component provides or consumes, and shows how systems and components communicate. The definition field for APIs is required.`,
+    APIremark:
+      'Note: External APIs should be registered as Resource, not as an API.',
     resourceTitle: 'Resource',
-    resourceParagraph: `Resource entities represent shared shared resources that a component
-          requires during runtime, such as object storage or other cloud
-          services.`,
-    linkText: `Read more about entities in your organization `,
+    resourceParagraph: `A Resource is an external or shared asset that a system or component depends on, but which is not necessarily owned by the same team. This can include technical infrastructure or external integrations.`,
+    linkText: `Read more about entities in your organization.`,
     linkText2: `Read more about entities in the Backstage documentation `,
   },
   successPage: {
@@ -393,23 +389,28 @@ export const catalogCreatorNorwegianTranslation = createTranslationResource({
           'form.errors.tagRegEx':
             'Tags kan kun inneholde alfanumeriske tegn og :, + eller # separert med -, og de kan ikke være lengre enn 63 tegn.',
 
-          'infoBox.title': 'Hvordan funker skjemaet?',
+          'infoBox.title': 'Hvordan fungerer skjemaet?',
           'infoBox.p1':
             'Dette skjemaet lar deg opprette eller redigere catalog-info.yaml-filer som Backstage bruker for å oppdage og administrere komponenter. Oppgi enten URL til et GitHub-repository for å legge det til i utviklerportalen, eller en lenke til en eksisterende fil for å redigere den.',
           'infoBox.p2':
             'Når du er ferdig, klikker du Opprett Pull Request for å foreslå endringer i repositoryet. Endringene gjelder først når pull request-en er slått sammen og katalogen er oppdatert.',
           'infoBox.subtitle': 'Hva er entiteter i Backstage?',
           'infoBox.p3':
-            'Utviklerportalen er bygget med Backstage, som definerer et sett med entiteter som brukes til å bygge programvarekatalogen. Disse entitetene er delt inn i tre grupper: kjerneentiteter, økosystementiteter og organisatoriske entiteter. Kjerneentiteter inkluderer Component, API og Resource. Økosystementiteter inkluderer System og Domain. Organisatoriske entiteter inkluderer Group og User. Nedenfor finner du en kort forklaring av kjerneentiteter.',
+            'Utviklerportalen er bygget med Backstage, som definerer et sett med entiteter som brukes til å bygge programvarekatalogen.',
+          'infoBox.systemTitle': 'System',
+          'infoBox.systemParagraph':
+            'Et system er en samling av komponenter som sammen løser et tydelig formål. Systemet kan bestå av flere komponenter som samarbeider for å levere en funksjonalitet.',
           'infoBox.componentTitle': 'Component',
           'infoBox.componentParagraph':
-            'En Component er et stykke programvare, for eksempel en tjeneste, et bibliotek eller et nettsted. Komponenter tilsvarer ofte et eget kodelager. Komponenter kan tilby API-er som andre komponenter bruker, og avhenger ofte av API-er og ressurser selv.',
+            'En komponent er en selvstendig del av et system – for eksempel en tjeneste, et bibliotek eller en app. Den har ofte sitt eget repository og kan utvikles, bygges og deployes uavhengig av andre deler av systemet.',
           'infoBox.APITitle': 'API',
           'infoBox.APIParagraph':
-            'En API-entitet beskriver et API som en komponent tilbyr, og som andre komponenter bruker. Offentlige API-er er den primære måten komponenter samhandler på. API-spesifikasjonen bør inkluderes i API-entiteter, og filbanen til dette dokumentet bør legges til i API-entiteter slik at utviklerportalen kan vise detaljert informasjon.',
+            'Et API beskriver grensesnittet en komponent tilbyr eller bruker, og viser hvordan systemer og komponenter kommuniserer. Definisjonsfeltet for API-er er påkrevd.',
+          'infoBox.APIremark':
+            'Merk: Eksterne API-er skal registreres som Resource, ikke som et API.',
           'infoBox.resourceTitle': 'Resource',
           'infoBox.resourceParagraph':
-            'Resource-entiteter representerer delte ressurser som en komponent trenger under kjøring, for eksempel objektlagring eller andre skytjenester.',
+            'En Resource er en ekstern eller delt ressurs som et system eller en komponent er avhengig av, men som ikke nødvendigvis eies av samme team. Dette kan være teknisk infrastruktur eller eksterne integrasjoner.',
           'infoBox.linkText': 'Les mer om entiteter i din organisasjon ',
           'infoBox.linkText2':
             'Les mer om entiteter i Backstage-dokumentasjonen ',


### PR DESCRIPTION
## 🔒 Bakgrunn
- API teksten skulle ha med at definsjon var obligatorisk. Endret de andre tekstene også litt så det representerte litt mer entitetsmodellen 
