### PR TITLE
chore: upgrade MUI to v7.3.9 across monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,9 @@
   "resolutions": {
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "@mui/material": "5.16.4",
+    "@mui/material": "7.3.9",
+    "@mui/system": "7.3.9",
+    "@mui/icons-material": "7.3.9",
     "jsonpath-plus": "^10.2.0",
     "jws": "^4.0.1",
     "tar": "^7.5.7",
@@ -86,7 +88,6 @@
     ]
   },
   "dependencies": {
-    "@mui/material": "^6.1.5",
     "@types/react": "^18"
   },
   "packageManager": "yarn@4.9.1+sha512.f95ce356460e05be48d66401c1ae64ef84d163dd689964962c6888a9810865e39097a5e9de748876c2e0bf89b232d583c33982773e9903ae7a76257270986538"

--- a/plugins/catalog-creator/package.json
+++ b/plugins/catalog-creator/package.json
@@ -36,7 +36,6 @@
     "@backstage/theme": "backstage:^",
     "@backstage/ui": "backstage:^",
     "@hookform/resolvers": "^5.2.2",
-    "@mui/icons-material": "^7.3.7",
     "@octokit/core": "^7.0.6",
     "@octokit/rest": "^22.0.1",
     "octokit-plugin-create-pull-request": "^6.0.1",
@@ -45,10 +44,8 @@
     "yaml": "^2.8.2"
   },
   "peerDependencies": {
-    "@material-ui/core": "^4.9.13",
-    "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "^4.0.0-alpha.61",
-    "@mui/material": "^5.16.4",
+    "@mui/icons-material": "7.3.9",
+    "@mui/material": "7.3.9",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "zod": "^3.25.0 || ^4.0.0"
   },

--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { Box, Flex, Link } from '@backstage/ui';
 import { Content, SupportButton } from '@backstage/core-components';
 import { githubAuthApiRef, OAuthApi, useApi } from '@backstage/core-plugin-api';
-import { useTheme } from '@material-ui/core/styles';
+import { useTheme } from '@mui/material/styles';
 import CircularProgress from '@mui/material/CircularProgress';
 
 import { CatalogForm } from '../CatalogForm';
@@ -190,7 +190,7 @@ export const CatalogCreatorPage = ({
                         {/* Submission Loading Overlay */}
                         {state.loading && (
                           <LoadingOverlay
-                            isDarkTheme={theme.palette.type === 'dark'}
+                            isDarkTheme={theme.palette.mode === 'dark'}
                           />
                         )}
                         <CatalogForm

--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/RepositoryForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/RepositoryForm.tsx
@@ -3,7 +3,7 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { catalogCreatorTranslationRef } from '../../utils/translations';
 import style from '../../catalog.module.css';
 import EditDocumentIcon from '@mui/icons-material/EditDocument';
-import Link from '@material-ui/core/Link';
+import Link from '@mui/material/Link';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 
 interface RepositoryFormProps {

--- a/plugins/catalog-creator/src/components/CatalogForm/FieldHeader.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/FieldHeader.tsx
@@ -1,5 +1,5 @@
 import { Flex } from '@backstage/ui';
-import { Tooltip } from '@material-ui/core';
+import Tooltip from '@mui/material/Tooltip';
 import { InfoOutlined } from '@mui/icons-material';
 
 import style from '../../catalog.module.css';

--- a/plugins/frontend-custom-components/package.json
+++ b/plugins/frontend-custom-components/package.json
@@ -36,10 +36,8 @@
     "@backstage/theme": "backstage:^",
     "@backstage/types": "backstage:^",
     "@backstage/ui": "backstage:^",
-    "@material-ui/core": "^4.12.4",
-    "@material-ui/icons": "^4.11.3",
-    "@material-ui/lab": "^4.0.0-alpha.61",
-    "@mui/material": "^7.3.7",
+    "@mui/icons-material": "7.3.9",
+    "@mui/material": "7.3.9",
     "@tanstack/react-query": "^5.90.20",
     "react-use": "^17.6.0",
     "remixicon": "^4.8.0"

--- a/plugins/frontend-custom-components/src/components/AboutCard/AboutField.tsx
+++ b/plugins/frontend-custom-components/src/components/AboutCard/AboutField.tsx
@@ -15,27 +15,26 @@
  */
 
 import { useElementFilter } from '@backstage/core-plugin-api';
-import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/core/styles';
+import Grid from '@mui/material/Grid';
+import Typography from '@mui/material/Typography';
+import { styled } from '@mui/material/styles';
 import { ReactNode } from 'react';
 
-const useStyles = makeStyles(theme => ({
-  value: {
-    fontWeight: 'bold',
-    overflow: 'hidden',
-    lineHeight: '24px',
-    wordBreak: 'break-word',
-  },
-  label: {
-    color: theme.palette.text.secondary,
-    textTransform: 'uppercase',
-    fontSize: '10px',
-    fontWeight: 'bold',
-    letterSpacing: 0.5,
-    overflow: 'hidden',
-    whiteSpace: 'nowrap',
-  },
+const ValueTypography = styled(Typography)({
+  fontWeight: 'bold',
+  overflow: 'hidden',
+  lineHeight: '24px',
+  wordBreak: 'break-word',
+});
+
+const LabelTypography = styled(Typography)(({ theme }) => ({
+  color: theme.palette.text.secondary,
+  textTransform: 'uppercase',
+  fontSize: '10px',
+  fontWeight: 'bold',
+  letterSpacing: 0.5,
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
 }));
 
 /**
@@ -54,7 +53,6 @@ export interface AboutFieldProps {
 /** @public */
 export function AboutField(props: AboutFieldProps) {
   const { label, value, gridSizes, children, className } = props;
-  const classes = useStyles();
 
   const childElements = useElementFilter(children, c => c.getElements());
 
@@ -63,15 +61,11 @@ export function AboutField(props: AboutFieldProps) {
     childElements.length > 0 ? (
       childElements
     ) : (
-      <Typography variant="body2" className={classes.value}>
-        {value || `unknown`}
-      </Typography>
+      <ValueTypography variant="body2">{value || `unknown`}</ValueTypography>
     );
   return (
-    <Grid item {...gridSizes} className={className}>
-      <Typography variant="h2" className={classes.label}>
-        {label}
-      </Typography>
+    <Grid size={gridSizes} className={className}>
+      <LabelTypography variant="h2">{label}</LabelTypography>
       {content}
     </Grid>
   );

--- a/plugins/frontend-custom-components/src/components/AboutCard/FunctionAboutCard.tsx
+++ b/plugins/frontend-custom-components/src/components/AboutCard/FunctionAboutCard.tsx
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import { useCallback } from 'react';
+import { useCallback, ElementType } from 'react';
 
-import { makeStyles } from '@material-ui/core/styles';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
-import CardHeader from '@material-ui/core/CardHeader';
-import Divider from '@material-ui/core/Divider';
-import IconButton from '@material-ui/core/IconButton';
-import CachedIcon from '@material-ui/icons/Cached';
-import EditIcon from '@material-ui/icons/Edit';
+import { styled } from '@mui/material/styles';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CardHeader from '@mui/material/CardHeader';
+import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+import CachedIcon from '@mui/icons-material/Cached';
+import EditIcon from '@mui/icons-material/Edit';
 
 import { AppIcon, InfoCardVariants, Link } from '@backstage/core-components';
 import {
@@ -61,24 +61,25 @@ const createFromTemplateRouteRef = createExternalRouteRef({
 // TODO: This hook is duplicated from the Scaffolder plugin for backwards compatibility
 // Remove it when the the legacy frontend system support is dropped.
 
-const useStyles = makeStyles({
-  gridItemCard: {
-    display: 'flex',
-    flexDirection: 'column',
-    height: 'calc(100% - 10px)', // for pages without content header
-    marginBottom: '10px',
-  },
-  fullHeightCard: {
-    display: 'flex',
-    flexDirection: 'column',
-    height: '100%',
-  },
-  gridItemCardContent: {
-    flex: 1,
-  },
-  fullHeightCardContent: {
-    flex: 1,
-  },
+const GridItemCard = styled(Card)({
+  display: 'flex',
+  flexDirection: 'column',
+  height: 'calc(100% - 10px)', // for pages without content header
+  marginBottom: '10px',
+});
+
+const FullHeightCard = styled(Card)({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+});
+
+const GridItemCardContent = styled(CardContent)({
+  flex: 1,
+});
+
+const FullHeightCardContent = styled(CardContent)({
+  flex: 1,
 });
 
 /**
@@ -97,7 +98,6 @@ export interface InternalAboutCardProps extends AboutCardProps {
 
 export function InternalAboutCard(props: InternalAboutCardProps) {
   const { variant } = props;
-  const classes = useStyles();
   const { entity } = useEntity();
   const catalogApi = useApi(catalogApiRef);
   const alertApi = useApi(alertApiRef);
@@ -112,19 +112,19 @@ export function InternalAboutCard(props: InternalAboutCardProps) {
   const entityMetadataEditUrl =
     entity.metadata.annotations?.[ANNOTATION_EDIT_URL];
 
-  let cardClass = '';
-  if (variant === 'gridItem') {
-    cardClass = classes.gridItemCard;
-  } else if (variant === 'fullHeight') {
-    cardClass = classes.fullHeightCard;
-  }
+  const getCardComponent = (): ElementType => {
+    if (variant === 'gridItem') return GridItemCard;
+    if (variant === 'fullHeight') return FullHeightCard;
+    return Card;
+  };
+  const CardComponent = getCardComponent();
 
-  let cardContentClass = '';
-  if (variant === 'gridItem') {
-    cardContentClass = classes.gridItemCardContent;
-  } else if (variant === 'fullHeight') {
-    cardContentClass = classes.fullHeightCardContent;
-  }
+  const getCardContentComponent = (): ElementType => {
+    if (variant === 'gridItem') return GridItemCardContent;
+    if (variant === 'fullHeight') return FullHeightCardContent;
+    return CardContent;
+  };
+  const CardContentComponent = getCardContentComponent();
 
   const entityLocation = entity.metadata.annotations?.[ANNOTATION_LOCATION];
   // Limiting the ability to manually refresh to the less expensive locations
@@ -144,7 +144,7 @@ export function InternalAboutCard(props: InternalAboutCardProps) {
   }, [catalogApi, entity, alertApi, t, errorApi]);
 
   return (
-    <Card className={cardClass}>
+    <CardComponent>
       <CardHeader
         title={props.title ?? t('aboutCard.title')}
         action={
@@ -183,10 +183,10 @@ export function InternalAboutCard(props: InternalAboutCardProps) {
         }
       />
       <Divider />
-      <CardContent className={cardContentClass}>
+      <CardContentComponent>
         <AboutContent entity={entity} />
-      </CardContent>
-    </Card>
+      </CardContentComponent>
+    </CardComponent>
   );
 }
 

--- a/plugins/frontend-custom-components/src/components/AboutCard/FunctionAboutContent.tsx
+++ b/plugins/frontend-custom-components/src/components/AboutCard/FunctionAboutContent.tsx
@@ -25,20 +25,13 @@ import {
   getEntityRelations,
 } from '@backstage/plugin-catalog-react';
 import { JsonArray } from '@backstage/types';
-import Chip from '@material-ui/core/Chip';
-import Grid from '@material-ui/core/Grid';
-import { makeStyles } from '@material-ui/core/styles';
+import Chip from '@mui/material/Chip';
+import Grid from '@mui/material/Grid';
 import { MarkdownContent } from '@backstage/core-components';
 import { AboutField } from './AboutField';
 import { LinksGridList } from './LinksGridList';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { catalogTranslationRef } from './translation';
-
-const useStyles = makeStyles({
-  description: {
-    wordBreak: 'break-word',
-  },
-});
 
 /**
  * Props for {@link AboutContent}.
@@ -76,7 +69,6 @@ function getLocationTargetHref(
 /** @public */
 export function AboutContent(props: AboutContentProps) {
   const { entity } = props;
-  const classes = useStyles();
   const { t } = useTranslationRef(catalogTranslationRef);
 
   const isSystem = entity.kind.toLocaleLowerCase('en-US') === 'system';
@@ -122,7 +114,6 @@ export function AboutContent(props: AboutContentProps) {
         gridSizes={{ xs: 12 }}
       >
         <MarkdownContent
-          className={classes.description}
           content={
             entity?.metadata?.description ||
             t('aboutCard.descriptionField.value')
@@ -132,7 +123,6 @@ export function AboutContent(props: AboutContentProps) {
       <AboutField
         label={t('aboutCard.ownerField.label')}
         value={t('aboutCard.ownerField.value')}
-        className={classes.description}
         gridSizes={{ xs: 12, sm: 6, lg: 4 }}
       >
         {ownedByRelations.length > 0 && (

--- a/plugins/frontend-custom-components/src/components/AboutCard/IconLink.tsx
+++ b/plugins/frontend-custom-components/src/components/AboutCard/IconLink.tsx
@@ -14,21 +14,19 @@
  * limitations under the License.
  */
 
-import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/core/styles';
-import LanguageIcon from '@material-ui/icons/Language';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { styled } from '@mui/material/styles';
+import LanguageIcon from '@mui/icons-material/Language';
 import { Link } from '@backstage/core-components';
 import { IconComponent } from '@backstage/core-plugin-api';
 
-const useStyles = makeStyles({
-  svgIcon: {
+const SvgIconWrapper = styled('div')({
+  display: 'inline-block',
+  '& svg': {
     display: 'inline-block',
-    '& svg': {
-      display: 'inline-block',
-      fontSize: 'inherit',
-      verticalAlign: 'baseline',
-    },
+    fontSize: 'inherit',
+    verticalAlign: 'baseline',
   },
 });
 
@@ -38,14 +36,15 @@ export function IconLink(props: {
   Icon?: IconComponent;
 }) {
   const { href, text, Icon } = props;
-  const classes = useStyles();
 
   return (
     <Box display="flex">
-      <Box mr={1} className={classes.svgIcon}>
-        <Typography component="div">
-          {Icon ? <Icon /> : <LanguageIcon />}
-        </Typography>
+      <Box mr={1}>
+        <SvgIconWrapper>
+          <Typography component="div">
+            {Icon ? <Icon /> : <LanguageIcon />}
+          </Typography>
+        </SvgIconWrapper>
       </Box>
       <Box flexGrow="1">
         <Link to={href} target="_blank" rel="noopener">

--- a/plugins/frontend-custom-components/src/components/AboutCard/LinksGridList.tsx
+++ b/plugins/frontend-custom-components/src/components/AboutCard/LinksGridList.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import ImageList from '@material-ui/core/ImageList';
-import ImageListItem from '@material-ui/core/ImageListItem';
+import ImageList from '@mui/material/ImageList';
+import ImageListItem from '@mui/material/ImageListItem';
 import { IconLink } from './IconLink.tsx';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { useDynamicColumns } from './useDynamicColumns.tsx';

--- a/plugins/frontend-custom-components/src/components/AboutCard/useDynamicColumns.tsx
+++ b/plugins/frontend-custom-components/src/components/AboutCard/useDynamicColumns.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { Theme } from '@material-ui/core/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { Theme } from '@mui/material/styles';
 import { Breakpoint, ColumnBreakpoints } from './LinksGridList';
 
 const colDefaults: ColumnBreakpoints = {

--- a/plugins/frontend-custom-components/src/components/EntityFunctionsCard/EntityFunctionsCard.tsx
+++ b/plugins/frontend-custom-components/src/components/EntityFunctionsCard/EntityFunctionsCard.tsx
@@ -20,7 +20,7 @@ import {
   RELATION_CHILD_OF,
 } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core-plugin-api';
-import Typography from '@material-ui/core/Typography';
+import Typography from '@mui/material/Typography';
 import { useAsync } from 'react-use';
 
 export type EntityFunctionsCardProps = {

--- a/plugins/frontend-custom-components/src/components/FunctionDependenciesCard/FunctionDependenciesCard.tsx
+++ b/plugins/frontend-custom-components/src/components/FunctionDependenciesCard/FunctionDependenciesCard.tsx
@@ -19,7 +19,7 @@ import {
   stringifyEntityRef,
 } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core-plugin-api';
-import Typography from '@material-ui/core/Typography';
+import Typography from '@mui/material/Typography';
 import { useAsync } from 'react-use';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { functionDependenciesCardTranslationRef } from './translations.ts';

--- a/plugins/frontend-custom-components/src/components/FunctionGroupPageCard/FunctionGroupPageCard.tsx
+++ b/plugins/frontend-custom-components/src/components/FunctionGroupPageCard/FunctionGroupPageCard.tsx
@@ -21,7 +21,7 @@ import {
   RELATION_DEPENDS_ON,
 } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core-plugin-api';
-import Typography from '@material-ui/core/Typography';
+import Typography from '@mui/material/Typography';
 import { useAsync } from 'react-use';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { functionGroupPageTranslationRef } from './translation';

--- a/plugins/frontend-custom-components/src/components/FunctionLinksCard/FunctionLinksCard.tsx
+++ b/plugins/frontend-custom-components/src/components/FunctionLinksCard/FunctionLinksCard.tsx
@@ -27,8 +27,8 @@ import { useRegelrettQuery } from '../../hooks/useRegelrettQuery';
 import { useRegelrettCreateContextMutation } from '../../hooks/useRegelrettCreateContextMutation';
 import { useIsGroupMember } from '../../hooks/useIsGroupMember';
 import Alert from '@mui/material/Alert';
-import { makeStyles } from '@material-ui/core/styles';
-import DescriptionOutlinedIcon from '@material-ui/icons/DescriptionOutlined';
+import { styled } from '@mui/material/styles';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
 import { useState, useEffect } from 'react';
 import { configApiRef, useApi } from '@backstage/frontend-plugin-api';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
@@ -40,38 +40,38 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { functionLinkCardTranslationRef } from './translation';
 import { FORM_TYPE_MAP } from '../../constants';
 import { buildFormUrl } from '../../utils/formUrl';
-import Typography from '@material-ui/core/Typography';
+import Typography from '@mui/material/Typography';
 import { isUnauthorizedError } from '../../errors';
 
-const useStyles = makeStyles(theme => ({
-  formList: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: theme.spacing(0.5),
-  },
-  formRow: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-    padding: `${theme.spacing(1)}px ${theme.spacing(1.5)}px`,
-    border: `1px solid ${theme.palette.divider}`,
-    borderRadius: theme.shape.borderRadius,
+const FormList = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(0.5),
+}));
+
+const FormRow = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+  padding: `${theme.spacing(1)} ${theme.spacing(1.5)}`,
+  border: `1px solid ${theme.palette.divider}`,
+  borderRadius: theme.shape.borderRadius,
+  backgroundColor:
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.04)'
+      : 'rgba(0, 0, 0, 0.03)',
+  transition: 'background-color 0.15s ease',
+  '&:hover': {
     backgroundColor:
-      theme.palette.type === 'dark'
-        ? 'rgba(255, 255, 255, 0.04)'
-        : 'rgba(0, 0, 0, 0.03)',
-    transition: 'background-color 0.15s ease',
-    '&:hover': {
-      backgroundColor:
-        theme.palette.type === 'dark'
-          ? 'rgba(255, 255, 255, 0.08)'
-          : 'rgba(0, 0, 0, 0.06)',
-    },
+      theme.palette.mode === 'dark'
+        ? 'rgba(255, 255, 255, 0.08)'
+        : 'rgba(0, 0, 0, 0.06)',
   },
-  formIcon: {
-    color: theme.palette.text.secondary,
-    fontSize: '1.2rem',
-  },
+}));
+
+const StyledFormIcon = styled(DescriptionOutlinedIcon)(({ theme }) => ({
+  color: theme.palette.text.secondary,
+  fontSize: '1.2rem',
 }));
 
 /** @public */
@@ -92,7 +92,6 @@ export const FunctionLinksCard = () => {
 
 function FunctionLinksCardItem(props: EntityLinksCardProps) {
   const { variant } = props;
-  const classes = useStyles();
   const { t } = useTranslationRef(functionLinkCardTranslationRef);
   const config = useApi(configApiRef);
   const catalogApi = useApi(catalogApiRef);
@@ -172,10 +171,10 @@ function FunctionLinksCardItem(props: EntityLinksCardProps) {
   const showData = () => {
     if (data && data.length !== 0 && !error) {
       return (
-        <div className={classes.formList}>
+        <FormList>
           {data.map(({ id, formId }) => (
-            <div key={id} className={classes.formRow}>
-              <DescriptionOutlinedIcon className={classes.formIcon} />
+            <FormRow key={id}>
+              <StyledFormIcon />
               <Link
                 to={buildFormUrl(regelrettBaseUrl, id)}
                 target="_blank"
@@ -183,9 +182,9 @@ function FunctionLinksCardItem(props: EntityLinksCardProps) {
               >
                 {getFormType(formId)}
               </Link>
-            </div>
+            </FormRow>
           ))}
-        </div>
+        </FormList>
       );
     } else if (error) {
       const isUnauthorized = isUnauthorizedError(error);

--- a/plugins/frontend-custom-components/src/components/FunctionLinksCard/IconLink.tsx
+++ b/plugins/frontend-custom-components/src/components/FunctionLinksCard/IconLink.tsx
@@ -14,21 +14,19 @@
  * limitations under the License.
  */
 
-import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/core/styles';
-import LanguageIcon from '@material-ui/icons/Language';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { styled } from '@mui/material/styles';
+import LanguageIcon from '@mui/icons-material/Language';
 import { Link } from '@backstage/core-components';
 import { IconComponent } from '@backstage/core-plugin-api';
 
-const useStyles = makeStyles({
-  svgIcon: {
+const SvgIconWrapper = styled('div')({
+  display: 'inline-block',
+  '& svg': {
     display: 'inline-block',
-    '& svg': {
-      display: 'inline-block',
-      fontSize: 'inherit',
-      verticalAlign: 'baseline',
-    },
+    fontSize: 'inherit',
+    verticalAlign: 'baseline',
   },
 });
 
@@ -38,14 +36,15 @@ export function IconLink(props: {
   Icon?: IconComponent;
 }) {
   const { href, text, Icon } = props;
-  const classes = useStyles();
 
   return (
     <Box display="flex">
-      <Box mr={1} className={classes.svgIcon}>
-        <Typography component="div">
-          {Icon ? <Icon /> : <LanguageIcon />}
-        </Typography>
+      <Box mr={1}>
+        <SvgIconWrapper>
+          <Typography component="div">
+            {Icon ? <Icon /> : <LanguageIcon />}
+          </Typography>
+        </SvgIconWrapper>
       </Box>
       <Box flexGrow="1">
         <Link to={href} target="_blank" rel="noopener">

--- a/plugins/frontend-custom-components/src/components/FunctionLinksCard/LinksGridList.tsx
+++ b/plugins/frontend-custom-components/src/components/FunctionLinksCard/LinksGridList.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import ImageList from '@material-ui/core/ImageList';
-import ImageListItem from '@material-ui/core/ImageListItem';
+import ImageList from '@mui/material/ImageList';
+import ImageListItem from '@mui/material/ImageListItem';
 import { IconLink } from './IconLink';
 import { ColumnBreakpoints } from './types';
 import { useDynamicColumns } from './useDynamicColumns';

--- a/plugins/frontend-custom-components/src/components/FunctionLinksCard/useDynamicColumns.tsx
+++ b/plugins/frontend-custom-components/src/components/FunctionLinksCard/useDynamicColumns.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { Theme } from '@material-ui/core/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { Theme } from '@mui/material/styles';
 import { Breakpoint, ColumnBreakpoints } from './types';
 
 const colDefaults: ColumnBreakpoints = {

--- a/plugins/frontend-custom-components/src/components/GroupFormLinksCard/FunctionFormsTabContent.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupFormLinksCard/FunctionFormsTabContent.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
-import DescriptionOutlinedIcon from '@material-ui/icons/DescriptionOutlined';
-import LayersIcon from '@material-ui/icons/Layers';
+import { styled } from '@mui/material/styles';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
+import LayersIcon from '@mui/icons-material/Layers';
 import { Link } from '@backstage/core-components';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { functionLinkCardTranslationRef } from '../FunctionLinksCard/translation';
@@ -11,75 +11,80 @@ import { RegelrettForm } from '../../types';
 import { CreateFormSection } from './CreateFormSection';
 import { Entity } from '@backstage/catalog-model';
 
-const useStyles = makeStyles(theme => ({
-  scrollContainer: {
-    maxHeight: 400,
-    overflowY: 'auto',
+const ScrollContainer = styled('div')({
+  maxHeight: 400,
+  overflowY: 'auto',
+});
+
+const SectionHeader = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+  padding: `${theme.spacing(1)} 0`,
+  marginTop: theme.spacing(1),
+  '&:first-child': {
+    marginTop: 0,
   },
-  sectionHeader: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-    padding: `${theme.spacing(1)}px 0`,
-    marginTop: theme.spacing(1),
-    '&:first-child': {
-      marginTop: 0,
-    },
-  },
-  sectionIcon: {
-    color: theme.palette.text.secondary,
-    fontSize: '1.2rem',
-  },
-  sectionName: {
-    fontWeight: 600,
-    fontSize: '0.9rem',
-    color: theme.palette.text.primary,
-  },
-  sectionBadge: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    minWidth: 20,
-    height: 20,
-    padding: '0 6px',
-    borderRadius: 10,
-    fontSize: '0.75rem',
-    fontWeight: 600,
+}));
+
+const StyledLayersIcon = styled(LayersIcon)(({ theme }) => ({
+  color: theme.palette.text.secondary,
+  fontSize: '1.2rem',
+}));
+
+const SectionName = styled('span')(({ theme }) => ({
+  fontWeight: 600,
+  fontSize: '0.9rem',
+  color: theme.palette.text.primary,
+}));
+
+const SectionBadge = styled('span')(({ theme }) => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minWidth: 20,
+  height: 20,
+  padding: '0 6px',
+  borderRadius: 10,
+  fontSize: '0.75rem',
+  fontWeight: 600,
+  backgroundColor:
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.12)'
+      : 'rgba(0, 0, 0, 0.08)',
+  color: theme.palette.text.secondary,
+}));
+
+const FormList = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(0.5),
+  marginBottom: theme.spacing(1),
+}));
+
+const FormRow = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+  padding: `${theme.spacing(1)} ${theme.spacing(1.5)}`,
+  border: `1px solid ${theme.palette.divider}`,
+  borderRadius: theme.shape.borderRadius,
+  backgroundColor:
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.04)'
+      : 'rgba(0, 0, 0, 0.03)',
+  transition: 'background-color 0.15s ease',
+  '&:hover': {
     backgroundColor:
-      theme.palette.type === 'dark'
-        ? 'rgba(255, 255, 255, 0.12)'
-        : 'rgba(0, 0, 0, 0.08)',
-    color: theme.palette.text.secondary,
+      theme.palette.mode === 'dark'
+        ? 'rgba(255, 255, 255, 0.08)'
+        : 'rgba(0, 0, 0, 0.06)',
   },
-  formList: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: theme.spacing(0.5),
-    marginBottom: theme.spacing(1),
-  },
-  formRow: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-    padding: `${theme.spacing(1)}px ${theme.spacing(1.5)}px`,
-    border: `1px solid ${theme.palette.divider}`,
-    borderRadius: theme.shape.borderRadius,
-    backgroundColor:
-      theme.palette.type === 'dark'
-        ? 'rgba(255, 255, 255, 0.04)'
-        : 'rgba(0, 0, 0, 0.03)',
-    transition: 'background-color 0.15s ease',
-    '&:hover': {
-      backgroundColor:
-        theme.palette.type === 'dark'
-          ? 'rgba(255, 255, 255, 0.08)'
-          : 'rgba(0, 0, 0, 0.06)',
-    },
-  },
-  formIcon: {
-    color: theme.palette.text.secondary,
-    fontSize: '1.2rem',
-  },
+}));
+
+const StyledFormIcon = styled(DescriptionOutlinedIcon)(({ theme }) => ({
+  color: theme.palette.text.secondary,
+  fontSize: '1.2rem',
 }));
 
 interface FunctionFormsTabContentProps {
@@ -97,7 +102,6 @@ export function FunctionFormsTabContent({
   functionEntities,
   onFormCreated,
 }: FunctionFormsTabContentProps) {
-  const classes = useStyles();
   const { t } = useTranslationRef(functionLinkCardTranslationRef);
   const getFormType = (formId: string) => FORM_TYPE_MAP[formId] || 'Unknown';
 
@@ -131,18 +135,18 @@ export function FunctionFormsTabContent({
       {forms.length === 0 ? (
         <p>{t('groupFormCard.noFunctionForms')}</p>
       ) : (
-        <div className={classes.scrollContainer}>
+        <ScrollContainer>
           {Object.entries(formsByFunction).map(([funcName, funcForms]) => (
             <div key={funcName}>
-              <div className={classes.sectionHeader}>
-                <LayersIcon className={classes.sectionIcon} />
-                <span className={classes.sectionName}>{funcName}</span>
-                <span className={classes.sectionBadge}>{funcForms.length}</span>
-              </div>
-              <div className={classes.formList}>
+              <SectionHeader>
+                <StyledLayersIcon />
+                <SectionName>{funcName}</SectionName>
+                <SectionBadge>{funcForms.length}</SectionBadge>
+              </SectionHeader>
+              <FormList>
                 {funcForms.map(form => (
-                  <div key={form.id} className={classes.formRow}>
-                    <DescriptionOutlinedIcon className={classes.formIcon} />
+                  <FormRow key={form.id}>
+                    <StyledFormIcon />
                     <Link
                       to={buildFormUrl(regelrettBaseUrl, form.id)}
                       target="_blank"
@@ -150,12 +154,12 @@ export function FunctionFormsTabContent({
                     >
                       {getFormType(form.formId)}
                     </Link>
-                  </div>
+                  </FormRow>
                 ))}
-              </div>
+              </FormList>
             </div>
           ))}
-        </div>
+        </ScrollContainer>
       )}
 
       {functionEntities.length > 0 && (

--- a/plugins/frontend-custom-components/src/components/GroupFormLinksCard/GroupFormLinksCard.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupFormLinksCard/GroupFormLinksCard.tsx
@@ -10,75 +10,79 @@ import { useTeamRegelrettQuery } from '../../hooks/useTeamRegelrettQuery';
 import { useIsGroupMember } from '../../hooks/useIsGroupMember';
 import Alert from '@mui/material/Alert';
 import { configApiRef, useApi } from '@backstage/frontend-plugin-api';
-import { makeStyles } from '@material-ui/core/styles';
-import PeopleIcon from '@material-ui/icons/People';
-import LayersIcon from '@material-ui/icons/Layers';
+import { styled } from '@mui/material/styles';
+import PeopleIcon from '@mui/icons-material/People';
+import LayersIcon from '@mui/icons-material/Layers';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { functionLinkCardTranslationRef } from '../FunctionLinksCard/translation';
 import { TeamFormsTabContent } from './TeamFormsTabContent';
 import { FunctionFormsTabContent } from './FunctionFormsTabContent';
 import { isUnauthorizedError } from '../../errors';
 
-const useStyles = makeStyles(theme => ({
-  tabContainer: {
-    display: 'flex',
-    gap: theme.spacing(1),
-    marginBottom: theme.spacing(2),
-  },
-  tab: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-    padding: `${theme.spacing(1)}px ${theme.spacing(2)}px`,
-    borderRadius: 20,
-    border: 'none',
-    cursor: 'pointer',
-    fontSize: 'var(--bui-font-size-3)',
-    fontWeight: 500,
-    fontFamily: theme.typography.fontFamily,
-    transition: 'all 0.2s ease',
-    '&:hover': {
-      opacity: 0.85,
-    },
-  },
-  activeTab: {
-    backgroundColor: theme.palette.primary.main,
-    color: theme.palette.primary.contrastText,
-  },
-  inactiveTab: {
-    backgroundColor:
-      theme.palette.type === 'dark'
-        ? 'rgba(255, 255, 255, 0.08)'
-        : 'rgba(0, 0, 0, 0.06)',
-    color: theme.palette.text.secondary,
-  },
-  badge: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    minWidth: 20,
-    height: 20,
-    padding: '0 6px',
-    borderRadius: 10,
-    fontSize: '0.75rem',
-    fontWeight: 600,
-    lineHeight: 1,
-  },
-  activeBadge: {
-    backgroundColor: 'rgba(255, 255, 255, 0.25)',
-    color: theme.palette.primary.contrastText,
-  },
-  inactiveBadge: {
-    backgroundColor:
-      theme.palette.type === 'dark'
-        ? 'rgba(255, 255, 255, 0.12)'
-        : 'rgba(0, 0, 0, 0.1)',
-    color: theme.palette.text.secondary,
-  },
-  icon: {
-    fontSize: '1.1rem',
+const TabContainer = styled('div')(({ theme }) => ({
+  display: 'flex',
+  gap: theme.spacing(1),
+  marginBottom: theme.spacing(2),
+}));
+
+const Tab = styled('button')(({ theme }) => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+  padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
+  borderRadius: 20,
+  border: 'none',
+  cursor: 'pointer',
+  fontSize: 'var(--bui-font-size-3)',
+  fontWeight: 500,
+  fontFamily: theme.typography.fontFamily,
+  transition: 'all 0.2s ease',
+  '&:hover': {
+    opacity: 0.85,
   },
 }));
+
+const ActiveTab = styled(Tab)(({ theme }) => ({
+  backgroundColor: theme.palette.primary.main,
+  color: theme.palette.primary.contrastText,
+}));
+
+const InactiveTab = styled(Tab)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.08)'
+      : 'rgba(0, 0, 0, 0.06)',
+  color: theme.palette.text.secondary,
+}));
+
+const TabBadge = styled('span')({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minWidth: 20,
+  height: 20,
+  padding: '0 6px',
+  borderRadius: 10,
+  fontSize: '0.75rem',
+  fontWeight: 600,
+  lineHeight: 1,
+});
+
+const ActiveBadge = styled(TabBadge)(({ theme }) => ({
+  backgroundColor: 'rgba(255, 255, 255, 0.25)',
+  color: theme.palette.primary.contrastText,
+}));
+
+const InactiveBadge = styled(TabBadge)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.12)'
+      : 'rgba(0, 0, 0, 0.1)',
+  color: theme.palette.text.secondary,
+}));
+
+const StyledPeopleIcon = styled(PeopleIcon)({ fontSize: '1.1rem' });
+const StyledLayersIcon = styled(LayersIcon)({ fontSize: '1.1rem' });
 
 const queryClient = new QueryClient();
 
@@ -91,7 +95,6 @@ export const GroupFormLinksCard = () => {
 };
 
 function GroupFormLinksCardWrapper() {
-  const classes = useStyles();
   const { t } = useTranslationRef(functionLinkCardTranslationRef);
   const config = useApi(configApiRef);
   const catalogApi = useApi(catalogApiRef);
@@ -165,34 +168,37 @@ function GroupFormLinksCardWrapper() {
     }
     return (
       <>
-        <div className={classes.tabContainer}>
-          <button
-            type="button"
-            className={`${classes.tab} ${activeTab === 'team' ? classes.activeTab : classes.inactiveTab}`}
-            onClick={() => setActiveTab('team')}
-          >
-            <PeopleIcon className={classes.icon} />
-            {t('groupFormCard.teamTab')}
-            <span
-              className={`${classes.badge} ${activeTab === 'team' ? classes.activeBadge : classes.inactiveBadge}`}
+        <TabContainer>
+          {activeTab === 'team' ? (
+            <ActiveTab type="button" onClick={() => setActiveTab('team')}>
+              <StyledPeopleIcon />
+              {t('groupFormCard.teamTab')}
+              <ActiveBadge>{teamForms.length}</ActiveBadge>
+            </ActiveTab>
+          ) : (
+            <InactiveTab type="button" onClick={() => setActiveTab('team')}>
+              <StyledPeopleIcon />
+              {t('groupFormCard.teamTab')}
+              <InactiveBadge>{teamForms.length}</InactiveBadge>
+            </InactiveTab>
+          )}
+          {activeTab === 'functions' ? (
+            <ActiveTab type="button" onClick={() => setActiveTab('functions')}>
+              <StyledLayersIcon />
+              {t('groupFormCard.functionsTab')}
+              <ActiveBadge>{functionForms.length}</ActiveBadge>
+            </ActiveTab>
+          ) : (
+            <InactiveTab
+              type="button"
+              onClick={() => setActiveTab('functions')}
             >
-              {teamForms.length}
-            </span>
-          </button>
-          <button
-            type="button"
-            className={`${classes.tab} ${activeTab === 'functions' ? classes.activeTab : classes.inactiveTab}`}
-            onClick={() => setActiveTab('functions')}
-          >
-            <LayersIcon className={classes.icon} />
-            {t('groupFormCard.functionsTab')}
-            <span
-              className={`${classes.badge} ${activeTab === 'functions' ? classes.activeBadge : classes.inactiveBadge}`}
-            >
-              {functionForms.length}
-            </span>
-          </button>
-        </div>
+              <StyledLayersIcon />
+              {t('groupFormCard.functionsTab')}
+              <InactiveBadge>{functionForms.length}</InactiveBadge>
+            </InactiveTab>
+          )}
+        </TabContainer>
         {activeTab === 'team' ? (
           <TeamFormsTabContent
             forms={teamForms}

--- a/plugins/frontend-custom-components/src/components/GroupFormLinksCard/IconLink.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupFormLinksCard/IconLink.tsx
@@ -14,20 +14,18 @@
  * limitations under the License.
  */
 
-import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/core/styles';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { styled } from '@mui/material/styles';
 import { Link } from '@backstage/core-components';
 import { IconComponent } from '@backstage/core-plugin-api';
 
-const useStyles = makeStyles({
-  svgIcon: {
+const SvgIconWrapper = styled('div')({
+  display: 'inline-block',
+  '& svg': {
     display: 'inline-block',
-    '& svg': {
-      display: 'inline-block',
-      fontSize: 'inherit',
-      verticalAlign: 'baseline',
-    },
+    fontSize: 'inherit',
+    verticalAlign: 'baseline',
   },
 });
 
@@ -37,15 +35,16 @@ export function IconLink(props: {
   Icon?: IconComponent;
 }) {
   const { href, text, Icon } = props;
-  const classes = useStyles();
 
   return (
     <Box display="flex">
       {Icon && (
-        <Box mr={1} className={classes.svgIcon}>
-          <Typography component="div">
-            <Icon />
-          </Typography>
+        <Box mr={1}>
+          <SvgIconWrapper>
+            <Typography component="div">
+              <Icon />
+            </Typography>
+          </SvgIconWrapper>
         </Box>
       )}
       <Box flexGrow="1">

--- a/plugins/frontend-custom-components/src/components/GroupFormLinksCard/LinksGridList.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupFormLinksCard/LinksGridList.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import ImageList from '@material-ui/core/ImageList';
-import ImageListItem from '@material-ui/core/ImageListItem';
+import ImageList from '@mui/material/ImageList';
+import ImageListItem from '@mui/material/ImageListItem';
 import { IconLink } from './IconLink';
 import { ColumnBreakpoints } from './types';
 import { useDynamicColumns } from './useDynamicColumns';

--- a/plugins/frontend-custom-components/src/components/GroupFormLinksCard/TeamFormsTabContent.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupFormLinksCard/TeamFormsTabContent.tsx
@@ -1,5 +1,5 @@
-import { makeStyles } from '@material-ui/core/styles';
-import DescriptionOutlinedIcon from '@material-ui/icons/DescriptionOutlined';
+import { styled } from '@mui/material/styles';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
 import { Link } from '@backstage/core-components';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { functionLinkCardTranslationRef } from '../FunctionLinksCard/translation';
@@ -8,35 +8,35 @@ import { buildFormUrl } from '../../utils/formUrl';
 import { RegelrettForm } from '../../types';
 import { CreateFormSection } from './CreateFormSection';
 
-const useStyles = makeStyles(theme => ({
-  formList: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: theme.spacing(0.5),
-  },
-  formRow: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-    padding: `${theme.spacing(1)}px ${theme.spacing(1.5)}px`,
-    border: `1px solid ${theme.palette.divider}`,
-    borderRadius: theme.shape.borderRadius,
+const FormList = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(0.5),
+}));
+
+const FormRow = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+  padding: `${theme.spacing(1)} ${theme.spacing(1.5)}`,
+  border: `1px solid ${theme.palette.divider}`,
+  borderRadius: theme.shape.borderRadius,
+  backgroundColor:
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.04)'
+      : 'rgba(0, 0, 0, 0.03)',
+  transition: 'background-color 0.15s ease',
+  '&:hover': {
     backgroundColor:
-      theme.palette.type === 'dark'
-        ? 'rgba(255, 255, 255, 0.04)'
-        : 'rgba(0, 0, 0, 0.03)',
-    transition: 'background-color 0.15s ease',
-    '&:hover': {
-      backgroundColor:
-        theme.palette.type === 'dark'
-          ? 'rgba(255, 255, 255, 0.08)'
-          : 'rgba(0, 0, 0, 0.06)',
-    },
+      theme.palette.mode === 'dark'
+        ? 'rgba(255, 255, 255, 0.08)'
+        : 'rgba(0, 0, 0, 0.06)',
   },
-  formIcon: {
-    color: theme.palette.text.secondary,
-    fontSize: '1.2rem',
-  },
+}));
+
+const StyledFormIcon = styled(DescriptionOutlinedIcon)(({ theme }) => ({
+  color: theme.palette.text.secondary,
+  fontSize: '1.2rem',
 }));
 
 interface TeamFormsTabContentProps {
@@ -54,7 +54,6 @@ export function TeamFormsTabContent({
   teamName,
   onFormCreated,
 }: TeamFormsTabContentProps) {
-  const classes = useStyles();
   const { t } = useTranslationRef(functionLinkCardTranslationRef);
   const getFormType = (formId: string) => FORM_TYPE_MAP[formId] || 'Unknown';
 
@@ -68,10 +67,10 @@ export function TeamFormsTabContent({
       {forms.length === 0 ? (
         <p>{t('groupFormCard.noTeamForms')}</p>
       ) : (
-        <div className={classes.formList}>
+        <FormList>
           {forms.map(form => (
-            <div key={form.id} className={classes.formRow}>
-              <DescriptionOutlinedIcon className={classes.formIcon} />
+            <FormRow key={form.id}>
+              <StyledFormIcon />
               <Link
                 to={buildFormUrl(regelrettBaseUrl, form.id)}
                 target="_blank"
@@ -79,9 +78,9 @@ export function TeamFormsTabContent({
               >
                 {`${form.name} – ${getFormType(form.formId)}`}
               </Link>
-            </div>
+            </FormRow>
           ))}
-        </div>
+        </FormList>
       )}
 
       {availableFormOptions.length > 0 && (

--- a/plugins/frontend-custom-components/src/components/GroupFormLinksCard/useDynamicColumns.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupFormLinksCard/useDynamicColumns.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { Theme } from '@material-ui/core/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { Theme } from '@mui/material/styles';
 import { Breakpoint, ColumnBreakpoints } from './types';
 
 const colDefaults: ColumnBreakpoints = {

--- a/plugins/security-champion/package.json
+++ b/plugins/security-champion/package.json
@@ -35,13 +35,13 @@
     "@backstage/plugin-catalog-react": "backstage:^",
     "@backstage/theme": "backstage:^",
     "@backstage/ui": "backstage:^",
-    "@mui/icons-material": "^7.3.7",
     "@tanstack/react-query": "^5.84.1",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
-    "@mui/material": "5.16.4",
-    "@mui/system": "5.16.4",
+    "@mui/icons-material": "7.3.9",
+    "@mui/material": "7.3.9",
+    "@mui/system": "7.3.9",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {

--- a/plugins/security-metrics/package.json
+++ b/plugins/security-metrics/package.json
@@ -37,12 +37,6 @@
     "@backstage/theme": "backstage:^",
     "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.14.0",
-    "@emotion/styled": "^11.14.1",
-    "@mui/icons-material": "^7.3.7",
-    "@mui/material": "^7.3.7",
-    "@mui/system": "^7.3.7",
-    "@mui/x-charts": "^8.25.0",
-    "@mui/x-date-pickers": "^8.25.0",
     "@tanstack/react-query": "^5.90.17",
     "@tanstack/react-query-devtools": "^5.91.2",
     "date-fns": "^4.1.0",
@@ -50,6 +44,9 @@
     "recharts": "^3.6.0"
   },
   "peerDependencies": {
+    "@mui/icons-material": "7.3.9",
+    "@mui/material": "7.3.9",
+    "@mui/system": "7.3.9",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3"

--- a/plugins/security-metrics/src/hooks/usePagination.ts
+++ b/plugins/security-metrics/src/hooks/usePagination.ts
@@ -1,6 +1,4 @@
 import { TablePaginationProps } from '@mui/material/TablePagination';
-// eslint-disable-next-line no-restricted-imports
-import TablePaginationActions from '@mui/material/TablePagination/TablePaginationActions';
 import { ChangeEvent, useState } from 'react';
 import type { MouseEvent as ReactMouseEvent } from 'react';
 
@@ -49,7 +47,6 @@ export const usePaginationProps = (
     onPageChange,
     onRowsPerPageChange,
     rowsPerPageOptions: rowsPerPageOptions,
-    ActionsComponent: TablePaginationActions,
     slotProps: slotProps,
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1715,7 +1715,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.28.6, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.28.6
   resolution: "@babel/runtime@npm:7.28.6"
   checksum: 10c0/358cf2429992ac1c466df1a21c1601d595c46930a13c1d4662fde908d44ee78ec3c183aaff513ecb01ef8c55c3624afe0309eeeb34715672dbfadb7feedb2c0d
@@ -5587,7 +5587,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/cache@npm:^11.13.5, @emotion/cache@npm:^11.14.0":
+"@emotion/cache@npm:^11.14.0":
   version: 11.14.0
   resolution: "@emotion/cache@npm:11.14.0"
   dependencies:
@@ -5687,7 +5687,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/styled@npm:^11.10.5, @emotion/styled@npm:^11.13.0, @emotion/styled@npm:^11.14.0, @emotion/styled@npm:^11.14.1":
+"@emotion/styled@npm:^11.10.5, @emotion/styled@npm:^11.13.0, @emotion/styled@npm:^11.14.0":
   version: 11.14.1
   resolution: "@emotion/styled@npm:11.14.1"
   dependencies:
@@ -7074,7 +7074,7 @@ __metadata:
     "@material-ui/core": "npm:^4.12.4"
     "@material-ui/icons": "npm:^4.11.3"
     "@material-ui/lab": "npm:^4.0.0-alpha.61"
-    "@mui/material": "npm:^7.3.7"
+    "@mui/material": "npm:7.3.9"
     "@tanstack/react-query": "npm:^5.90.20"
     "@testing-library/jest-dom": "npm:^6.9.1"
     "@testing-library/react": "npm:^16.3.1"
@@ -7784,7 +7784,6 @@ __metadata:
     "@backstage/theme": "backstage:^"
     "@backstage/ui": "backstage:^"
     "@hookform/resolvers": "npm:^5.2.2"
-    "@mui/icons-material": "npm:^7.3.7"
     "@octokit/core": "npm:^7.0.6"
     "@octokit/rest": "npm:^22.0.1"
     msw: "npm:^2.12.7"
@@ -7794,10 +7793,8 @@ __metadata:
     react-use: "npm:^17.6.0"
     yaml: "npm:^2.8.2"
   peerDependencies:
-    "@material-ui/core": ^4.9.13
-    "@material-ui/icons": ^4.9.1
-    "@material-ui/lab": ^4.0.0-alpha.61
-    "@mui/material": ^5.16.4
+    "@mui/icons-material": 7.3.9
+    "@mui/material": 7.3.9
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     zod: ^3.25.0 || ^4.0.0
   languageName: unknown
@@ -7879,14 +7876,14 @@ __metadata:
     "@backstage/plugin-catalog-react": "backstage:^"
     "@backstage/theme": "backstage:^"
     "@backstage/ui": "backstage:^"
-    "@mui/icons-material": "npm:^7.3.7"
     "@tanstack/react-query": "npm:^5.84.1"
     msw: "npm:^2.12.7"
     react: "npm:^18"
     react-use: "npm:^17.2.4"
   peerDependencies:
-    "@mui/material": 5.16.4
-    "@mui/system": 5.16.4
+    "@mui/icons-material": 7.3.9
+    "@mui/material": 7.3.9
+    "@mui/system": 7.3.9
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
   languageName: unknown
   linkType: soft
@@ -7930,12 +7927,6 @@ __metadata:
     "@backstage/theme": "backstage:^"
     "@emotion/cache": "npm:^11.14.0"
     "@emotion/react": "npm:^11.14.0"
-    "@emotion/styled": "npm:^11.14.1"
-    "@mui/icons-material": "npm:^7.3.7"
-    "@mui/material": "npm:^7.3.7"
-    "@mui/system": "npm:^7.3.7"
-    "@mui/x-charts": "npm:^8.25.0"
-    "@mui/x-date-pickers": "npm:^8.25.0"
     "@tanstack/eslint-plugin-query": "npm:^5.83.1"
     "@tanstack/react-query": "npm:^5.90.17"
     "@tanstack/react-query-devtools": "npm:^5.91.2"
@@ -7944,6 +7935,9 @@ __metadata:
     react-use: "npm:^17.6.0"
     recharts: "npm:^3.6.0"
   peerDependencies:
+    "@mui/icons-material": 7.3.9
+    "@mui/material": 7.3.9
+    "@mui/system": 7.3.9
     react: ^18.0.0
     react-dom: ^18.0.0
     react-router-dom: ^6.30.3
@@ -8726,58 +8720,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/core-downloads-tracker@npm:^5.16.1, @mui/core-downloads-tracker@npm:^5.16.4":
+"@mui/core-downloads-tracker@npm:^5.16.1":
   version: 5.18.0
   resolution: "@mui/core-downloads-tracker@npm:5.18.0"
   checksum: 10c0/d82962a1b69878cf6a6785b6600302a943d474af00bba50169e207ce0bb5d072f1ed65783c7d5ca940cbe4228ab86bc95bb57545cf2cd039d588f2571bbefe0c
   languageName: node
   linkType: hard
 
-"@mui/icons-material@npm:^5.17.1":
-  version: 5.18.0
-  resolution: "@mui/icons-material@npm:5.18.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.23.9"
-  peerDependencies:
-    "@mui/material": ^5.0.0
-    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/4fc61ea1b8ff276c8545b4f4f3881d9be590af24d8c2cbb076b34ec9a9230fd3147c30dd12399133c8d99c9eb748bd73014fa29b187b94229b90783023af4482
+"@mui/core-downloads-tracker@npm:^7.3.9":
+  version: 7.3.9
+  resolution: "@mui/core-downloads-tracker@npm:7.3.9"
+  checksum: 10c0/3228e049ce76fecc598da19d2db44e81c76c400bcb7c0d31785b35eb2eb1deb2f3193cec5346004d1a5d8dcf70272b3341430cfb84c10488316cca37e301341e
   languageName: node
   linkType: hard
 
-"@mui/icons-material@npm:^6.1.0":
-  version: 6.5.0
-  resolution: "@mui/icons-material@npm:6.5.0"
+"@mui/icons-material@npm:7.3.9":
+  version: 7.3.9
+  resolution: "@mui/icons-material@npm:7.3.9"
   dependencies:
-    "@babel/runtime": "npm:^7.26.0"
+    "@babel/runtime": "npm:^7.28.6"
   peerDependencies:
-    "@mui/material": ^6.5.0
+    "@mui/material": ^7.3.9
     "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10c0/0afec2280e8dde4ff34686481497c4b3ced8193f0038bf8984fd502808c053ba8464c35409def0380424cade1d282f647fac1db7c55046b2b232b0d2c52a589d
-  languageName: node
-  linkType: hard
-
-"@mui/icons-material@npm:^7.3.7":
-  version: 7.3.7
-  resolution: "@mui/icons-material@npm:7.3.7"
-  dependencies:
-    "@babel/runtime": "npm:^7.28.4"
-  peerDependencies:
-    "@mui/material": ^7.3.7
-    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/902a2a942539ac577c0cc9dfce09bed383362eb9e68c8dc6dff179c377ec685b2ae7032baf9ef04ba4ab595302a13455ae2c24ea22fd0ed28768c3b20c62b210
+  checksum: 10c0/2df04e1f3ee2e7a960bd9f0418ac90d33595ebecf30d121b86e0b84bbffa4b8f6bce803ef66f114b23b164f29ee6357d1e3290a867fd10b3a8db505088f06366
   languageName: node
   linkType: hard
 
@@ -8810,45 +8779,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/material@npm:5.16.4":
-  version: 5.16.4
-  resolution: "@mui/material@npm:5.16.4"
+"@mui/material@npm:7.3.9":
+  version: 7.3.9
+  resolution: "@mui/material@npm:7.3.9"
   dependencies:
-    "@babel/runtime": "npm:^7.23.9"
-    "@mui/core-downloads-tracker": "npm:^5.16.4"
-    "@mui/system": "npm:^5.16.4"
-    "@mui/types": "npm:^7.2.15"
-    "@mui/utils": "npm:^5.16.4"
+    "@babel/runtime": "npm:^7.28.6"
+    "@mui/core-downloads-tracker": "npm:^7.3.9"
+    "@mui/system": "npm:^7.3.9"
+    "@mui/types": "npm:^7.4.12"
+    "@mui/utils": "npm:^7.3.9"
     "@popperjs/core": "npm:^2.11.8"
-    "@types/react-transition-group": "npm:^4.4.10"
-    clsx: "npm:^2.1.0"
-    csstype: "npm:^3.1.3"
+    "@types/react-transition-group": "npm:^4.4.12"
+    clsx: "npm:^2.1.1"
+    csstype: "npm:^3.2.3"
     prop-types: "npm:^15.8.1"
-    react-is: "npm:^18.3.1"
+    react-is: "npm:^19.2.3"
     react-transition-group: "npm:^4.4.5"
   peerDependencies:
     "@emotion/react": ^11.5.0
     "@emotion/styled": ^11.3.0
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    "@mui/material-pigment-css": ^7.3.9
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
     "@emotion/react":
       optional: true
     "@emotion/styled":
       optional: true
+    "@mui/material-pigment-css":
+      optional: true
     "@types/react":
       optional: true
-  checksum: 10c0/ab12f3219d3a6b5dd3564e7b3826e283167c64b947774e3e35301419d35cd9875d45d8625e8c145d59fe38c7a7ef110251b11a47b94e5468fa96afbb179d2e1f
+  checksum: 10c0/d486145016e026fda55e626a6e7fb1cf9f3e89c60d2d064e60551a03e7867f82ccc6c7921199f007a218e50aa1e45f5b215193ff6e33faa5fc9f7b55637ce95f
   languageName: node
   linkType: hard
 
-"@mui/private-theming@npm:^5.17.1":
-  version: 5.17.1
-  resolution: "@mui/private-theming@npm:5.17.1"
+"@mui/private-theming@npm:^7.3.9":
+  version: 7.3.9
+  resolution: "@mui/private-theming@npm:7.3.9"
   dependencies:
-    "@babel/runtime": "npm:^7.23.9"
-    "@mui/utils": "npm:^5.17.1"
+    "@babel/runtime": "npm:^7.28.6"
+    "@mui/utils": "npm:^7.3.9"
     prop-types: "npm:^15.8.1"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -8856,54 +8828,15 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10c0/53015616e3497d5fe1b068c49a5f3ebc81160fe4a08a05f1cf61acfe64522a2e6bb3d13110797a5619ceb46dce291dc13b5031cd4bcf4dbf42800b73f98640dd
+  checksum: 10c0/04f9647b62b7c516b743d4f800def768e77f5302f61fe74e6a0e8ce8b111037ac45f866e8c5ad8d1c9390163962872e949c058cec6693b6faa2004302bb70be3
   languageName: node
   linkType: hard
 
-"@mui/private-theming@npm:^7.3.7":
-  version: 7.3.7
-  resolution: "@mui/private-theming@npm:7.3.7"
+"@mui/styled-engine@npm:^7.3.9":
+  version: 7.3.9
+  resolution: "@mui/styled-engine@npm:7.3.9"
   dependencies:
-    "@babel/runtime": "npm:^7.28.4"
-    "@mui/utils": "npm:^7.3.7"
-    prop-types: "npm:^15.8.1"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/aa848bea257f0c4a6a8784ab71aa7189aa31a2a98f02628c783c956a25e759be71a65d7809688c6ac1835504d21e798123aeb3eeaedea1473a16337e60a5d50c
-  languageName: node
-  linkType: hard
-
-"@mui/styled-engine@npm:^5.18.0":
-  version: 5.18.0
-  resolution: "@mui/styled-engine@npm:5.18.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.23.9"
-    "@emotion/cache": "npm:^11.13.5"
-    "@emotion/serialize": "npm:^1.3.3"
-    csstype: "npm:^3.1.3"
-    prop-types: "npm:^15.8.1"
-  peerDependencies:
-    "@emotion/react": ^11.4.1
-    "@emotion/styled": ^11.3.0
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@emotion/react":
-      optional: true
-    "@emotion/styled":
-      optional: true
-  checksum: 10c0/68dad75142eea160fc51abf14915d07afd0e7e7791823f6ea6845b2037fde9de6c17b84247a1f283a1437d130857cb97c1a8474c25c161a934671bc48f205418
-  languageName: node
-  linkType: hard
-
-"@mui/styled-engine@npm:^7.3.7":
-  version: 7.3.7
-  resolution: "@mui/styled-engine@npm:7.3.7"
-  dependencies:
-    "@babel/runtime": "npm:^7.28.4"
+    "@babel/runtime": "npm:^7.28.6"
     "@emotion/cache": "npm:^11.14.0"
     "@emotion/serialize": "npm:^1.3.3"
     "@emotion/sheet": "npm:^1.4.0"
@@ -8918,47 +8851,19 @@ __metadata:
       optional: true
     "@emotion/styled":
       optional: true
-  checksum: 10c0/7350f45ea8314643ffc95430b9cc980d0a88d3144629af1deb2842c9aea62d34d8736dfa8197bb51e28785e56144b252fdbb7904c7800d69c547f479bca87805
+  checksum: 10c0/b7646474880bb0787faffa48703ba16191cca3f88eb09efab3947b4edf7536bf03107909b85011cf4af41188b13d7b6b72c31b470559929e3c4c403007c5ac68
   languageName: node
   linkType: hard
 
-"@mui/system@npm:^5.16.1, @mui/system@npm:^5.16.4":
-  version: 5.18.0
-  resolution: "@mui/system@npm:5.18.0"
+"@mui/system@npm:7.3.9":
+  version: 7.3.9
+  resolution: "@mui/system@npm:7.3.9"
   dependencies:
-    "@babel/runtime": "npm:^7.23.9"
-    "@mui/private-theming": "npm:^5.17.1"
-    "@mui/styled-engine": "npm:^5.18.0"
-    "@mui/types": "npm:~7.2.15"
-    "@mui/utils": "npm:^5.17.1"
-    clsx: "npm:^2.1.0"
-    csstype: "npm:^3.1.3"
-    prop-types: "npm:^15.8.1"
-  peerDependencies:
-    "@emotion/react": ^11.5.0
-    "@emotion/styled": ^11.3.0
-    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@emotion/react":
-      optional: true
-    "@emotion/styled":
-      optional: true
-    "@types/react":
-      optional: true
-  checksum: 10c0/9f5ad15f08c71560e9723b1f136214a0871079a976285f8b813041081850e1f9e2e9fb00766c15814217852694a521a9a91cde3bed95b8062defa8052f69eabf
-  languageName: node
-  linkType: hard
-
-"@mui/system@npm:^7.3.7":
-  version: 7.3.7
-  resolution: "@mui/system@npm:7.3.7"
-  dependencies:
-    "@babel/runtime": "npm:^7.28.4"
-    "@mui/private-theming": "npm:^7.3.7"
-    "@mui/styled-engine": "npm:^7.3.7"
-    "@mui/types": "npm:^7.4.10"
-    "@mui/utils": "npm:^7.3.7"
+    "@babel/runtime": "npm:^7.28.6"
+    "@mui/private-theming": "npm:^7.3.9"
+    "@mui/styled-engine": "npm:^7.3.9"
+    "@mui/types": "npm:^7.4.12"
+    "@mui/utils": "npm:^7.3.9"
     clsx: "npm:^2.1.1"
     csstype: "npm:^3.2.3"
     prop-types: "npm:^15.8.1"
@@ -8974,11 +8879,11 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 10c0/0b020d39812431e29ac20ebc0ce1317750d108633237a27f6fb595824eb1f979ffd283e8a89f2487ea1d658aee18c23d68226f6efa2bdfd621493a4aabcf1e74
+  checksum: 10c0/293e4e76e24d3517f8883fe7e8d1a640775a1e7e11b5e9917cd566238d0b0f71f799829d823a022b30a65c6c6f9257c1274a0aec9015b1b7b8d58b27de9d35d8
   languageName: node
   linkType: hard
 
-"@mui/types@npm:^7.2.14, @mui/types@npm:^7.2.15, @mui/types@npm:^7.4.10":
+"@mui/types@npm:^7.2.14, @mui/types@npm:^7.2.15":
   version: 7.4.10
   resolution: "@mui/types@npm:7.4.10"
   dependencies:
@@ -8989,6 +8894,20 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/2e1e807795dcb6f5bdb62eb49068a7f4414299c62f55ceaaa05925a1d043799216150873c00c02f086fd631f7171c97ea416dc66c099c98649503ee3046dab3d
+  languageName: node
+  linkType: hard
+
+"@mui/types@npm:^7.4.12":
+  version: 7.4.12
+  resolution: "@mui/types@npm:7.4.12"
+  dependencies:
+    "@babel/runtime": "npm:^7.28.6"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/e2247f9c3b8ef08e2eb7494ad8fcaffd8d695655cb355b8c3f23ebecbf69e13fcf73411b0a209fc0750eb416f7d0f7da1aa82557beb9bd58f26f9645f3f2ce95
   languageName: node
   linkType: hard
 
@@ -9004,7 +8923,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/utils@npm:^5.14.15, @mui/utils@npm:^5.15.14, @mui/utils@npm:^5.16.1, @mui/utils@npm:^5.16.4, @mui/utils@npm:^5.17.1":
+"@mui/utils@npm:^5.14.15, @mui/utils@npm:^5.15.14, @mui/utils@npm:^5.16.1":
   version: 5.17.1
   resolution: "@mui/utils@npm:5.17.1"
   dependencies:
@@ -9024,12 +8943,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/utils@npm:^7.3.5, @mui/utils@npm:^7.3.7":
-  version: 7.3.7
-  resolution: "@mui/utils@npm:7.3.7"
+"@mui/utils@npm:^7.3.9":
+  version: 7.3.9
+  resolution: "@mui/utils@npm:7.3.9"
   dependencies:
-    "@babel/runtime": "npm:^7.28.4"
-    "@mui/types": "npm:^7.4.10"
+    "@babel/runtime": "npm:^7.28.6"
+    "@mui/types": "npm:^7.4.12"
     "@types/prop-types": "npm:^15.7.15"
     clsx: "npm:^2.1.1"
     prop-types: "npm:^15.8.1"
@@ -9040,139 +8959,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10c0/2732a01a24968c8fe73b1cf3c7afabffd8a5f13556f3f8078529eaf09d855a05cb7905421b733cb671f771406eb857f5dddb3b82166ecc2a3d0ab1a987954d08
-  languageName: node
-  linkType: hard
-
-"@mui/x-charts-vendor@npm:8.25.0":
-  version: 8.25.0
-  resolution: "@mui/x-charts-vendor@npm:8.25.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.28.4"
-    "@types/d3-array": "npm:^3.2.2"
-    "@types/d3-color": "npm:^3.1.3"
-    "@types/d3-format": "npm:^3.0.4"
-    "@types/d3-interpolate": "npm:^3.0.4"
-    "@types/d3-path": "npm:^3.1.1"
-    "@types/d3-scale": "npm:^4.0.9"
-    "@types/d3-shape": "npm:^3.1.7"
-    "@types/d3-time": "npm:^3.0.4"
-    "@types/d3-time-format": "npm:^4.0.3"
-    "@types/d3-timer": "npm:^3.0.2"
-    d3-array: "npm:^3.2.4"
-    d3-color: "npm:^3.1.0"
-    d3-format: "npm:^3.1.0"
-    d3-interpolate: "npm:^3.0.1"
-    d3-path: "npm:^3.1.0"
-    d3-scale: "npm:^4.0.2"
-    d3-shape: "npm:^3.2.0"
-    d3-time: "npm:^3.1.0"
-    d3-time-format: "npm:^4.1.0"
-    d3-timer: "npm:^3.0.1"
-    flatqueue: "npm:^3.0.0"
-    internmap: "npm:^2.0.3"
-  checksum: 10c0/82efee9fa648efe7f1e085fe3f43b539f8bcf9869fbf6be83b5c4c2a9485df38a215bafa8f1b906b221c9b824ad60e0f4d86dbc1d8342c3798dc6cb72cbb5cfb
-  languageName: node
-  linkType: hard
-
-"@mui/x-charts@npm:^8.25.0":
-  version: 8.25.0
-  resolution: "@mui/x-charts@npm:8.25.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.28.4"
-    "@mui/utils": "npm:^7.3.5"
-    "@mui/x-charts-vendor": "npm:8.25.0"
-    "@mui/x-internal-gestures": "npm:0.4.0"
-    "@mui/x-internals": "npm:8.25.0"
-    bezier-easing: "npm:^2.1.0"
-    clsx: "npm:^2.1.1"
-    prop-types: "npm:^15.8.1"
-    reselect: "npm:^5.1.1"
-    use-sync-external-store: "npm:^1.6.0"
-  peerDependencies:
-    "@emotion/react": ^11.9.0
-    "@emotion/styled": ^11.8.1
-    "@mui/material": ^5.15.14 || ^6.0.0 || ^7.0.0
-    "@mui/system": ^5.15.14 || ^6.0.0 || ^7.0.0
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@emotion/react":
-      optional: true
-    "@emotion/styled":
-      optional: true
-  checksum: 10c0/6b06d2bd8e6697342db15e4ae7eae5ec66f845bcf14e6895ddac3b3e759fa97651b1c8e9f2ecb64fe14cbdbaceb0c865885d6676c933bfbac4afc2c529f472ca
-  languageName: node
-  linkType: hard
-
-"@mui/x-date-pickers@npm:^8.25.0":
-  version: 8.25.0
-  resolution: "@mui/x-date-pickers@npm:8.25.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.28.4"
-    "@mui/utils": "npm:^7.3.5"
-    "@mui/x-internals": "npm:8.25.0"
-    "@types/react-transition-group": "npm:^4.4.12"
-    clsx: "npm:^2.1.1"
-    prop-types: "npm:^15.8.1"
-    react-transition-group: "npm:^4.4.5"
-  peerDependencies:
-    "@emotion/react": ^11.9.0
-    "@emotion/styled": ^11.8.1
-    "@mui/material": ^5.15.14 || ^6.0.0 || ^7.0.0
-    "@mui/system": ^5.15.14 || ^6.0.0 || ^7.0.0
-    date-fns: ^2.25.0 || ^3.2.0 || ^4.0.0
-    date-fns-jalali: ^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0
-    dayjs: ^1.10.7
-    luxon: ^3.0.2
-    moment: ^2.29.4
-    moment-hijri: ^2.1.2 || ^3.0.0
-    moment-jalaali: ^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@emotion/react":
-      optional: true
-    "@emotion/styled":
-      optional: true
-    date-fns:
-      optional: true
-    date-fns-jalali:
-      optional: true
-    dayjs:
-      optional: true
-    luxon:
-      optional: true
-    moment:
-      optional: true
-    moment-hijri:
-      optional: true
-    moment-jalaali:
-      optional: true
-  checksum: 10c0/ce789b06705296479a4db4ca1deb28c4f10e708941c46bef99b4f763691625e28b9f89b9650942ec18d6cb8c04258ef50167b49844cb6a91bb14b0c3ad7cc61c
-  languageName: node
-  linkType: hard
-
-"@mui/x-internal-gestures@npm:0.4.0":
-  version: 0.4.0
-  resolution: "@mui/x-internal-gestures@npm:0.4.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.28.4"
-  checksum: 10c0/29b278a8933b65acd9530a259fd95d6d4a721e4a5c9f34dfab818a13a50fb560959d56519c35fb9a4b5f924aaf38c8f44407b8e82b90754af255fcaad75d0118
-  languageName: node
-  linkType: hard
-
-"@mui/x-internals@npm:8.25.0":
-  version: 8.25.0
-  resolution: "@mui/x-internals@npm:8.25.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.28.4"
-    "@mui/utils": "npm:^7.3.5"
-    reselect: "npm:^5.1.1"
-    use-sync-external-store: "npm:^1.6.0"
-  peerDependencies:
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10c0/d4bb9f3b2ac3a51f8bb473458558ccdf137dbb7866965a90893592fbd8d4efbcd49e54ed39c1733f690b4fdf5dfbd98cfde519739dda163d5dc230fd1e50a584
+  checksum: 10c0/218423d82807bf031ad69cb897ac0d0038b65da1bf282e167d1c195764946964e2bea2dbcbb2c01e143d9cb3a702efe3f5ff3320602a001e6ba5202f82648e3e
   languageName: node
   linkType: hard
 
@@ -17266,7 +17053,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-array@npm:*, @types/d3-array@npm:^3.0.3, @types/d3-array@npm:^3.2.2":
+"@types/d3-array@npm:*, @types/d3-array@npm:^3.0.3":
   version: 3.2.2
   resolution: "@types/d3-array@npm:3.2.2"
   checksum: 10c0/6137cb97302f8a4f18ca22c0560c585cfcb823f276b23d89f2c0c005d72697ec13bca671c08e68b4b0cabd622e3f0e91782ee221580d6774074050be96dd7028
@@ -17298,7 +17085,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-color@npm:*, @types/d3-color@npm:^3.1.3":
+"@types/d3-color@npm:*":
   version: 3.1.3
   resolution: "@types/d3-color@npm:3.1.3"
   checksum: 10c0/65eb0487de606eb5ad81735a9a5b3142d30bc5ea801ed9b14b77cb14c9b909f718c059f13af341264ee189acf171508053342142bdf99338667cea26a2d8d6ae
@@ -17368,7 +17155,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-format@npm:*, @types/d3-format@npm:^3.0.4":
+"@types/d3-format@npm:*":
   version: 3.0.4
   resolution: "@types/d3-format@npm:3.0.4"
   checksum: 10c0/3ac1600bf9061a59a228998f7cd3f29e85cbf522997671ba18d4d84d10a2a1aff4f95aceb143fa9960501c3ec351e113fc75884e6a504ace44dc1744083035ee
@@ -17391,7 +17178,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-interpolate@npm:*, @types/d3-interpolate@npm:^3.0.1, @types/d3-interpolate@npm:^3.0.4":
+"@types/d3-interpolate@npm:*, @types/d3-interpolate@npm:^3.0.1":
   version: 3.0.4
   resolution: "@types/d3-interpolate@npm:3.0.4"
   dependencies:
@@ -17400,7 +17187,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-path@npm:*, @types/d3-path@npm:^3.1.1":
+"@types/d3-path@npm:*":
   version: 3.1.1
   resolution: "@types/d3-path@npm:3.1.1"
   checksum: 10c0/2c36eb31ebaf2ce4712e793fd88087117976f7c4ed69cc2431825f999c8c77cca5cea286f3326432b770739ac6ccd5d04d851eb65e7a4dbcc10c982b49ad2c02
@@ -17435,7 +17222,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-scale@npm:*, @types/d3-scale@npm:^4.0.2, @types/d3-scale@npm:^4.0.9":
+"@types/d3-scale@npm:*, @types/d3-scale@npm:^4.0.2":
   version: 4.0.9
   resolution: "@types/d3-scale@npm:4.0.9"
   dependencies:
@@ -17451,7 +17238,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-shape@npm:*, @types/d3-shape@npm:^3.1.0, @types/d3-shape@npm:^3.1.7":
+"@types/d3-shape@npm:*, @types/d3-shape@npm:^3.1.0":
   version: 3.1.8
   resolution: "@types/d3-shape@npm:3.1.8"
   dependencies:
@@ -17460,21 +17247,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-time-format@npm:*, @types/d3-time-format@npm:^4.0.3":
+"@types/d3-time-format@npm:*":
   version: 4.0.3
   resolution: "@types/d3-time-format@npm:4.0.3"
   checksum: 10c0/9ef5e8e2b96b94799b821eed5d61a3d432c7903247966d8ad951b8ce5797fe46554b425cb7888fa5bf604b4663c369d7628c0328ffe80892156671c58d1a7f90
   languageName: node
   linkType: hard
 
-"@types/d3-time@npm:*, @types/d3-time@npm:^3.0.0, @types/d3-time@npm:^3.0.4":
+"@types/d3-time@npm:*, @types/d3-time@npm:^3.0.0":
   version: 3.0.4
   resolution: "@types/d3-time@npm:3.0.4"
   checksum: 10c0/6d9e2255d63f7a313a543113920c612e957d70da4fb0890931da6c2459010291b8b1f95e149a538500c1c99e7e6c89ffcce5554dd29a31ff134a38ea94b6d174
   languageName: node
   linkType: hard
 
-"@types/d3-timer@npm:*, @types/d3-timer@npm:^3.0.0, @types/d3-timer@npm:^3.0.2":
+"@types/d3-timer@npm:*, @types/d3-timer@npm:^3.0.0":
   version: 3.0.2
   resolution: "@types/d3-timer@npm:3.0.2"
   checksum: 10c0/c644dd9571fcc62b1aa12c03bcad40571553020feeb5811f1d8a937ac1e65b8a04b759b4873aef610e28b8714ac71c9885a4d6c127a048d95118f7e5b506d9e1
@@ -18025,7 +17812,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-transition-group@npm:^4.2.0, @types/react-transition-group@npm:^4.4.10, @types/react-transition-group@npm:^4.4.12":
+"@types/react-transition-group@npm:^4.2.0, @types/react-transition-group@npm:^4.4.12":
   version: 4.4.12
   resolution: "@types/react-transition-group@npm:4.4.12"
   peerDependencies:
@@ -20119,13 +19906,6 @@ __metadata:
     node-gyp: "npm:latest"
     prebuild-install: "npm:^7.1.1"
   checksum: 10c0/a58fb3f7a7f5469ba0b8de0855aa67396ff34f951a6975746e4b21987f530be6a34427d1d4bd5958cf48c67ed7ba1df038ae163d2ee9d944237f6b8112f6640d
-  languageName: node
-  linkType: hard
-
-"bezier-easing@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "bezier-easing@npm:2.1.0"
-  checksum: 10c0/138a160698de3c12501479cc80280d5cc0ab47df73e20d7b5058cba6d62c0876eb97e63aa1e398233269aa2a6bb396fb0ee394da391de7258c9da20729df5158
   languageName: node
   linkType: hard
 
@@ -22325,7 +22105,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.0.10, csstype@npm:^3.0.2, csstype@npm:^3.1.2, csstype@npm:^3.1.3, csstype@npm:^3.2.2, csstype@npm:^3.2.3":
+"csstype@npm:^3.0.10, csstype@npm:^3.0.2, csstype@npm:^3.1.2, csstype@npm:^3.2.2, csstype@npm:^3.2.3":
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
   checksum: 10c0/cd29c51e70fa822f1cecd8641a1445bed7063697469d35633b516e60fe8c1bde04b08f6c5b6022136bb669b64c63d4173af54864510fbb4ee23281801841a3ce
@@ -22377,7 +22157,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:2.5.0 - 3, d3-array@npm:3, d3-array@npm:^3.1.6, d3-array@npm:^3.2.0, d3-array@npm:^3.2.4":
+"d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:2.5.0 - 3, d3-array@npm:3, d3-array@npm:^3.1.6, d3-array@npm:^3.2.0":
   version: 3.2.4
   resolution: "d3-array@npm:3.2.4"
   dependencies:
@@ -22415,7 +22195,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-color@npm:1 - 3, d3-color@npm:3, d3-color@npm:^3.1.0":
+"d3-color@npm:1 - 3, d3-color@npm:3":
   version: 3.1.0
   resolution: "d3-color@npm:3.1.0"
   checksum: 10c0/a4e20e1115fa696fce041fbe13fbc80dc4c19150fa72027a7c128ade980bc0eeeba4bcf28c9e21f0bce0e0dbfe7ca5869ef67746541dcfda053e4802ad19783c
@@ -22505,7 +22285,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-format@npm:1 - 3, d3-format@npm:3, d3-format@npm:^3.1.0":
+"d3-format@npm:1 - 3, d3-format@npm:3":
   version: 3.1.2
   resolution: "d3-format@npm:3.1.2"
   checksum: 10c0/0de452ae07585238e7f01607a7e0066665c34609652188b6ac7dc9f424f69465a425e07d16d79bd0e5955202ac7f241c66d0c76f68a79fc6f4857c94cf420652
@@ -22612,7 +22392,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-shape@npm:3, d3-shape@npm:^3.0.0, d3-shape@npm:^3.1.0, d3-shape@npm:^3.2.0":
+"d3-shape@npm:3, d3-shape@npm:^3.0.0, d3-shape@npm:^3.1.0":
   version: 3.2.0
   resolution: "d3-shape@npm:3.2.0"
   dependencies:
@@ -22630,7 +22410,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-time-format@npm:2 - 4, d3-time-format@npm:4, d3-time-format@npm:^4.1.0":
+"d3-time-format@npm:2 - 4, d3-time-format@npm:4":
   version: 4.1.0
   resolution: "d3-time-format@npm:4.1.0"
   dependencies:
@@ -22639,7 +22419,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-time@npm:1 - 3, d3-time@npm:2.1.1 - 3, d3-time@npm:3, d3-time@npm:^3.0.0, d3-time@npm:^3.1.0":
+"d3-time@npm:1 - 3, d3-time@npm:2.1.1 - 3, d3-time@npm:3, d3-time@npm:^3.0.0":
   version: 3.1.0
   resolution: "d3-time@npm:3.1.0"
   dependencies:
@@ -25232,13 +25012,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatqueue@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "flatqueue@npm:3.0.0"
-  checksum: 10c0/585f4f2c6c3d080b9ef32318258984c5602fb94990886e53c8cf1272ed3629efd64157b1f06b9f0c584b3dc79da547279246027c282ac07e3199ec490dc7c91d
-  languageName: node
-  linkType: hard
-
 "flatstr@npm:^1.0.12":
   version: 1.0.12
   resolution: "flatstr@npm:1.0.12"
@@ -27628,7 +27401,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"internmap@npm:1 - 2, internmap@npm:^2.0.3":
+"internmap@npm:1 - 2":
   version: 2.0.3
   resolution: "internmap@npm:2.0.3"
   checksum: 10c0/8cedd57f07bbc22501516fbfc70447f0c6812871d471096fad9ea603516eacc2137b633633daf432c029712df0baefd793686388ddf5737e3ea15074b877f7ed
@@ -36340,10 +36113,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^19.0.0, react-is@npm:^19.2.3":
+"react-is@npm:^19.0.0":
   version: 19.2.3
   resolution: "react-is@npm:19.2.3"
   checksum: 10c0/2b54c422c21b8dbd68a435a1cce21ecd5b6f06f48659531f7d53dd7368365da5a67e946f352fb2010d11ca40658aa67bec90995f0f1ec5556c0f71dbffe54994
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^19.2.3":
+  version: 19.2.4
+  resolution: "react-is@npm:19.2.4"
+  checksum: 10c0/477a7cfc900f24194606e315fa353856a3a13487ea8eca841678817cad4daef64339ea0d1e84e58459fc75dbe0d9ba00bb0cc626db3d07e0cf31edc64cb4fa37
   languageName: node
   linkType: hard
 
@@ -37963,7 +37743,6 @@ __metadata:
   dependencies:
     "@backstage/cli": "backstage:^"
     "@jest/environment-jsdom-abstract": "npm:^30.2.0"
-    "@mui/material": "npm:^6.1.5"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.0.9"
     "@types/react": "npm:^18"


### PR DESCRIPTION
## Hva er gjort

Alle MUI-pakker i monorepoet er oppgradert og standardisert til versjon **7.3.9** (eksakt pinning, ingen `^`). Tidligere var det en blanding av v4, v5 og v7 på tvers av plugins.

## Endringer

### Versjonsoppgradering
- Root `resolutions` pinner nå `@mui/material`, `@mui/icons-material` og `@mui/system` til eksakt `7.3.9` – dette sikrer at alle pakker i monorepoet får nøyaktig samme versjon
- Fjernet overflødig `@mui/material` fra root `dependencies` (kun nødvendig i `resolutions`)

### Migrering av `frontend-custom-components` fra MUI v4 til v7
Den eneste gjenværende bruken av det gamle `@material-ui/core`-pakkenavnet (v4) er nå migrert:
- `makeStyles` erstattet med `styled()` fra `@mui/material/styles`
- Grid `item`/`xs`-API oppdatert til v7 sitt `size`-prop
- Alle `@material-ui/icons`-imports byttet til `@mui/icons-material`
- `theme.palette.type` → `theme.palette.mode`
- `@material-ui/core`, `@material-ui/icons`, `@material-ui/lab` fjernet fra `dependencies`

### Opprydding i `catalog-creator`
- Erstattet siste tre `@material-ui/core`-imports med v7-ekvivalenter (`Tooltip`, `useTheme`, `Link`)
- Fikset `theme.palette.type` → `theme.palette.mode` (v4-API som lå skjult)
- Fjernet `@material-ui/core/icons/lab` fra `peerDependencies`

### Opprydding av `dependencies` vs `peerDependencies`
For publiserte plugins er MUI-pakker nå korrekt plassert som `peerDependencies` (leveres av host-appen):
- `security-metrics`: Flyttet `@mui/material`, `@mui/system`, `@mui/icons-material` fra `dependencies` til `peerDependencies`. Fjernet ubrukte `@emotion/styled`, `@mui/x-charts` og `@mui/x-date-pickers`
- `security-champion`: Flyttet `@mui/icons-material` fra `dependencies` til `peerDependencies`
- `catalog-creator`: Flyttet `@mui/icons-material` til `peerDependencies`

### Annet
- Fjernet intern `TablePaginationActions`-import i `usePagination.ts` (no-op, erstattet av `slots`-API i v7)