### PR TITLE
refactor: migrate from @material-ui v4 to @mui v5+

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -55,9 +55,7 @@
     "@kartverket/backstage-plugin-risk-scorecard": "6.0.2",
     "@kartverket/backstage-plugin-security-champion": "workspace:",
     "@kartverket/backstage-plugin-security-metrics-frontend": "workspace:",
-    "@material-ui/core": "^4.12.4",
-    "@material-ui/icons": "^4.11.3",
-    "@material-ui/lab": "^4.0.0-alpha.61",
+    "@mui/x-tree-view": "^8.27.2",
     "backstage-plugin-techdocs-addon-mermaid": "^0.23.0",
     "jwt-decode": "^4.0.0",
     "react": "^18",
@@ -65,6 +63,7 @@
     "react-router": "^6.30.3",
     "react-router-dom": "^6.30.3",
     "react-use": "^17.6.0",
+    "tss-react": "^4.9.20",
     "zod": "^4.3.5"
   },
   "devDependencies": {

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -16,7 +16,7 @@ import {
   entityPresentationApiRef,
 } from '@backstage/plugin-catalog-react';
 import { DefaultEntityPresentationApi } from '@backstage/plugin-catalog';
-import MuiAssignmentIcon from '@material-ui/icons/Assignment';
+import MuiAssignmentIcon from '@mui/icons-material/Assignment';
 
 export const apis: AnyApiFactory[] = [
   createApiFactory({

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -13,16 +13,16 @@ import {
 } from '@backstage/core-components';
 import { MyGroupsSidebarItem } from '@backstage/plugin-org';
 import { UserSettingsSignInAvatar } from '@backstage/plugin-user-settings';
-import { makeStyles } from '@material-ui/core';
-import EditIcon from '@material-ui/icons/Edit';
-import AppsIcon from '@material-ui/icons/Apps';
-import TreeIcon from '@material-ui/icons/AccountTree';
-import HomeIcon from '@material-ui/icons/Home';
-import MenuIcon from '@material-ui/icons/Menu';
-import GroupIcon from '@material-ui/icons/People';
-import SearchIcon from '@material-ui/icons/Search';
-import SpeedIcon from '@material-ui/icons/Speed';
-import LibraryBooks from '@material-ui/icons/LibraryBooks';
+import { makeStyles } from 'tss-react/mui';
+import EditIcon from '@mui/icons-material/Edit';
+import AppsIcon from '@mui/icons-material/Apps';
+import TreeIcon from '@mui/icons-material/AccountTree';
+import HomeIcon from '@mui/icons-material/Home';
+import MenuIcon from '@mui/icons-material/Menu';
+import GroupIcon from '@mui/icons-material/People';
+import SearchIcon from '@mui/icons-material/Search';
+import SpeedIcon from '@mui/icons-material/Speed';
+import LibraryBooks from '@mui/icons-material/LibraryBooks';
 import { PropsWithChildren } from 'react';
 import LogoFull from './LogoFull';
 import LogoIcon from './LogoIcon';
@@ -30,9 +30,9 @@ import { NotificationsSidebarItem } from '@backstage/plugin-notifications';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { sidebarTranslationRef } from '../../utils/translations';
 import { SidebarSearchModal } from '../search/SidebarSearchModal';
-import SettingsIcon from '@material-ui/icons/Settings';
+import SettingsIcon from '@mui/icons-material/Settings';
 
-const useSidebarLogoStyles = makeStyles({
+const useSidebarLogoStyles = makeStyles()(() => ({
   root: {
     width: sidebarConfig.drawerWidthClosed,
     height: 3 * sidebarConfig.logoHeight,
@@ -45,10 +45,10 @@ const useSidebarLogoStyles = makeStyles({
     width: sidebarConfig.drawerWidthClosed,
     marginLeft: 24,
   },
-});
+}));
 
 const SidebarLogo = () => {
-  const classes = useSidebarLogoStyles();
+  const { classes } = useSidebarLogoStyles();
   const { isOpen } = useSidebarOpenState();
 
   return (

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -6,7 +6,7 @@ import {
   EntitySwitch,
   isKind,
 } from '@backstage/plugin-catalog';
-import { Grid } from '@material-ui/core';
+import { Grid } from '@mui/material';
 import { EntityCatalogGraphCard } from '@backstage/plugin-catalog-graph';
 import {
   entityWarningContent,

--- a/packages/app/src/components/catalog/entityPages/ApiPage.tsx
+++ b/packages/app/src/components/catalog/entityPages/ApiPage.tsx
@@ -1,4 +1,4 @@
-import { Grid } from '@material-ui/core';
+import { Grid } from '@mui/material';
 import {
   EntityApiDefinitionCard,
   EntityProvidingComponentsCard,

--- a/packages/app/src/components/catalog/entityPages/ComponentPages.tsx
+++ b/packages/app/src/components/catalog/entityPages/ComponentPages.tsx
@@ -1,4 +1,4 @@
-import { Grid } from '@material-ui/core';
+import { Grid } from '@mui/material';
 import {
   EntityDependsOnComponentsCard,
   EntityDependsOnResourcesCard,

--- a/packages/app/src/components/catalog/entityPages/DomainPage.tsx
+++ b/packages/app/src/components/catalog/entityPages/DomainPage.tsx
@@ -1,4 +1,4 @@
-import { Grid } from '@material-ui/core';
+import { Grid } from '@mui/material';
 import {
   EntityAboutCard,
   EntityHasSystemsCard,

--- a/packages/app/src/components/catalog/entityPages/FunctionEntityPage.tsx
+++ b/packages/app/src/components/catalog/entityPages/FunctionEntityPage.tsx
@@ -1,4 +1,4 @@
-import { Grid } from '@material-ui/core';
+import { Grid } from '@mui/material';
 import { EntityLayout } from '@backstage/plugin-catalog';
 import { EntityCatalogGraphCard } from '@backstage/plugin-catalog-graph';
 import { useEntity } from '@backstage/plugin-catalog-react';

--- a/packages/app/src/components/catalog/entityPages/GroupPage.tsx
+++ b/packages/app/src/components/catalog/entityPages/GroupPage.tsx
@@ -1,4 +1,4 @@
-import { Grid } from '@material-ui/core';
+import { Grid } from '@mui/material';
 import { EntityLayout } from '@backstage/plugin-catalog';
 import {
   EntityGroupProfileCard,

--- a/packages/app/src/components/catalog/entityPages/ResourcePage.tsx
+++ b/packages/app/src/components/catalog/entityPages/ResourcePage.tsx
@@ -1,4 +1,4 @@
-import { Grid } from '@material-ui/core';
+import { Grid } from '@mui/material';
 import {
   EntityAboutCard,
   EntityLayout,

--- a/packages/app/src/components/catalog/entityPages/SystemPage.tsx
+++ b/packages/app/src/components/catalog/entityPages/SystemPage.tsx
@@ -1,4 +1,4 @@
-import { Grid } from '@material-ui/core';
+import { Grid } from '@mui/material';
 import {
   EntityAboutCard,
   EntityHasComponentsCard,

--- a/packages/app/src/components/catalog/entityPages/UserPage.tsx
+++ b/packages/app/src/components/catalog/entityPages/UserPage.tsx
@@ -1,4 +1,4 @@
-import { Grid } from '@material-ui/core';
+import { Grid } from '@mui/material';
 import { EntityLayout } from '@backstage/plugin-catalog';
 import {
   EntityUserProfileCard,

--- a/packages/app/src/components/catalog/entityPages/shared.tsx
+++ b/packages/app/src/components/catalog/entityPages/shared.tsx
@@ -1,4 +1,4 @@
-import { Button, Grid } from '@material-ui/core';
+import { Button, Grid } from '@mui/material';
 import {
   EntityAboutCard,
   EntityHasSubcomponentsCard,

--- a/packages/app/src/components/functions/FunctionTree.tsx
+++ b/packages/app/src/components/functions/FunctionTree.tsx
@@ -1,8 +1,9 @@
-import { TreeView, TreeItem } from '@material-ui/lab';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import ChevronRightIcon from '@material-ui/icons/ChevronRight';
-import { makeStyles } from '@material-ui/core/styles';
-import { Chip, Paper } from '@material-ui/core';
+import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
+import { TreeItem } from '@mui/x-tree-view/TreeItem';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { makeStyles } from 'tss-react/mui';
+import { Chip, Paper } from '@mui/material';
 import { EntityData } from './types';
 import { Link } from '@backstage/core-components';
 
@@ -19,7 +20,7 @@ function shortOwnerName(owner: string): string {
   return slashIdx >= 0 ? owner.slice(slashIdx + 1) : owner;
 }
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles()((theme) => ({
   // Remove MUI TreeItem's default hover/selected backgrounds — hover is on the card instead
   treeContent: {
     padding: 0,
@@ -106,7 +107,7 @@ function FunctionTreeItems({
 }: {
   parentRef: string;
   funcMap: Map<string | undefined, EntityData[]>;
-  classes: ReturnType<typeof useStyles>;
+  classes: ReturnType<typeof useStyles>["classes"];
   depth?: number;
   visited?: Set<string>;
 }) {
@@ -125,7 +126,7 @@ function FunctionTreeItems({
         return (
           <TreeItem
             key={child.ref ?? child.title}
-            nodeId={child.ref ?? child.title}
+          itemId={child.ref ?? child.title}
             classes={{
               content: classes.treeContent,
               label: classes.treeLabel,
@@ -184,19 +185,15 @@ export const FunctionTree = ({
   funcMap: Map<string | undefined, EntityData[]>;
   defaultExpanded?: string[];
 }) => {
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   return (
-    <TreeView
-      defaultCollapseIcon={<ExpandMoreIcon />}
-      defaultExpandIcon={<ChevronRightIcon />}
-      defaultExpanded={defaultExpanded}
-    >
+    <SimpleTreeView slots={{ collapseIcon: ExpandMoreIcon, expandIcon: ChevronRightIcon }} defaultExpandedItems={defaultExpanded}>
       <FunctionTreeItems
         parentRef={rootRef}
         funcMap={funcMap}
         classes={classes}
       />
-    </TreeView>
+    </SimpleTreeView>
   );
 };

--- a/packages/app/src/components/functions/FunctionTree.tsx
+++ b/packages/app/src/components/functions/FunctionTree.tsx
@@ -20,7 +20,7 @@ function shortOwnerName(owner: string): string {
   return slashIdx >= 0 ? owner.slice(slashIdx + 1) : owner;
 }
 
-const useStyles = makeStyles()((theme) => ({
+const useStyles = makeStyles()(theme => ({
   // Remove MUI TreeItem's default hover/selected backgrounds — hover is on the card instead
   treeContent: {
     padding: 0,
@@ -107,7 +107,7 @@ function FunctionTreeItems({
 }: {
   parentRef: string;
   funcMap: Map<string | undefined, EntityData[]>;
-  classes: ReturnType<typeof useStyles>["classes"];
+  classes: ReturnType<typeof useStyles>['classes'];
   depth?: number;
   visited?: Set<string>;
 }) {
@@ -126,7 +126,7 @@ function FunctionTreeItems({
         return (
           <TreeItem
             key={child.ref ?? child.title}
-          itemId={child.ref ?? child.title}
+            itemId={child.ref ?? child.title}
             classes={{
               content: classes.treeContent,
               label: classes.treeLabel,
@@ -188,7 +188,10 @@ export const FunctionTree = ({
   const { classes } = useStyles();
 
   return (
-    <SimpleTreeView slots={{ collapseIcon: ExpandMoreIcon, expandIcon: ChevronRightIcon }} defaultExpandedItems={defaultExpanded}>
+    <SimpleTreeView
+      slots={{ collapseIcon: ExpandMoreIcon, expandIcon: ChevronRightIcon }}
+      defaultExpandedItems={defaultExpanded}
+    >
       <FunctionTreeItems
         parentRef={rootRef}
         funcMap={funcMap}

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -7,8 +7,9 @@ import {
 import { Content, Page } from '@backstage/core-components';
 import { HomePageSearchBar } from '@backstage/plugin-search';
 import { SearchContextProvider } from '@backstage/plugin-search-react';
-import { Grid, makeStyles } from '@material-ui/core';
-import { useTheme } from '@material-ui/core/styles';
+import { Grid } from '@mui/material';
+import { makeStyles } from 'tss-react/mui';
+import { useTheme } from '@mui/material/styles';
 import LogoFull from '../Root/LogoFull';
 import grafanaLogo from './logos/Grafana.png';
 import argoLogo from './logos/Argo.png';
@@ -24,7 +25,7 @@ import { homepageTranslationRef } from '../../utils/translations';
 import { SupportButton } from '@internal/plugin-frontend-custom-components';
 import { Flex } from '@backstage/ui';
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles()((theme) => ({
   searchBarInput: {
     maxWidth: '60vw',
     margin: 'auto',
@@ -37,7 +38,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const useLogoStyles = makeStyles(theme => ({
+const useLogoStyles = makeStyles()((theme) => ({
   container: {
     margin: theme.spacing(0, 5),
     width: '100%',
@@ -53,9 +54,9 @@ const useLogoStyles = makeStyles(theme => ({
 }));
 
 export const HomePage = () => {
-  const classes = useStyles();
+  const { classes } = useStyles();
 
-  const { svg, path, container } = useLogoStyles();
+  const { classes: { svg, path, container } } = useLogoStyles();
   const theme = useTheme();
   const mode = theme.palette.type === 'dark' ? 'light' : 'dark';
   const { t } = useTranslationRef(homepageTranslationRef);

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -60,7 +60,7 @@ export const HomePage = () => {
     classes: { svg, path, container },
   } = useLogoStyles();
   const theme = useTheme();
-  const mode = theme.palette.type === 'dark' ? 'light' : 'dark';
+  const mode = theme.palette.mode === 'dark' ? 'light' : 'dark';
   const { t } = useTranslationRef(homepageTranslationRef);
 
   return (

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -25,7 +25,7 @@ import { homepageTranslationRef } from '../../utils/translations';
 import { SupportButton } from '@internal/plugin-frontend-custom-components';
 import { Flex } from '@backstage/ui';
 
-const useStyles = makeStyles()((theme) => ({
+const useStyles = makeStyles()(theme => ({
   searchBarInput: {
     maxWidth: '60vw',
     margin: 'auto',
@@ -38,7 +38,7 @@ const useStyles = makeStyles()((theme) => ({
   },
 }));
 
-const useLogoStyles = makeStyles()((theme) => ({
+const useLogoStyles = makeStyles()(theme => ({
   container: {
     margin: theme.spacing(0, 5),
     width: '100%',
@@ -56,7 +56,9 @@ const useLogoStyles = makeStyles()((theme) => ({
 export const HomePage = () => {
   const { classes } = useStyles();
 
-  const { classes: { svg, path, container } } = useLogoStyles();
+  const {
+    classes: { svg, path, container },
+  } = useLogoStyles();
   const theme = useTheme();
   const mode = theme.palette.type === 'dark' ? 'light' : 'dark';
   const { t } = useTranslationRef(homepageTranslationRef);

--- a/packages/app/src/components/search/SearchPage.tsx
+++ b/packages/app/src/components/search/SearchPage.tsx
@@ -1,4 +1,6 @@
-import { makeStyles, Theme, Grid, Paper } from '@material-ui/core';
+import { makeStyles } from 'tss-react/mui';
+import { Theme } from '@mui/material/styles';
+import { Grid, Paper } from '@mui/material';
 
 import { CatalogSearchResultListItem } from '@backstage/plugin-catalog';
 import {
@@ -24,7 +26,7 @@ import {
 } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   bar: {
     padding: theme.spacing(1, 0),
   },
@@ -40,7 +42,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 const SearchPage = () => {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { types } = useSearch();
   const catalogApi = useApi(catalogApiRef);
 

--- a/packages/app/src/components/search/SidebarSearchModal.tsx
+++ b/packages/app/src/components/search/SidebarSearchModal.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import SearchIcon from '@material-ui/icons/Search';
+import SearchIcon from '@mui/icons-material/Search';
 import { SidebarItem } from '@backstage/core-components';
 import { IconComponent } from '@backstage/core-plugin-api';
 import {

--- a/plugins/catalog-creator/package.json
+++ b/plugins/catalog-creator/package.json
@@ -42,12 +42,10 @@
     "octokit-plugin-create-pull-request": "^6.0.1",
     "react-hook-form": "^7.71.1",
     "react-use": "^17.6.0",
+    "tss-react": "^4.9.20",
     "yaml": "^2.8.2"
   },
   "peerDependencies": {
-    "@material-ui/core": "^4.9.13",
-    "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "^4.0.0-alpha.61",
     "@mui/material": "^5.16.4",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "zod": "^3.25.0 || ^4.0.0"

--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { Box, Flex, Link } from '@backstage/ui';
 import { Content, SupportButton } from '@backstage/core-components';
 import { githubAuthApiRef, OAuthApi, useApi } from '@backstage/core-plugin-api';
-import { useTheme } from '@material-ui/core/styles';
+import { useTheme } from '@mui/material/styles';
 import CircularProgress from '@mui/material/CircularProgress';
 
 import { CatalogForm } from '../CatalogForm';

--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
@@ -190,7 +190,7 @@ export const CatalogCreatorPage = ({
                         {/* Submission Loading Overlay */}
                         {state.loading && (
                           <LoadingOverlay
-                            isDarkTheme={theme.palette.type === 'dark'}
+                            isDarkTheme={theme.palette.mode === 'dark'}
                           />
                         )}
                         <CatalogForm

--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/RepositoryForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/RepositoryForm.tsx
@@ -3,7 +3,7 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { catalogCreatorTranslationRef } from '../../utils/translations';
 import style from '../../catalog.module.css';
 import EditDocumentIcon from '@mui/icons-material/EditDocument';
-import Link from '@material-ui/core/Link';
+import Link from '@mui/material/Link';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 
 interface RepositoryFormProps {

--- a/plugins/catalog-creator/src/components/CatalogForm/FieldHeader.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/FieldHeader.tsx
@@ -1,5 +1,5 @@
 import { Flex } from '@backstage/ui';
-import { Tooltip } from '@mui/material';
+import Tooltip from '@mui/material/Tooltip';
 import { InfoOutlined } from '@mui/icons-material';
 
 import style from '../../catalog.module.css';

--- a/plugins/catalog-creator/src/components/CatalogForm/FieldHeader.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/FieldHeader.tsx
@@ -1,5 +1,5 @@
 import { Flex } from '@backstage/ui';
-import { Tooltip } from '@material-ui/core';
+import { Tooltip } from '@mui/material';
 import { InfoOutlined } from '@mui/icons-material';
 
 import style from '../../catalog.module.css';

--- a/plugins/frontend-custom-components/package.json
+++ b/plugins/frontend-custom-components/package.json
@@ -36,6 +36,7 @@
     "@backstage/theme": "backstage:^",
     "@backstage/types": "backstage:^",
     "@backstage/ui": "backstage:^",
+    "@mui/icons-material": "^7.3.7",
     "@mui/material": "^7.3.7",
     "@tanstack/react-query": "^5.90.20",
     "react-use": "^17.6.0",

--- a/plugins/frontend-custom-components/package.json
+++ b/plugins/frontend-custom-components/package.json
@@ -36,13 +36,11 @@
     "@backstage/theme": "backstage:^",
     "@backstage/types": "backstage:^",
     "@backstage/ui": "backstage:^",
-    "@material-ui/core": "^4.12.4",
-    "@material-ui/icons": "^4.11.3",
-    "@material-ui/lab": "^4.0.0-alpha.61",
     "@mui/material": "^7.3.7",
     "@tanstack/react-query": "^5.90.20",
     "react-use": "^17.6.0",
-    "remixicon": "^4.8.0"
+    "remixicon": "^4.8.0",
+    "tss-react": "^4.9.20"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0"

--- a/plugins/frontend-custom-components/src/components/AboutCard/AboutField.tsx
+++ b/plugins/frontend-custom-components/src/components/AboutCard/AboutField.tsx
@@ -15,12 +15,12 @@
  */
 
 import { useElementFilter } from '@backstage/core-plugin-api';
-import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/core/styles';
+import Grid from '@mui/material/Grid';
+import Typography from '@mui/material/Typography';
+import { makeStyles } from 'tss-react/mui';
 import { ReactNode } from 'react';
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles()((theme) => ({
   value: {
     fontWeight: 'bold',
     overflow: 'hidden',
@@ -54,7 +54,7 @@ export interface AboutFieldProps {
 /** @public */
 export function AboutField(props: AboutFieldProps) {
   const { label, value, gridSizes, children, className } = props;
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   const childElements = useElementFilter(children, c => c.getElements());
 

--- a/plugins/frontend-custom-components/src/components/AboutCard/AboutField.tsx
+++ b/plugins/frontend-custom-components/src/components/AboutCard/AboutField.tsx
@@ -20,7 +20,7 @@ import Typography from '@mui/material/Typography';
 import { makeStyles } from 'tss-react/mui';
 import { ReactNode } from 'react';
 
-const useStyles = makeStyles()((theme) => ({
+const useStyles = makeStyles()(theme => ({
   value: {
     fontWeight: 'bold',
     overflow: 'hidden',

--- a/plugins/frontend-custom-components/src/components/AboutCard/FunctionAboutCard.tsx
+++ b/plugins/frontend-custom-components/src/components/AboutCard/FunctionAboutCard.tsx
@@ -16,14 +16,14 @@
 
 import { useCallback } from 'react';
 
-import { makeStyles } from '@material-ui/core/styles';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
-import CardHeader from '@material-ui/core/CardHeader';
-import Divider from '@material-ui/core/Divider';
-import IconButton from '@material-ui/core/IconButton';
-import CachedIcon from '@material-ui/icons/Cached';
-import EditIcon from '@material-ui/icons/Edit';
+import { makeStyles } from 'tss-react/mui';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CardHeader from '@mui/material/CardHeader';
+import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+import CachedIcon from '@mui/icons-material/Cached';
+import EditIcon from '@mui/icons-material/Edit';
 
 import { AppIcon, InfoCardVariants, Link } from '@backstage/core-components';
 import {
@@ -61,7 +61,7 @@ const createFromTemplateRouteRef = createExternalRouteRef({
 // TODO: This hook is duplicated from the Scaffolder plugin for backwards compatibility
 // Remove it when the the legacy frontend system support is dropped.
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()(() => ({
   gridItemCard: {
     display: 'flex',
     flexDirection: 'column',
@@ -79,7 +79,7 @@ const useStyles = makeStyles({
   fullHeightCardContent: {
     flex: 1,
   },
-});
+}));
 
 /**
  * Props for {@link EntityAboutCard}.
@@ -97,7 +97,7 @@ export interface InternalAboutCardProps extends AboutCardProps {
 
 export function InternalAboutCard(props: InternalAboutCardProps) {
   const { variant } = props;
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { entity } = useEntity();
   const catalogApi = useApi(catalogApiRef);
   const alertApi = useApi(alertApiRef);

--- a/plugins/frontend-custom-components/src/components/AboutCard/FunctionAboutContent.tsx
+++ b/plugins/frontend-custom-components/src/components/AboutCard/FunctionAboutContent.tsx
@@ -25,20 +25,20 @@ import {
   getEntityRelations,
 } from '@backstage/plugin-catalog-react';
 import { JsonArray } from '@backstage/types';
-import Chip from '@material-ui/core/Chip';
-import Grid from '@material-ui/core/Grid';
-import { makeStyles } from '@material-ui/core/styles';
+import Chip from '@mui/material/Chip';
+import Grid from '@mui/material/Grid';
+import { makeStyles } from 'tss-react/mui';
 import { MarkdownContent } from '@backstage/core-components';
 import { AboutField } from './AboutField';
 import { LinksGridList } from './LinksGridList';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { catalogTranslationRef } from './translation';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()(() => ({
   description: {
     wordBreak: 'break-word',
   },
-});
+}));
 
 /**
  * Props for {@link AboutContent}.
@@ -76,7 +76,7 @@ function getLocationTargetHref(
 /** @public */
 export function AboutContent(props: AboutContentProps) {
   const { entity } = props;
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { t } = useTranslationRef(catalogTranslationRef);
 
   const isSystem = entity.kind.toLocaleLowerCase('en-US') === 'system';

--- a/plugins/frontend-custom-components/src/components/AboutCard/IconLink.tsx
+++ b/plugins/frontend-custom-components/src/components/AboutCard/IconLink.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/core/styles';
-import LanguageIcon from '@material-ui/icons/Language';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { makeStyles } from 'tss-react/mui';
+import LanguageIcon from '@mui/icons-material/Language';
 import { Link } from '@backstage/core-components';
 import { IconComponent } from '@backstage/core-plugin-api';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()(() => ({
   svgIcon: {
     display: 'inline-block',
     '& svg': {
@@ -30,7 +30,7 @@ const useStyles = makeStyles({
       verticalAlign: 'baseline',
     },
   },
-});
+}));
 
 export function IconLink(props: {
   href: string;
@@ -38,7 +38,7 @@ export function IconLink(props: {
   Icon?: IconComponent;
 }) {
   const { href, text, Icon } = props;
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   return (
     <Box display="flex">

--- a/plugins/frontend-custom-components/src/components/AboutCard/LinksGridList.tsx
+++ b/plugins/frontend-custom-components/src/components/AboutCard/LinksGridList.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import ImageList from '@material-ui/core/ImageList';
-import ImageListItem from '@material-ui/core/ImageListItem';
+import ImageList from '@mui/material/ImageList';
+import ImageListItem from '@mui/material/ImageListItem';
 import { IconLink } from './IconLink.tsx';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { useDynamicColumns } from './useDynamicColumns.tsx';

--- a/plugins/frontend-custom-components/src/components/AboutCard/useDynamicColumns.tsx
+++ b/plugins/frontend-custom-components/src/components/AboutCard/useDynamicColumns.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { Theme } from '@material-ui/core/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { Theme } from '@mui/material/styles';
 import { Breakpoint, ColumnBreakpoints } from './LinksGridList';
 
 const colDefaults: ColumnBreakpoints = {

--- a/plugins/frontend-custom-components/src/components/EntityFunctionsCard/EntityFunctionsCard.tsx
+++ b/plugins/frontend-custom-components/src/components/EntityFunctionsCard/EntityFunctionsCard.tsx
@@ -20,7 +20,7 @@ import {
   RELATION_CHILD_OF,
 } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core-plugin-api';
-import Typography from '@material-ui/core/Typography';
+import Typography from '@mui/material/Typography';
 import { useAsync } from 'react-use';
 
 export type EntityFunctionsCardProps = {

--- a/plugins/frontend-custom-components/src/components/FunctionDependenciesCard/FunctionDependenciesCard.tsx
+++ b/plugins/frontend-custom-components/src/components/FunctionDependenciesCard/FunctionDependenciesCard.tsx
@@ -19,7 +19,7 @@ import {
   stringifyEntityRef,
 } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core-plugin-api';
-import Typography from '@material-ui/core/Typography';
+import Typography from '@mui/material/Typography';
 import { useAsync } from 'react-use';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { functionDependenciesCardTranslationRef } from './translations.ts';

--- a/plugins/frontend-custom-components/src/components/FunctionGroupPageCard/FunctionGroupPageCard.tsx
+++ b/plugins/frontend-custom-components/src/components/FunctionGroupPageCard/FunctionGroupPageCard.tsx
@@ -21,7 +21,7 @@ import {
   RELATION_DEPENDS_ON,
 } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core-plugin-api';
-import Typography from '@material-ui/core/Typography';
+import Typography from '@mui/material/Typography';
 import { useAsync } from 'react-use';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { functionGroupPageTranslationRef } from './translation';

--- a/plugins/frontend-custom-components/src/components/FunctionLinksCard/FunctionLinksCard.tsx
+++ b/plugins/frontend-custom-components/src/components/FunctionLinksCard/FunctionLinksCard.tsx
@@ -43,7 +43,7 @@ import { buildFormUrl } from '../../utils/formUrl';
 import Typography from '@mui/material/Typography';
 import { isUnauthorizedError } from '../../errors';
 
-const useStyles = makeStyles()((theme) => ({
+const useStyles = makeStyles()(theme => ({
   formList: {
     display: 'flex',
     flexDirection: 'column',

--- a/plugins/frontend-custom-components/src/components/FunctionLinksCard/FunctionLinksCard.tsx
+++ b/plugins/frontend-custom-components/src/components/FunctionLinksCard/FunctionLinksCard.tsx
@@ -57,13 +57,13 @@ const useStyles = makeStyles()(theme => ({
     border: `1px solid ${theme.palette.divider}`,
     borderRadius: theme.shape.borderRadius,
     backgroundColor:
-      theme.palette.type === 'dark'
+      theme.palette.mode === 'dark'
         ? 'rgba(255, 255, 255, 0.04)'
         : 'rgba(0, 0, 0, 0.03)',
     transition: 'background-color 0.15s ease',
     '&:hover': {
       backgroundColor:
-        theme.palette.type === 'dark'
+        theme.palette.mode === 'dark'
           ? 'rgba(255, 255, 255, 0.08)'
           : 'rgba(0, 0, 0, 0.06)',
     },

--- a/plugins/frontend-custom-components/src/components/FunctionLinksCard/FunctionLinksCard.tsx
+++ b/plugins/frontend-custom-components/src/components/FunctionLinksCard/FunctionLinksCard.tsx
@@ -27,8 +27,8 @@ import { useRegelrettQuery } from '../../hooks/useRegelrettQuery';
 import { useRegelrettCreateContextMutation } from '../../hooks/useRegelrettCreateContextMutation';
 import { useIsGroupMember } from '../../hooks/useIsGroupMember';
 import Alert from '@mui/material/Alert';
-import { makeStyles } from '@material-ui/core/styles';
-import DescriptionOutlinedIcon from '@material-ui/icons/DescriptionOutlined';
+import { makeStyles } from 'tss-react/mui';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
 import { useState, useEffect } from 'react';
 import { configApiRef, useApi } from '@backstage/frontend-plugin-api';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
@@ -40,10 +40,10 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { functionLinkCardTranslationRef } from './translation';
 import { FORM_TYPE_MAP } from '../../constants';
 import { buildFormUrl } from '../../utils/formUrl';
-import Typography from '@material-ui/core/Typography';
+import Typography from '@mui/material/Typography';
 import { isUnauthorizedError } from '../../errors';
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles()((theme) => ({
   formList: {
     display: 'flex',
     flexDirection: 'column',
@@ -92,7 +92,7 @@ export const FunctionLinksCard = () => {
 
 function FunctionLinksCardItem(props: EntityLinksCardProps) {
   const { variant } = props;
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { t } = useTranslationRef(functionLinkCardTranslationRef);
   const config = useApi(configApiRef);
   const catalogApi = useApi(catalogApiRef);

--- a/plugins/frontend-custom-components/src/components/FunctionLinksCard/IconLink.tsx
+++ b/plugins/frontend-custom-components/src/components/FunctionLinksCard/IconLink.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/core/styles';
-import LanguageIcon from '@material-ui/icons/Language';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { makeStyles } from 'tss-react/mui';
+import LanguageIcon from '@mui/icons-material/Language';
 import { Link } from '@backstage/core-components';
 import { IconComponent } from '@backstage/core-plugin-api';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()(() => ({
   svgIcon: {
     display: 'inline-block',
     '& svg': {
@@ -30,7 +30,7 @@ const useStyles = makeStyles({
       verticalAlign: 'baseline',
     },
   },
-});
+}));
 
 export function IconLink(props: {
   href: string;
@@ -38,7 +38,7 @@ export function IconLink(props: {
   Icon?: IconComponent;
 }) {
   const { href, text, Icon } = props;
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   return (
     <Box display="flex">

--- a/plugins/frontend-custom-components/src/components/FunctionLinksCard/LinksGridList.tsx
+++ b/plugins/frontend-custom-components/src/components/FunctionLinksCard/LinksGridList.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import ImageList from '@material-ui/core/ImageList';
-import ImageListItem from '@material-ui/core/ImageListItem';
+import ImageList from '@mui/material/ImageList';
+import ImageListItem from '@mui/material/ImageListItem';
 import { IconLink } from './IconLink';
 import { ColumnBreakpoints } from './types';
 import { useDynamicColumns } from './useDynamicColumns';

--- a/plugins/frontend-custom-components/src/components/FunctionLinksCard/useDynamicColumns.tsx
+++ b/plugins/frontend-custom-components/src/components/FunctionLinksCard/useDynamicColumns.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { Theme } from '@material-ui/core/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { Theme } from '@mui/material/styles';
 import { Breakpoint, ColumnBreakpoints } from './types';
 
 const colDefaults: ColumnBreakpoints = {

--- a/plugins/frontend-custom-components/src/components/GroupFormLinksCard/FunctionFormsTabContent.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupFormLinksCard/FunctionFormsTabContent.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
-import DescriptionOutlinedIcon from '@material-ui/icons/DescriptionOutlined';
-import LayersIcon from '@material-ui/icons/Layers';
+import { makeStyles } from 'tss-react/mui';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
+import LayersIcon from '@mui/icons-material/Layers';
 import { Link } from '@backstage/core-components';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { functionLinkCardTranslationRef } from '../FunctionLinksCard/translation';
@@ -11,7 +11,7 @@ import { RegelrettForm } from '../../types';
 import { CreateFormSection } from './CreateFormSection';
 import { Entity } from '@backstage/catalog-model';
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles()((theme) => ({
   scrollContainer: {
     maxHeight: 400,
     overflowY: 'auto',
@@ -97,7 +97,7 @@ export function FunctionFormsTabContent({
   functionEntities,
   onFormCreated,
 }: FunctionFormsTabContentProps) {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { t } = useTranslationRef(functionLinkCardTranslationRef);
   const getFormType = (formId: string) => FORM_TYPE_MAP[formId] || 'Unknown';
 

--- a/plugins/frontend-custom-components/src/components/GroupFormLinksCard/FunctionFormsTabContent.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupFormLinksCard/FunctionFormsTabContent.tsx
@@ -11,7 +11,7 @@ import { RegelrettForm } from '../../types';
 import { CreateFormSection } from './CreateFormSection';
 import { Entity } from '@backstage/catalog-model';
 
-const useStyles = makeStyles()((theme) => ({
+const useStyles = makeStyles()(theme => ({
   scrollContainer: {
     maxHeight: 400,
     overflowY: 'auto',

--- a/plugins/frontend-custom-components/src/components/GroupFormLinksCard/FunctionFormsTabContent.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupFormLinksCard/FunctionFormsTabContent.tsx
@@ -46,7 +46,7 @@ const useStyles = makeStyles()(theme => ({
     fontSize: '0.75rem',
     fontWeight: 600,
     backgroundColor:
-      theme.palette.type === 'dark'
+      theme.palette.mode === 'dark'
         ? 'rgba(255, 255, 255, 0.12)'
         : 'rgba(0, 0, 0, 0.08)',
     color: theme.palette.text.secondary,
@@ -65,13 +65,13 @@ const useStyles = makeStyles()(theme => ({
     border: `1px solid ${theme.palette.divider}`,
     borderRadius: theme.shape.borderRadius,
     backgroundColor:
-      theme.palette.type === 'dark'
+      theme.palette.mode === 'dark'
         ? 'rgba(255, 255, 255, 0.04)'
         : 'rgba(0, 0, 0, 0.03)',
     transition: 'background-color 0.15s ease',
     '&:hover': {
       backgroundColor:
-        theme.palette.type === 'dark'
+        theme.palette.mode === 'dark'
           ? 'rgba(255, 255, 255, 0.08)'
           : 'rgba(0, 0, 0, 0.06)',
     },

--- a/plugins/frontend-custom-components/src/components/GroupFormLinksCard/GroupFormLinksCard.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupFormLinksCard/GroupFormLinksCard.tsx
@@ -19,7 +19,7 @@ import { TeamFormsTabContent } from './TeamFormsTabContent';
 import { FunctionFormsTabContent } from './FunctionFormsTabContent';
 import { isUnauthorizedError } from '../../errors';
 
-const useStyles = makeStyles()((theme) => ({
+const useStyles = makeStyles()(theme => ({
   tabContainer: {
     display: 'flex',
     gap: theme.spacing(1),

--- a/plugins/frontend-custom-components/src/components/GroupFormLinksCard/GroupFormLinksCard.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupFormLinksCard/GroupFormLinksCard.tsx
@@ -10,16 +10,16 @@ import { useTeamRegelrettQuery } from '../../hooks/useTeamRegelrettQuery';
 import { useIsGroupMember } from '../../hooks/useIsGroupMember';
 import Alert from '@mui/material/Alert';
 import { configApiRef, useApi } from '@backstage/frontend-plugin-api';
-import { makeStyles } from '@material-ui/core/styles';
-import PeopleIcon from '@material-ui/icons/People';
-import LayersIcon from '@material-ui/icons/Layers';
+import { makeStyles } from 'tss-react/mui';
+import PeopleIcon from '@mui/icons-material/People';
+import LayersIcon from '@mui/icons-material/Layers';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { functionLinkCardTranslationRef } from '../FunctionLinksCard/translation';
 import { TeamFormsTabContent } from './TeamFormsTabContent';
 import { FunctionFormsTabContent } from './FunctionFormsTabContent';
 import { isUnauthorizedError } from '../../errors';
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles()((theme) => ({
   tabContainer: {
     display: 'flex',
     gap: theme.spacing(1),
@@ -91,7 +91,7 @@ export const GroupFormLinksCard = () => {
 };
 
 function GroupFormLinksCardWrapper() {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { t } = useTranslationRef(functionLinkCardTranslationRef);
   const config = useApi(configApiRef);
   const catalogApi = useApi(catalogApiRef);

--- a/plugins/frontend-custom-components/src/components/GroupFormLinksCard/GroupFormLinksCard.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupFormLinksCard/GroupFormLinksCard.tsx
@@ -47,7 +47,7 @@ const useStyles = makeStyles()(theme => ({
   },
   inactiveTab: {
     backgroundColor:
-      theme.palette.type === 'dark'
+      theme.palette.mode === 'dark'
         ? 'rgba(255, 255, 255, 0.08)'
         : 'rgba(0, 0, 0, 0.06)',
     color: theme.palette.text.secondary,
@@ -70,7 +70,7 @@ const useStyles = makeStyles()(theme => ({
   },
   inactiveBadge: {
     backgroundColor:
-      theme.palette.type === 'dark'
+      theme.palette.mode === 'dark'
         ? 'rgba(255, 255, 255, 0.12)'
         : 'rgba(0, 0, 0, 0.1)',
     color: theme.palette.text.secondary,

--- a/plugins/frontend-custom-components/src/components/GroupFormLinksCard/IconLink.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupFormLinksCard/IconLink.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { makeStyles } from 'tss-react/mui';
 import { Link } from '@backstage/core-components';
 import { IconComponent } from '@backstage/core-plugin-api';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()(() => ({
   svgIcon: {
     display: 'inline-block',
     '& svg': {
@@ -29,7 +29,7 @@ const useStyles = makeStyles({
       verticalAlign: 'baseline',
     },
   },
-});
+}));
 
 export function IconLink(props: {
   href: string;
@@ -37,7 +37,7 @@ export function IconLink(props: {
   Icon?: IconComponent;
 }) {
   const { href, text, Icon } = props;
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   return (
     <Box display="flex">

--- a/plugins/frontend-custom-components/src/components/GroupFormLinksCard/LinksGridList.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupFormLinksCard/LinksGridList.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import ImageList from '@material-ui/core/ImageList';
-import ImageListItem from '@material-ui/core/ImageListItem';
+import ImageList from '@mui/material/ImageList';
+import ImageListItem from '@mui/material/ImageListItem';
 import { IconLink } from './IconLink';
 import { ColumnBreakpoints } from './types';
 import { useDynamicColumns } from './useDynamicColumns';

--- a/plugins/frontend-custom-components/src/components/GroupFormLinksCard/TeamFormsTabContent.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupFormLinksCard/TeamFormsTabContent.tsx
@@ -8,7 +8,7 @@ import { buildFormUrl } from '../../utils/formUrl';
 import { RegelrettForm } from '../../types';
 import { CreateFormSection } from './CreateFormSection';
 
-const useStyles = makeStyles()((theme) => ({
+const useStyles = makeStyles()(theme => ({
   formList: {
     display: 'flex',
     flexDirection: 'column',

--- a/plugins/frontend-custom-components/src/components/GroupFormLinksCard/TeamFormsTabContent.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupFormLinksCard/TeamFormsTabContent.tsx
@@ -1,5 +1,5 @@
-import { makeStyles } from '@material-ui/core/styles';
-import DescriptionOutlinedIcon from '@material-ui/icons/DescriptionOutlined';
+import { makeStyles } from 'tss-react/mui';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
 import { Link } from '@backstage/core-components';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { functionLinkCardTranslationRef } from '../FunctionLinksCard/translation';
@@ -8,7 +8,7 @@ import { buildFormUrl } from '../../utils/formUrl';
 import { RegelrettForm } from '../../types';
 import { CreateFormSection } from './CreateFormSection';
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles()((theme) => ({
   formList: {
     display: 'flex',
     flexDirection: 'column',
@@ -54,7 +54,7 @@ export function TeamFormsTabContent({
   teamName,
   onFormCreated,
 }: TeamFormsTabContentProps) {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { t } = useTranslationRef(functionLinkCardTranslationRef);
   const getFormType = (formId: string) => FORM_TYPE_MAP[formId] || 'Unknown';
 

--- a/plugins/frontend-custom-components/src/components/GroupFormLinksCard/TeamFormsTabContent.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupFormLinksCard/TeamFormsTabContent.tsx
@@ -22,13 +22,13 @@ const useStyles = makeStyles()(theme => ({
     border: `1px solid ${theme.palette.divider}`,
     borderRadius: theme.shape.borderRadius,
     backgroundColor:
-      theme.palette.type === 'dark'
+      theme.palette.mode === 'dark'
         ? 'rgba(255, 255, 255, 0.04)'
         : 'rgba(0, 0, 0, 0.03)',
     transition: 'background-color 0.15s ease',
     '&:hover': {
       backgroundColor:
-        theme.palette.type === 'dark'
+        theme.palette.mode === 'dark'
           ? 'rgba(255, 255, 255, 0.08)'
           : 'rgba(0, 0, 0, 0.06)',
     },

--- a/plugins/frontend-custom-components/src/components/GroupFormLinksCard/useDynamicColumns.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupFormLinksCard/useDynamicColumns.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { Theme } from '@material-ui/core/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { Theme } from '@mui/material/styles';
 import { Breakpoint, ColumnBreakpoints } from './types';
 
 const colDefaults: ColumnBreakpoints = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1715,7 +1715,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.28.6, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.28.6
   resolution: "@babel/runtime@npm:7.28.6"
   checksum: 10c0/358cf2429992ac1c466df1a21c1601d595c46930a13c1d4662fde908d44ee78ec3c183aaff513ecb01ef8c55c3624afe0309eeeb34715672dbfadb7feedb2c0d
@@ -5261,6 +5261,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@base-ui/utils@npm:^0.2.3":
+  version: 0.2.5
+  resolution: "@base-ui/utils@npm:0.2.5"
+  dependencies:
+    "@babel/runtime": "npm:^7.28.6"
+    "@floating-ui/utils": "npm:^0.2.10"
+    reselect: "npm:^5.1.1"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    "@types/react": ^17 || ^18 || ^19
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/c871763ab132f6373895eef41477ff5a263330bc926317ed625226909ccb230109b1282556913eebd692094342644d7447a6f7bcb61aa8d6b0c60965ad3724a7
+  languageName: node
+  linkType: hard
+
 "@bcoe/v8-coverage@npm:^0.2.3":
   version: 0.2.3
   resolution: "@bcoe/v8-coverage@npm:0.2.3"
@@ -5587,7 +5606,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/cache@npm:^11.13.5, @emotion/cache@npm:^11.14.0":
+"@emotion/cache@npm:*, @emotion/cache@npm:^11.13.5, @emotion/cache@npm:^11.14.0":
   version: 11.14.0
   resolution: "@emotion/cache@npm:11.14.0"
   dependencies:
@@ -5667,7 +5686,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/serialize@npm:^1.3.3":
+"@emotion/serialize@npm:*, @emotion/serialize@npm:^1.3.3":
   version: 1.3.3
   resolution: "@emotion/serialize@npm:1.3.3"
   dependencies:
@@ -5723,7 +5742,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/utils@npm:^1.4.2":
+"@emotion/utils@npm:*, @emotion/utils@npm:^1.4.2":
   version: 1.4.2
   resolution: "@emotion/utils@npm:1.4.2"
   checksum: 10c0/7d0010bf60a2a8c1a033b6431469de4c80e47aeb8fd856a17c1d1f76bbc3a03161a34aeaa78803566e29681ca551e7bf9994b68e9c5f5c796159923e44f78d9a
@@ -7071,9 +7090,6 @@ __metadata:
     "@backstage/theme": "backstage:^"
     "@backstage/types": "backstage:^"
     "@backstage/ui": "backstage:^"
-    "@material-ui/core": "npm:^4.12.4"
-    "@material-ui/icons": "npm:^4.11.3"
-    "@material-ui/lab": "npm:^4.0.0-alpha.61"
     "@mui/material": "npm:^7.3.7"
     "@tanstack/react-query": "npm:^5.90.20"
     "@testing-library/jest-dom": "npm:^6.9.1"
@@ -7083,6 +7099,7 @@ __metadata:
     react: "npm:^18"
     react-use: "npm:^17.6.0"
     remixicon: "npm:^4.8.0"
+    tss-react: "npm:^4.9.20"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
   languageName: unknown
@@ -7792,11 +7809,9 @@ __metadata:
     react: "npm:^18"
     react-hook-form: "npm:^7.71.1"
     react-use: "npm:^17.6.0"
+    tss-react: "npm:^4.9.20"
     yaml: "npm:^2.8.2"
   peerDependencies:
-    "@material-ui/core": ^4.9.13
-    "@material-ui/icons": ^4.9.1
-    "@material-ui/lab": ^4.0.0-alpha.61
     "@mui/material": ^5.16.4
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     zod: ^3.25.0 || ^4.0.0
@@ -9173,6 +9188,48 @@ __metadata:
   peerDependencies:
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: 10c0/d4bb9f3b2ac3a51f8bb473458558ccdf137dbb7866965a90893592fbd8d4efbcd49e54ed39c1733f690b4fdf5dfbd98cfde519739dda163d5dc230fd1e50a584
+  languageName: node
+  linkType: hard
+
+"@mui/x-internals@npm:8.26.0":
+  version: 8.26.0
+  resolution: "@mui/x-internals@npm:8.26.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.28.4"
+    "@mui/utils": "npm:^7.3.5"
+    reselect: "npm:^5.1.1"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/819564e1b1c7626f5e237edd81f716a3871df1479f2e2e9fbef45a5963df21c510eca4931f6af726fdcd9dc643a019e44c5d61657865b389ef0a2ab5abb10d6c
+  languageName: node
+  linkType: hard
+
+"@mui/x-tree-view@npm:^8.27.2":
+  version: 8.27.2
+  resolution: "@mui/x-tree-view@npm:8.27.2"
+  dependencies:
+    "@babel/runtime": "npm:^7.28.4"
+    "@base-ui/utils": "npm:^0.2.3"
+    "@mui/utils": "npm:^7.3.5"
+    "@mui/x-internals": "npm:8.26.0"
+    "@types/react-transition-group": "npm:^4.4.12"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+    react-transition-group: "npm:^4.4.5"
+  peerDependencies:
+    "@emotion/react": ^11.9.0
+    "@emotion/styled": ^11.8.1
+    "@mui/material": ^5.15.14 || ^6.0.0 || ^7.0.0
+    "@mui/system": ^5.15.14 || ^6.0.0 || ^7.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+  checksum: 10c0/281cf08d9264f898b0ad43ae3ecfdf02c8443abb08877d45140d91c82717b64567ceae7c0513502dd34b844f7de8e00db13cdbb4c8b19859504466d31368cd67
   languageName: node
   linkType: hard
 
@@ -19241,9 +19298,7 @@ __metadata:
     "@kartverket/backstage-plugin-risk-scorecard": "npm:6.0.2"
     "@kartverket/backstage-plugin-security-champion": "workspace:"
     "@kartverket/backstage-plugin-security-metrics-frontend": "workspace:"
-    "@material-ui/core": "npm:^4.12.4"
-    "@material-ui/icons": "npm:^4.11.3"
-    "@material-ui/lab": "npm:^4.0.0-alpha.61"
+    "@mui/x-tree-view": "npm:^8.27.2"
     "@types/react-dom": "npm:^18"
     backstage-plugin-techdocs-addon-mermaid: "npm:^0.23.0"
     jwt-decode: "npm:^4.0.0"
@@ -19252,6 +19307,7 @@ __metadata:
     react-router: "npm:^6.30.3"
     react-router-dom: "npm:^6.30.3"
     react-use: "npm:^17.6.0"
+    tss-react: "npm:^4.9.20"
     zod: "npm:^4.3.5"
   languageName: unknown
   linkType: soft
@@ -40459,6 +40515,28 @@ __metadata:
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
+  languageName: node
+  linkType: hard
+
+"tss-react@npm:^4.9.20":
+  version: 4.9.20
+  resolution: "tss-react@npm:4.9.20"
+  dependencies:
+    "@emotion/cache": "npm:*"
+    "@emotion/serialize": "npm:*"
+    "@emotion/utils": "npm:*"
+  peerDependencies:
+    "@emotion/react": ^11.4.1
+    "@emotion/server": ^11.4.0
+    "@mui/material": ^5.0.0 || ^6.0.0 || ^7.0.0
+    "@types/react": ^16.8.0 || ^17.0.2 || ^18.0.0 || ^19.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/server":
+      optional: true
+    "@mui/material":
+      optional: true
+  checksum: 10c0/90095c969eaa6db893ea9ddb078b76e9668740a55aa8efc95086097cc818c5fc0b48c003d44892980db7665256487db19a39dad46e2952c3d554f7e1e361e8d9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7090,6 +7090,7 @@ __metadata:
     "@backstage/theme": "backstage:^"
     "@backstage/types": "backstage:^"
     "@backstage/ui": "backstage:^"
+    "@mui/icons-material": "npm:^7.3.7"
     "@mui/material": "npm:^7.3.7"
     "@tanstack/react-query": "npm:^5.90.20"
     "@testing-library/jest-dom": "npm:^6.9.1"


### PR DESCRIPTION
## Summary

This PR migrates all MUI v4 (@material-ui/*) imports to MUI v5+ (@mui/*) equivalents.

## Changes

### Dependencies
- Removed `@material-ui/core`, `@material-ui/icons`, `@material-ui/lab` from all affected packages
- Added `tss-react@^4.9.20` for `makeStyles` migration
- Added `@mui/x-tree-view@^8.27.2` to `packages/app` for TreeView

### Import changes
- `@material-ui/core` → `@mui/material`
- `@material-ui/icons/*` → `@mui/icons-material/*`
- `@material-ui/lab` TreeView/TreeItem → `@mui/x-tree-view`
- `makeStyles` → `tss-react/mui` (with updated call signature)

### TreeView migration
- `TreeView` → `SimpleTreeView` with `slots` prop for icons
- `nodeId` → `itemId` on TreeItem
- `defaultExpanded` → `defaultExpandedItems`