### PR TITLE
Fix margins

### DIFF
--- a/plugins/security-metrics/src/components/Views/GroupPage.tsx
+++ b/plugins/security-metrics/src/components/Views/GroupPage.tsx
@@ -94,7 +94,7 @@ export const GroupPage = () => {
 
   return (
     <Stack gap={2}>
-      <Stack flexDirection="row" gap={2} alignItems="center">
+      <Stack flexDirection="row" alignItems="center">
         <Stack
           flexDirection="row"
           gap={2}
@@ -105,7 +105,7 @@ export const GroupPage = () => {
           <SecretsAlert secretsOverviewData={secrets} />
           {notPermitted.length > 0 && <NoAccessAlert repos={notPermitted} />}
         </Stack>
-        <Box display="flex" alignItems="center">
+        <Box display="flex" alignItems="center" mr={2} ml={2}>
           <StarFilterButton
             hasStarred={hasStarred}
             effectiveFilter={effectiveFilter}
@@ -116,7 +116,6 @@ export const GroupPage = () => {
         </Box>
         <Button
           variant="text"
-          sx={{ ml: 2 }}
           startIcon={<SettingsIcon />}
           color="primary"
           onClick={handleOpenNotificationsDialog}


### PR DESCRIPTION
## 🔑 Løsning

Minimerer mellomrommet mellom de ulike knappene på toppen av sikkerhetsmetrikker-plugin

## 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| <img width="503" height="130" alt="Screenshot 2025-12-04 at 14 42 24" src="https://github.com/user-attachments/assets/13d059d4-e82e-4ca5-8455-ad554b386890" /> | <img width="496" height="113" alt="Screenshot 2025-12-04 at 14 42 18" src="https://github.com/user-attachments/assets/bba0aaac-0364-4039-a287-fb8b3fcbd072" /> |