### PR TITLE
Feat/move function location when new parent function

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -182,6 +182,10 @@ const routes = (
     <Route path="/dask-onboarding" element={<DaskOnboardingPage />} />
     <Route path="/opencost" element={<OpencostPage />} />
     <Route
+      path="/catalog-creator-function"
+      element={<CatalogCreatorPage createFunction />}
+    />
+    <Route
       path="/catalog-creator"
       element={
         <CatalogCreatorPage docsLink="/docs/default/Component/kartverket.dev" />

--- a/packages/app/src/components/catalog/CatalogCreatorContainer.tsx
+++ b/packages/app/src/components/catalog/CatalogCreatorContainer.tsx
@@ -2,7 +2,7 @@ import { EntityRelationWarning } from '@backstage/plugin-catalog';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { CatalogCreatorPage } from '@kartverket/backstage-plugin-catalog-creator';
 
-export const EntityCatalogCreatorWrapper = ({
+export const CatalogCreatorContainer = ({
   createFunction = false,
 }: {
   createFunction?: boolean;

--- a/packages/app/src/components/catalog/EntityCatalogCreatorWrapper.tsx
+++ b/packages/app/src/components/catalog/EntityCatalogCreatorWrapper.tsx
@@ -2,7 +2,11 @@ import { EntityRelationWarning } from '@backstage/plugin-catalog';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { CatalogCreatorPage } from '@kartverket/backstage-plugin-catalog-creator';
 
-export const EntityCatalogCreatorWrapper = () => {
+export const EntityCatalogCreatorWrapper = ({
+  createFunction = false,
+}: {
+  createFunction?: boolean;
+}) => {
   const { entity } = useEntity();
 
   // Extract git URL from entity metadata
@@ -23,6 +27,7 @@ export const EntityCatalogCreatorWrapper = () => {
         originLocation={gitUrl}
         entityKind={entity.kind}
         entityName={entity.metadata.name}
+        createFunction={createFunction}
       />
     </>
   );

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -239,7 +239,7 @@ const functionEntityPage = (
       </Grid>
     </EntityLayout.Route>
     <EntityLayout.Route path="/edit" title="Edit">
-      <CatalogCreatorContainer createFunction />
+      <CatalogCreatorContainer />
     </EntityLayout.Route>
   </EntityLayout>
 );

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -235,7 +235,7 @@ const functionEntityPage = (
       </Grid>
     </EntityLayout.Route>
     <EntityLayout.Route path="/edit" title="Edit">
-      <EntityCatalogCreatorWrapper />
+      <EntityCatalogCreatorWrapper createFunction />
     </EntityLayout.Route>
   </EntityLayout>
 );

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -68,7 +68,7 @@ import {
 import { RiScPage } from '@kartverket/backstage-plugin-risk-scorecard';
 import { SecurityMetricsPage } from '@kartverket/backstage-plugin-security-metrics-frontend';
 import { SecurityChampionCard } from '@kartverket/backstage-plugin-security-champion';
-import { EntityCatalogCreatorWrapper } from './EntityCatalogCreatorWrapper';
+import { CatalogCreatorContainer } from './CatalogCreatorContainer';
 import {
   EntityDependenciesCard,
   FunctionAboutCard,
@@ -235,7 +235,7 @@ const functionEntityPage = (
       </Grid>
     </EntityLayout.Route>
     <EntityLayout.Route path="/edit" title="Edit">
-      <EntityCatalogCreatorWrapper createFunction />
+      <CatalogCreatorContainer createFunction />
     </EntityLayout.Route>
   </EntityLayout>
 );
@@ -246,7 +246,7 @@ const serviceEntityPage = (
       {defaultComponentContent}
     </EntityLayout.Route>
     <EntityLayout.Route path="/edit" title="Edit">
-      <EntityCatalogCreatorWrapper />
+      <CatalogCreatorContainer />
     </EntityLayout.Route>
     <EntityLayout.Route path="/ci-cd" title="CI/CD">
       {cicdContent}
@@ -294,7 +294,7 @@ const websiteEntityPage = (
       {defaultComponentContent}
     </EntityLayout.Route>
     <EntityLayout.Route path="/edit" title="Edit">
-      <EntityCatalogCreatorWrapper />
+      <CatalogCreatorContainer />
     </EntityLayout.Route>
 
     <EntityLayout.Route path="/ci-cd" title="CI/CD">
@@ -336,7 +336,7 @@ const opsEntityPage = (
       {defaultComponentContent}
     </EntityLayout.Route>
     <EntityLayout.Route path="/edit" title="Edit">
-      <EntityCatalogCreatorWrapper />
+      <CatalogCreatorContainer />
     </EntityLayout.Route>
 
     <EntityLayout.Route path="/risc" title="Kodenær RoS">
@@ -355,7 +355,7 @@ const experimentEntityPage = (
       {defaultComponentContent}
     </EntityLayout.Route>
     <EntityLayout.Route path="/edit" title="Edit">
-      <EntityCatalogCreatorWrapper />
+      <CatalogCreatorContainer />
     </EntityLayout.Route>
 
     <EntityLayout.Route path="/docs" title="Docs">
@@ -439,7 +439,7 @@ const apiPage = (
       </Grid>
     </EntityLayout.Route>
     <EntityLayout.Route path="/edit" title="Edit">
-      <EntityCatalogCreatorWrapper />
+      <CatalogCreatorContainer />
     </EntityLayout.Route>
     <EntityLayout.Route path="/definition" title="Definition">
       <Grid container spacing={3}>

--- a/packages/app/src/components/functions/FunctionsPage.tsx
+++ b/packages/app/src/components/functions/FunctionsPage.tsx
@@ -12,6 +12,7 @@ import {
 import { EntityRelationsGraph } from '@backstage/plugin-catalog-graph';
 import { useApi } from '@backstage/core-plugin-api';
 import { useEffect, useState } from 'react';
+import { ButtonLink, Flex } from '@backstage/ui';
 
 type RootEntityNamesType = {
   kind: string;
@@ -57,6 +58,12 @@ export const FunctionsPage = () => {
         subtitle="Oversikt over hva Kartverket må kunne gjøre for å levere på sitt samfunnsoppdrag, og hvordan dette støttes av del-funksjoner, systemer og team."
       />
       <Content>
+        <Flex justify="end" style={{ marginBottom: '1rem' }}>
+          <ButtonLink href="/catalog-creator-function">
+            Create new function
+          </ButtonLink>
+        </Flex>
+
         <EntityListProvider>
           <Grid container spacing={3}>
             <Grid item xs={12} md={6}>

--- a/plugins/catalog-backend-module-function-kind/src/processor/FunctionEntitiesProcessor.ts
+++ b/plugins/catalog-backend-module-function-kind/src/processor/FunctionEntitiesProcessor.ts
@@ -164,10 +164,10 @@ export class FunctionEntitiesProcessor implements CatalogProcessor {
     );
 
     doEmit(
-      functionEntity.spec.childFunctions,
+      functionEntity.spec.parentFunction,
       { defaultKind: 'Function', defaultNamespace: selfRef.namespace },
-      RELATION_PARENT_OF,
       RELATION_CHILD_OF,
+      RELATION_PARENT_OF,
     );
 
     doEmit(

--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
@@ -24,7 +24,7 @@ export interface CatalogCreatorPageProps {
   docsLink?: string;
   entityKind?: string;
   entityName?: string;
-  createFunction: boolean;
+  createFunction?: boolean;
 }
 
 export const CatalogCreatorPage = ({

--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
@@ -92,6 +92,7 @@ export const CatalogCreatorPage = ({
       data,
       entityKind,
       entityName,
+      catalogApi,
     );
   };
 

--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
@@ -23,6 +23,7 @@ export interface CatalogCreatorPageProps {
   docsLink?: string;
   entityKind?: string;
   entityName?: string;
+  createFunction: boolean;
 }
 
 export const CatalogCreatorPage = ({
@@ -30,6 +31,7 @@ export const CatalogCreatorPage = ({
   entityKind,
   entityName,
   docsLink,
+  createFunction,
 }: CatalogCreatorPageProps) => {
   const githubAuthApi: OAuthApi = useApi(githubAuthApiRef);
   const theme = useTheme();
@@ -45,9 +47,11 @@ export const CatalogCreatorPage = ({
     analysisResult,
     repoInfo,
     repoState,
+    repoFunctionState,
     doAnalyzeUrl,
     doGetRepoInfo,
     doSubmitToGithub,
+    doSubmitFunctionToGithub,
     isLoading,
     hasError,
     hasExistingCatalogFile,
@@ -55,6 +59,8 @@ export const CatalogCreatorPage = ({
     shouldShowForm,
   } = useCatalogCreator(githubAuthApi);
   const { t } = useTranslationRef(catalogCreatorTranslationRef);
+
+  const state = createFunction ? repoFunctionState : repoState;
 
   useEffect(() => {
     document.title = `${t('contentHeader.title')} | ${window.location.hostname}`;
@@ -81,6 +87,10 @@ export const CatalogCreatorPage = ({
     );
   };
 
+  const handleFunctionCatalogFormSubmit = (data: FormEntity[]) => {
+    doSubmitFunctionToGithub();
+  };
+
   const handleResetForm = () => {
     setUrl('');
     setDefaultName('');
@@ -103,9 +113,9 @@ export const CatalogCreatorPage = ({
         </Flex>
         <Flex>
           <Box flex-grow="1" width="100%">
-            {repoState.value?.severity === 'success' ? (
+            {state.value?.severity === 'success' ? (
               <SuccessMessage
-                prUrl={repoState.value.prUrl}
+                prUrl={state.value.prUrl}
                 onReset={handleResetForm}
               />
             ) : (
@@ -123,11 +133,11 @@ export const CatalogCreatorPage = ({
                   shouldCreateNewFile={shouldCreateNewFile}
                   hasError={hasError}
                   isLoading={isLoading}
-                  repoStateError={Boolean(repoState.error)}
+                  repoStateError={Boolean(state.error)}
                   showForm={showForm}
                   existingPrUrl={repoInfo.value?.existingPrUrl}
                   analysisError={analysisResult.error}
-                  repoStateErrorMessage={repoState.error?.message}
+                  repoStateErrorMessage={state.error?.message}
                   repoInfoError={repoInfo.error}
                   catalogInfoError={catalogInfoState.error}
                 />
@@ -140,13 +150,17 @@ export const CatalogCreatorPage = ({
                     {shouldShowForm && (
                       <div style={{ position: 'relative' }}>
                         {/* Submission Loading Overlay */}
-                        {repoState.loading && (
+                        {state.loading && (
                           <LoadingOverlay
                             isDarkTheme={theme.palette.type === 'dark'}
                           />
                         )}
                         <CatalogForm
-                          onSubmit={handleCatalogFormSubmit}
+                          onSubmit={
+                            createFunction
+                              ? handleFunctionCatalogFormSubmit
+                              : handleCatalogFormSubmit
+                          }
                           currentYaml={catalogInfoState.value!}
                           defaultName={defaultName}
                         />

--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/StatusMessages.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/StatusMessages.tsx
@@ -32,6 +32,7 @@ export const StatusMessages = ({
   catalogInfoError,
 }: StatusMessagesProps) => {
   const { t } = useTranslationRef(catalogCreatorTranslationRef);
+
   return (
     <div>
       {hasUnexpectedExistingCatalogFile &&

--- a/plugins/catalog-creator/src/components/CatalogForm/Autocompletes/MultipleEntitiesAutocomplete.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/Autocompletes/MultipleEntitiesAutocomplete.tsx
@@ -31,8 +31,8 @@ type MultipleEntitiesAutocompleteProps = {
     | 'dependsOn'
     | 'dependsOnComponents'
     | 'dependsOnFunctions'
-    | 'dependsOnSystems'
-    | 'childFunctions';
+    | 'dependsOnSystems';
+
   required?: boolean;
   kind?: Kind;
 };

--- a/plugins/catalog-creator/src/components/CatalogForm/Autocompletes/SingleEntityAutocomplete.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/Autocompletes/SingleEntityAutocomplete.tsx
@@ -22,8 +22,9 @@ type SingleEntityAutocompleteProps = {
     | 'APIForm'
     | 'systemForm'
     | 'resourceForm'
-    | 'domainForm';
-  fieldname: 'owner' | 'system' | 'domain';
+    | 'domainForm'
+    | 'functionForm';
+  fieldname: 'owner' | 'system' | 'domain' | 'parentFunction';
   required?: boolean;
   kind?: Kind;
 };

--- a/plugins/catalog-creator/src/components/CatalogForm/CatalogForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/CatalogForm.tsx
@@ -43,12 +43,14 @@ export type CatalogFormProps = {
   onSubmit: (data: FormEntity[]) => void;
   currentYaml: RequiredYamlFields[] | null;
   defaultName?: string;
+  createFunction?: boolean;
 };
 
 export const CatalogForm = ({
   onSubmit,
   currentYaml,
   defaultName = '',
+  createFunction,
 }: CatalogFormProps) => {
   const catalogApi = useApi(catalogApiRef);
   const { t } = useTranslationRef(catalogCreatorTranslationRef);
@@ -139,8 +141,8 @@ export const CatalogForm = ({
         : [
             {
               id: 0,
-              kind: 'Component',
-              name: defaultName,
+              kind: createFunction ? 'Function' : 'Component',
+              name: createFunction ? '' : defaultName,
               owner: '',
               title: '',
             },
@@ -422,33 +424,35 @@ export const CatalogForm = ({
               </Card>
             );
           })}
-
-          <Flex direction="column">
-            <Text className={style.addEntityTitle}>
-              {t('form.addEntity.title')}
-            </Text>
-            <Flex align="end" justify="start">
-              <Select
-                label={t('form.addEntity.label')}
-                value={addEntityKind}
-                className={style.selectKind}
-                onChange={value => setAddEntityKind(value as Kind)}
-                options={Object.values(AllowedEntityKinds).map(
-                  lifecycleStage => ({
-                    value: lifecycleStage as string,
-                    label: lifecycleStage,
-                  }),
-                )}
-              />
-              <Button
-                type="button"
-                onClick={() => appendHandler(addEntityKind)}
-              >
-                {t('form.addEntity.buttonText')}
-              </Button>
+          {((currentYaml && currentYaml[0].kind !== 'Function') ||
+            !createFunction) && (
+            <Flex direction="column">
+              <Text className={style.addEntityTitle}>
+                {t('form.addEntity.title')}
+              </Text>
+              <Flex align="end" justify="start">
+                <Select
+                  label={t('form.addEntity.label')}
+                  value={addEntityKind}
+                  className={style.selectKind}
+                  onChange={value => setAddEntityKind(value as Kind)}
+                  options={Object.values(AllowedEntityKinds).map(
+                    lifecycleStage => ({
+                      value: lifecycleStage as string,
+                      label: lifecycleStage,
+                    }),
+                  )}
+                />
+                <Button
+                  type="button"
+                  onClick={() => appendHandler(addEntityKind)}
+                >
+                  {t('form.addEntity.buttonText')}
+                </Button>
+              </Flex>
+              <EntityDescription entityKind={addEntityKind} />
             </Flex>
-            <EntityDescription entityKind={addEntityKind} />
-          </Flex>
+          )}
           <Divider className={style.endOfFormDivider} />
           <Box className={style.infoText}>
             <Flex align="center" gap="sm">

--- a/plugins/catalog-creator/src/components/CatalogForm/CatalogForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/CatalogForm.tsx
@@ -176,6 +176,7 @@ export const CatalogForm = ({
           system: '',
           definition: '',
           title: '',
+          parentFunction: '',
         };
         break;
       case 'API' as Kind:
@@ -189,6 +190,7 @@ export const CatalogForm = ({
           system: '',
           definition: '',
           title: '',
+          parentFunction: '',
         };
         break;
       case 'System' as Kind:
@@ -202,6 +204,7 @@ export const CatalogForm = ({
           system: '',
           definition: '',
           title: '',
+          parentFunction: '',
         };
         break;
       default:
@@ -215,6 +218,7 @@ export const CatalogForm = ({
           system: '',
           definition: '',
           title: '',
+          parentFunction: '',
         };
     }
     setIndexCount(prev => prev + 1);

--- a/plugins/catalog-creator/src/components/CatalogForm/Forms/FunctionForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/Forms/FunctionForm.tsx
@@ -73,7 +73,7 @@ export const FunctionForm = ({
   useUpdateDependentFormFields(
     functions,
     typeof functionVal === 'string' ? [functionVal] : undefined,
-    `entities.${index}.childFunctions`,
+    `entities.${index}.parentFunction`,
     setValue,
   );
 
@@ -102,6 +102,17 @@ export const FunctionForm = ({
           errors={errors}
           fieldname="owner"
           entities={groups || []}
+          required
+        />
+      </div>
+      <div>
+        <SingleEntityAutocomplete
+          index={index}
+          control={control}
+          errors={errors}
+          formname="functionForm"
+          fieldname="parentFunction"
+          entities={functions || []}
           required
         />
       </div>
@@ -149,16 +160,7 @@ export const FunctionForm = ({
           entities={functions || []}
         />
       </div>
-      <div>
-        <MultipleEntitiesAutocomplete
-          index={index}
-          control={control}
-          errors={errors}
-          formname="functionForm"
-          fieldname="childFunctions"
-          entities={functions || []}
-        />
-      </div>
+
       <TagField index={index} control={control} errors={errors} options={[]} />
       <FieldHeader
         fieldName={t('form.functionForm.links.fieldName')}

--- a/plugins/catalog-creator/src/controllers/githubController.ts
+++ b/plugins/catalog-creator/src/controllers/githubController.ts
@@ -99,4 +99,50 @@ export class GithubController {
       }
     }
   };
+
+  submitFunctionCatalogInfoToGithub = async (
+    githubAuthApi: OAuthApi,
+    couldNotCreatePRErrorMsg: string,
+  ): Promise<Status | undefined> => {
+    const newFileContent = 'testcontent';
+    const newFilePath = 'folder/newfile.yaml';
+
+    const existingFilePath = 'catalog-info.yaml';
+    const updatedContent = `locations: ${newFilePath}`;
+
+    const OctokitPlugin = Octokit.plugin(createPullRequest);
+    const token = await githubAuthApi.getAccessToken();
+    const octokit = new OctokitPlugin({ auth: token });
+
+    try {
+      const result = await octokit.createPullRequest({
+        owner: 'kartverket',
+        repo: 'funksjonsregister-PoC',
+        title: 'Test function',
+        body: 'Creates new catalog file and updates existing catalog with reference',
+        head: 'add-catalog-file',
+        changes: [
+          {
+            files: {
+              [newFilePath]: newFileContent,
+              [existingFilePath]: updatedContent,
+            },
+            commit: 'Test test test',
+          },
+        ],
+      });
+      return {
+        message: 'created a pull request',
+        severity: 'success',
+        prUrl: result?.data.html_url,
+      };
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        error.message = couldNotCreatePRErrorMsg;
+        throw error;
+      } else {
+        throw new Error('Unknown error when trying to create a PR.');
+      }
+    }
+  };
 }

--- a/plugins/catalog-creator/src/hooks/useCatalogCreator.ts
+++ b/plugins/catalog-creator/src/hooks/useCatalogCreator.ts
@@ -103,6 +103,7 @@ export const useCatalogCreator = (
       catalogInfoFormList?: FormEntity[],
       entityKind?: string,
       entityName?: string,
+      catalogApi?: CatalogApi
     ) => {
       scrollToTop();
 
@@ -119,6 +120,7 @@ export const useCatalogCreator = (
         t('form.knownErrorAlerts.couldNotCreatePR'),
         entityKind,
         entityName,
+        catalogApi
       );
     },
     [

--- a/plugins/catalog-creator/src/hooks/useCatalogCreator.ts
+++ b/plugins/catalog-creator/src/hooks/useCatalogCreator.ts
@@ -9,6 +9,7 @@ import { scrollToTop } from '../utils/pageUtils';
 import { FormEntity } from '../types/types';
 import { catalogCreatorTranslationRef } from '../utils/translations';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { CatalogApi } from '@backstage/plugin-catalog-react';
 
 export const useCatalogCreator = (
   githubAuthApi: OAuthApi,
@@ -128,12 +129,18 @@ export const useCatalogCreator = (
   );
 
   const [repoFunctionState, doSubmitFunctionToGithub] = useAsyncFn(
-    async (catalogInfoFormList?: FormEntity[]) => {
+    async (catalogApi: CatalogApi, catalogInfoFormList?: FormEntity[]) => {
       scrollToTop();
+
+      if (!catalogInfoFormList) {
+        return undefined;
+      }
 
       return await githubController.submitFunctionCatalogInfoToGithub(
         githubAuthApi,
         t('form.knownErrorAlerts.couldNotCreatePR'),
+        catalogInfoFormList,
+        catalogApi,
       );
     },
     [

--- a/plugins/catalog-creator/src/hooks/useCatalogCreator.ts
+++ b/plugins/catalog-creator/src/hooks/useCatalogCreator.ts
@@ -124,6 +124,22 @@ export const useCatalogCreator = (githubAuthApi: OAuthApi) => {
     ],
   );
 
+  const [repoFunctionState, doSubmitFunctionToGithub] = useAsyncFn(
+    async (catalogInfoFormList?: FormEntity[]) => {
+      scrollToTop();
+
+      return await githubController.submitFunctionCatalogInfoToGithub(
+        githubAuthApi,
+        t('form.knownErrorAlerts.couldNotCreatePR'),
+      );
+    },
+    [
+      githubController.submitCatalogInfoToGithub,
+      githubAuthApi,
+      catalogInfoState.value,
+    ],
+  );
+
   const isLoading =
     repoInfo.loading || analysisResult.loading || catalogInfoState.loading;
   const hasError = Boolean(
@@ -153,11 +169,13 @@ export const useCatalogCreator = (githubAuthApi: OAuthApi) => {
     repoInfo,
     analysisResult,
     repoState,
+    repoFunctionState,
 
     doFetchCatalogInfo,
     doAnalyzeUrl,
     doGetRepoInfo,
     doSubmitToGithub,
+    doSubmitFunctionToGithub,
 
     isLoading,
     hasError,

--- a/plugins/catalog-creator/src/schemas/formSchema.ts
+++ b/plugins/catalog-creator/src/schemas/formSchema.ts
@@ -240,14 +240,11 @@ export const functionSchema = baseEntitySchema.extend({
       { message: 'form.errors.dependsOnComponentsNoSpace' },
     )
     .optional(),
-  childFunctions: z
-    .array(z.string())
-    .refine(
-      entries =>
-        entries.every(entry => entry.trim().length > 0 && !entry.includes(' ')),
-      { message: 'form.errors.childFunctionsNoSpace' },
-    )
-    .optional(),
+  parentFunction: z
+    .string('form.errors.noParentFunction')
+    .trim()
+    .min(1, 'form.errors.noOwner')
+    .refine(s => !s.includes(' '), { message: 'form.errors.ownerNoSpace' }),
   links: z
     .array(
       z.object({

--- a/plugins/catalog-creator/src/schemas/formSchema.ts
+++ b/plugins/catalog-creator/src/schemas/formSchema.ts
@@ -243,8 +243,10 @@ export const functionSchema = baseEntitySchema.extend({
   parentFunction: z
     .string('form.errors.noParentFunction')
     .trim()
-    .min(1, 'form.errors.noOwner')
-    .refine(s => !s.includes(' '), { message: 'form.errors.ownerNoSpace' }),
+    .min(1, 'form.errors.noParentFunction')
+    .refine(s => !s.includes(' '), {
+      message: 'form.errors.parentFunctionNoSpace',
+    }),
   links: z
     .array(
       z.object({

--- a/plugins/catalog-creator/src/translator/translator.ts
+++ b/plugins/catalog-creator/src/translator/translator.ts
@@ -262,6 +262,7 @@ export const updateYaml = (
 export const updateFunctionLocationsFile = (
   originalContent: RequiredYamlFields,
   newTarget: string,
+  oldTarget?: string
 ) => {
   if (originalContent.kind === 'Location') {
     const updated = {
@@ -269,7 +270,7 @@ export const updateFunctionLocationsFile = (
       spec: {
         ...originalContent.spec,
         targets: originalContent.spec.targets
-          ? [...originalContent.spec.targets, newTarget]
+          ? [...originalContent.spec.targets.filter((it => it!== oldTarget)), newTarget]
           : [newTarget],
       },
     };
@@ -277,3 +278,4 @@ export const updateFunctionLocationsFile = (
   }
   return yaml.stringify(originalContent);
 };
+

--- a/plugins/catalog-creator/src/translator/translator.ts
+++ b/plugins/catalog-creator/src/translator/translator.ts
@@ -225,10 +225,10 @@ export const updateYaml = (
             form.dependsOnFunctions?.length === 0
               ? undefined
               : form.dependsOnFunctions || initial.spec.dependsOnFunctions,
-          childFunctions:
-            form.childFunctions?.length === 0
+          parentFunction:
+            form.parentFunction?.length === 0
               ? undefined
-              : form.childFunctions || initial.spec.childFunctions,
+              : form.parentFunction || initial.spec.parentFunction,
         },
       };
       break;

--- a/plugins/catalog-creator/src/translator/translator.ts
+++ b/plugins/catalog-creator/src/translator/translator.ts
@@ -9,10 +9,13 @@ export const updateYaml = (
 ): string => {
   let updated: RequiredYamlFields;
 
+  const defaultApiVersion = 'backstage.io/v1alpha1';
+
   switch (form.kind) {
     case 'Component':
       updated = {
         ...initial,
+        apiVersion: defaultApiVersion,
         kind: form.kind || initial.kind,
         metadata: {
           ...initial.metadata,
@@ -79,6 +82,7 @@ export const updateYaml = (
 
       updated = {
         ...initial,
+        apiVersion: defaultApiVersion,
         kind: form.kind || initial.kind,
         metadata: {
           ...initial.metadata,
@@ -106,6 +110,7 @@ export const updateYaml = (
     case 'System':
       updated = {
         ...initial,
+        apiVersion: defaultApiVersion,
         kind: form.kind || initial.kind,
         metadata: {
           ...initial.metadata,
@@ -133,6 +138,7 @@ export const updateYaml = (
     case 'Domain':
       updated = {
         ...initial,
+        apiVersion: defaultApiVersion,
         kind: form.kind || initial.kind,
         metadata: {
           ...initial.metadata,
@@ -160,6 +166,7 @@ export const updateYaml = (
     case 'Resource':
       updated = {
         ...initial,
+        apiVersion: defaultApiVersion,
         kind: form.kind || initial.kind,
         metadata: {
           ...initial.metadata,
@@ -191,6 +198,7 @@ export const updateYaml = (
     case 'Function':
       updated = {
         ...initial,
+        apiVersion: 'kartverket.dev/v1alpha1',
         kind: form.kind || initial.kind,
         metadata: {
           ...initial.metadata,
@@ -235,6 +243,7 @@ export const updateYaml = (
     default:
       updated = {
         ...initial,
+        apiVersion: defaultApiVersion,
         kind: form.kind || initial.kind,
         metadata: {
           ...initial.metadata,
@@ -248,4 +257,23 @@ export const updateYaml = (
       };
   }
   return yaml.stringify(updated);
+};
+
+export const updateFunctionLocationsFile = (
+  originalContent: RequiredYamlFields,
+  newTarget: string,
+) => {
+  if (originalContent.kind === 'Location') {
+    const updated = {
+      ...originalContent,
+      spec: {
+        ...originalContent.spec,
+        targets: originalContent.spec.targets
+          ? [...originalContent.spec.targets, newTarget]
+          : [newTarget],
+      },
+    };
+    return yaml.stringify(updated);
+  }
+  return yaml.stringify(originalContent);
 };

--- a/plugins/catalog-creator/src/types/types.ts
+++ b/plugins/catalog-creator/src/types/types.ts
@@ -80,7 +80,7 @@ export type Status = {
 export type FormEntity = z.infer<typeof entitySchema>;
 
 export type RequiredYamlFields = {
-  apiVersion: 'backstage.io/v1alpha1';
+  apiVersion: string;
   kind: string;
   metadata: {
     name: string;
@@ -116,7 +116,7 @@ export type RequiredYamlFields = {
           $asyncapi?: string | undefined;
         }
       | string;
-    target?: string;
+    targets?: string[];
     dependencyOf?: string[];
     [key: string]: any; // Allow additional spec fields
   };

--- a/plugins/catalog-creator/src/utils/getRepoInfo.ts
+++ b/plugins/catalog-creator/src/utils/getRepoInfo.ts
@@ -58,7 +58,10 @@ export async function getRepoInfo(
 
     const matchingPr = response.data.find(pr => {
       if (entityKind === 'Function') {
-        return pr.title === `Update ${entityName} function`;
+        return (
+          pr.title === `Update ${entityName} function` ||
+          pr.title === `Create ${entityName} function`
+        );
       }
       if (entityKind !== 'Function') {
         return pr.title === 'Create/update catalog-info.yaml';

--- a/plugins/catalog-creator/src/utils/translations.ts
+++ b/plugins/catalog-creator/src/utils/translations.ts
@@ -166,10 +166,10 @@ export const catalogCreatorMessages = {
         tooltipText: 'Other functions that this function depends on.',
         placeholder: 'Select functions',
       },
-      childFunctions: {
-        fieldName: 'Child Functions',
-        tooltipText: 'Functions that are part of or belong to this function.',
-        placeholder: 'Select functions',
+      parentFunction: {
+        fieldName: 'Parent Function',
+        tooltipText: 'Function that this function enable',
+        placeholder: 'Select function',
       },
       links: {
         fieldName: 'Links',
@@ -224,6 +224,8 @@ export const catalogCreatorMessages = {
 
       linksNoSpace: 'Url cannot contain space',
       linksLength: 'Url cannot be longer than 63 characters',
+
+      noParentFunction: 'Add a parent function',
     },
 
     infoAlerts: {
@@ -420,10 +422,10 @@ export const catalogCreatorNorwegianTranslation = createTranslationResource({
             'Andre funksjoner som denne funksjonen er avhengig av.',
           'form.functionForm.dependsOnFunctions.placeholder': 'Velg funksjoner',
 
-          'form.functionForm.childFunctions.fieldName': 'Underfunksjoner',
-          'form.functionForm.childFunctions.tooltipText':
-            'Funksjoner som er en del av eller tilhører denne funksjonen.',
-          'form.functionForm.childFunctions.placeholder': 'Velg funksjoner',
+          'form.functionForm.parentFunction.fieldName': 'Forelderfunksjon',
+          'form.functionForm.parentFunction.tooltipText':
+            'Funksjon som denne funksjonen muliggjør.',
+          'form.functionForm.parentFunction.placeholder': 'Velg funksjon',
 
           'form.functionForm.links.fieldName': 'Lenker',
           'form.functionForm.links.cardTitle': 'Lenke',
@@ -457,6 +459,8 @@ export const catalogCreatorNorwegianTranslation = createTranslationResource({
 
           'form.errors.noOwner': 'Legg til eier',
           'form.errors.ownerNoSpace': 'Eier kan ikke inneholde mellomrom',
+
+          'form.errors.noParentFunction': 'Legg til forelderfunksjon',
 
           'form.errors.systemNoSpace': 'System kan ikke inneholde mellomrom',
 

--- a/plugins/catalog-creator/src/utils/translations.ts
+++ b/plugins/catalog-creator/src/utils/translations.ts
@@ -226,6 +226,7 @@ export const catalogCreatorMessages = {
       linksLength: 'Url cannot be longer than 63 characters',
 
       noParentFunction: 'Add a parent function',
+      parentFunctionNoSpace: 'Parent function cannot contain space',
     },
 
     infoAlerts: {
@@ -459,6 +460,8 @@ export const catalogCreatorNorwegianTranslation = createTranslationResource({
           'form.errors.ownerNoSpace': 'Eier kan ikke inneholde mellomrom',
 
           'form.errors.noParentFunction': 'Legg til forelderfunksjon',
+          'form.errors.parentFunctionNoSpace':
+            'Forelderfunksjon kan ikke inneholde mellomrom',
 
           'form.errors.systemNoSpace': 'System kan ikke inneholde mellomrom',
 

--- a/plugins/function-kind-common/src/index.ts
+++ b/plugins/function-kind-common/src/index.ts
@@ -39,9 +39,9 @@ export interface FunctionEntityV1alpha1 extends Entity {
     dependsOnComponents?: string[];
 
     /**
-     * Optional: The functions this function is a parent of
+     * Optional: The function this function is a parent of
      */
-    childFunctions?: string[];
+    parentFunction?: string;
 
     /**
      * Optional: The functions this function depends on.

--- a/plugins/function-kind-common/src/schema/kinds/FunctionEntityV1Alpha1.schema.json
+++ b/plugins/function-kind-common/src/schema/kinds/FunctionEntityV1Alpha1.schema.json
@@ -26,9 +26,9 @@
               "description": "An entity reference to the owner of the function",
               "minLength": 1
             },
-            "childFunctions": {
-              "type": "array",
-              "description": "Entity references to children of the function"
+            "parentFunction": {
+              "type": "string",
+              "description": "Entity reference to parent of the function"
             },
             "dependsOnSystems": {
               "type": "array",


### PR DESCRIPTION
## 🔒 Bakgrunn
Tidligere har endring på funksjoner bare påvirket yaml-filen for den gitte funksjonen. men fordi vi bruker funksjonstreeet til å strukturere funksjonssrepoet krever foreldrebytte endring utenfor funksjonens egene yaml-fil.

## 🔑 Løsning
Når foreldrefunksjonen endres slettes gammel funksjons-fil, det legges til en ny fil i ny foreldrefunksjons mappe og lokasjon oppdateres i catalog-info for hele repoet.

## 📸 "Bilder"

| Før   | Etter |
| ----- | ----- |
| https://github.com/kartverket/funksjonsregister-PoC/pull/135/changes | https://github.com/kartverket/funksjonsregister-PoC/pull/161/changes |