### PR TITLE
[Sikkerhetsmetrikker-plugin] Add banner when no components are found and improve error handling

### DIFF
--- a/plugins/security-metrics-backend/src/Errors.ts
+++ b/plugins/security-metrics-backend/src/Errors.ts
@@ -1,53 +1,28 @@
-import { StatusCodes } from 'http-status-codes';
-import { Left } from './Either';
+import { ErrorBody, ErrorResponse } from './services/ApiService/typesBackend';
 
-export enum OurOwnErrorMessages {
-  UNKNOWN_ERROR = 'Vi har fått en ny API-feil som vi ikke har håndtert enda',
-}
+export async function errorHandling(
+  response: Response,
+): Promise<ErrorResponse> {
+  let errorBody: ErrorBody | undefined;
 
-export type ApiError = {
-  statusCode: StatusCodes;
-  frontendMessage?: OurOwnErrorMessages;
-  error?: any;
-};
+  try {
+    const contentType = response.headers.get('content-type') ?? '';
 
-export function errorHandling(response: Response) {
-  switch (response.status) {
-    case 400: {
-      return Left.create<ApiError>({
-        statusCode: StatusCodes.BAD_REQUEST,
-      });
+    if (contentType.includes('application/json')) {
+      errorBody = (await response.json()) as ErrorBody;
+    } else {
+      const text = await response.text();
+      errorBody = text ? { message: text } : undefined;
     }
-    case 401: {
-      return Left.create<ApiError>({
-        statusCode: StatusCodes.UNAUTHORIZED,
-      });
-    }
-    case 403: {
-      return Left.create<ApiError>({
-        statusCode: StatusCodes.FORBIDDEN,
-      });
-    }
-    case 404: {
-      return Left.create<ApiError>({
-        statusCode: StatusCodes.NOT_FOUND,
-      });
-    }
-    case 500: {
-      return Left.create<ApiError>({
-        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
-      });
-    }
-    case 503: {
-      return Left.create<ApiError>({
-        statusCode: StatusCodes.SERVICE_UNAVAILABLE,
-      });
-    }
-    default: {
-      return Left.create<ApiError>({
-        statusCode: response.status,
-        frontendMessage: OurOwnErrorMessages.UNKNOWN_ERROR,
-      });
-    }
+  } catch {
+    errorBody = undefined;
   }
+
+  return {
+    status: errorBody?.status ?? response.status,
+    code: errorBody?.code ?? 'UNKNOWN_ERROR',
+    message:
+      errorBody?.message ??
+      'Vi har fått en API-feil som vi ikke har håndtert enda',
+  };
 }

--- a/plugins/security-metrics-backend/src/services/ApiService/api.service.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/api.service.ts
@@ -1,20 +1,21 @@
+import { LoggerService } from '@backstage/backend-plugin-api';
+import { Either, Left, Right } from '../../Either';
+import { errorHandling } from '../../Errors';
 import { EntraIdService } from '../EntraIdService/auth.service';
 import {
+  ErrorResponse,
   MetricsUpdateStatus,
   Repository,
-  SecurityChamp,
   SeverityCounts,
   SikkerhetsmetrikkerSystemTotal,
   SlackNotificationConfig,
   Status,
   VulnerabilitySeverityCounts,
 } from './typesBackend';
-import { LoggerService } from '@backstage/backend-plugin-api';
-import { ApiError, errorHandling, OurOwnErrorMessages } from '../../Errors';
-import { Either, Left, Right } from '../../Either';
 
 export class ApiService {
   private readonly baseUrl: string;
+  private readonly upstreamOrigin: string;
   private entraIdService: EntraIdService;
   private logger: LoggerService;
 
@@ -24,159 +25,174 @@ export class ApiService {
     logger: LoggerService,
   ) {
     this.baseUrl = baseUrl;
+    this.upstreamOrigin = new URL(baseUrl).origin;
     this.entraIdService = entraIdService;
     this.logger = logger;
   }
 
-  async fetchSecurityChampionInfo(
-    repositoryNames: string[],
+  private async getSmapiToken(
     entraIdToken: string,
-  ): Promise<Either<ApiError, SecurityChamp[]>> {
-    const endpointUrl = new URL(`${this.baseUrl}/api/securityChampion`);
-
+  ): Promise<Either<ErrorResponse, string>> {
     const smapiToken = await this.entraIdService.getOboToken(entraIdToken);
 
     if (!smapiToken) {
-      throw new Error('Failed to fetch token for Security-metrics API');
+      return Left.create({
+        status: 401,
+        code: 'TOKEN_FETCH_FAILED',
+        message: 'Fikk ikke tak i token for sikkerhetsmetrikker-APIet',
+      });
+    }
+
+    return Right.create(smapiToken);
+  }
+
+  private getAuthorizedHeaders(
+    smApiToken: string,
+    initHeaders?: HeadersInit,
+  ): HeadersInit {
+    return {
+      Accept: 'application/json',
+      Authorization: `Bearer ${smApiToken}`,
+      ...(initHeaders ?? {}),
+    };
+  }
+
+  private buildEndpoint(
+    path: string,
+    query?: Record<string, string | undefined>,
+  ): Either<ErrorResponse, URL> {
+    const endpoint = new URL(path, this.baseUrl);
+
+    if (
+      endpoint.origin !== this.upstreamOrigin ||
+      !(
+        [
+          '/api/scannerData',
+          '/api/oppdateringer/alertsMetadata/status',
+          '/api/slack/configure-notifications',
+        ].includes(endpoint.pathname) ||
+        endpoint.pathname.startsWith('/api/scannerData/')
+      )
+    ) {
+      return Left.create({
+        status: 500,
+        code: 'INVALID_UPSTREAM_ENDPOINT',
+        message: 'Ugyldig upstream-endpoint.',
+      });
+    }
+
+    Object.entries(query ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        endpoint.searchParams.set(key, value);
+      }
+    });
+
+    return Right.create(endpoint);
+  }
+
+  private async request<T>(
+    endpoint: URL,
+    entraIdToken: string,
+    init: RequestInit,
+    parseSuccess: (response: Response) => Promise<T>,
+    upstreamErrorMessage: string,
+  ): Promise<Either<ErrorResponse, T>> {
+    const tokenResult = await this.getSmapiToken(entraIdToken);
+    if (tokenResult.isLeft()) {
+      return Left.create(tokenResult.error);
     }
 
     try {
-      const response = await fetch(`${endpointUrl}`, {
-        method: 'POST',
-        headers: {
-          Accept: 'application/json',
-          Authorization: `Bearer ${smapiToken}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ repositoryNames: repositoryNames }),
+      const response = await fetch(endpoint.toString(), {
+        ...init,
+        headers: this.getAuthorizedHeaders(tokenResult.value, init.headers),
       });
 
       if (response.ok) {
-        const securityChampion: SecurityChamp[] = await response.json();
-        return Right.create(securityChampion);
+        return Right.create(await parseSuccess(response));
       }
-      return errorHandling(response);
+
+      return Left.create(await errorHandling(response));
     } catch (error) {
       this.logger.error(
-        `Security champion API returned error ${error} from endpoint ${endpointUrl}`,
+        `Security-metrics API returned error ${error} from endpoint ${endpoint.toString()}`,
       );
-      throw new Error(`Security champion API returned error: ${error}`);
+
+      return Left.create({
+        status: 503,
+        code: 'UPSTREAM_REQUEST_FAILED',
+        message: upstreamErrorMessage,
+      });
     }
   }
 
   async fetchMetricsData(
     componentNames: string[],
     entraIdToken: string,
-  ): Promise<Either<ApiError, SikkerhetsmetrikkerSystemTotal[]>> {
-    const endpointUrl = new URL(`${this.baseUrl}/api/scannerData`);
-    const smapiToken = await this.entraIdService.getOboToken(entraIdToken);
-
-    if (!smapiToken) {
-      throw new Error('Failed to fetch token for Security-metrics API');
+  ): Promise<Either<ErrorResponse, SikkerhetsmetrikkerSystemTotal[]>> {
+    const endpointResult = this.buildEndpoint('/api/scannerData');
+    if (endpointResult.isLeft()) {
+      return Left.create(endpointResult.error);
     }
 
-    try {
-      const response = await fetch(`${endpointUrl}`, {
+    return this.request(
+      endpointResult.value,
+      entraIdToken,
+      {
         method: 'POST',
         headers: {
-          Accept: 'application/json',
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${smapiToken}`,
         },
-        body: JSON.stringify({ componentNames: componentNames }),
-      });
-
-      if (response.ok) {
-        const repositories: SikkerhetsmetrikkerSystemTotal[] =
-          await response.json();
-        return Right.create(repositories);
-      }
-      return errorHandling(response);
-    } catch (error) {
-      this.logger.error(
-        `Security-metrics API returned error ${error} from endpoint ${endpointUrl}`,
-      );
-      return Left.create({
-        statusCode: 500,
-        frontendMessage: OurOwnErrorMessages.UNKNOWN_ERROR,
-        error: error,
-      });
-    }
-  }
-
-  async fetchMetricsUpdateStatus(
-    entraIdToken: string,
-  ): Promise<Either<ApiError, MetricsUpdateStatus>> {
-    const endpointUrl = new URL(`${this.baseUrl}/api/scannerData/status`);
-    const smapiToken = await this.entraIdService.getOboToken(entraIdToken);
-
-    if (!smapiToken) {
-      throw new Error('Failed to fetch token for Security-metrics API');
-    }
-
-    try {
-      const response = await fetch(`${endpointUrl}`, {
-        method: 'GET',
-        headers: {
-          Accept: 'application/json',
-          Authorization: `Bearer ${smapiToken}`,
-        },
-      });
-
-      if (response.ok) {
-        const status: MetricsUpdateStatus = await response.json();
-        return Right.create(status);
-      }
-      return errorHandling(response);
-    } catch (error) {
-      this.logger.error(
-        `Security-metrics API returned error ${error} from endpoint ${endpointUrl}`,
-      );
-      return Left.create({
-        statusCode: 500,
-        frontendMessage: OurOwnErrorMessages.UNKNOWN_ERROR,
-        error: error,
-      });
-    }
+        body: JSON.stringify({ componentNames }),
+      },
+      response => response.json(),
+      'Tjenesten for sikkerhetsmetrikker er utilgjengelig akkurat nå. Prøv igjen senere.',
+    );
   }
 
   async fetchComponentMetricsData(
     componentName: string,
     entraIdToken: string,
-  ): Promise<Either<ApiError, Repository>> {
-    const endpointUrl = new URL(
-      `${this.baseUrl}/api/scannerData/${componentName}`,
+  ): Promise<Either<ErrorResponse, Repository>> {
+    const safeComponentName = encodeURIComponent(componentName);
+    const endpointResult = this.buildEndpoint(
+      `/api/scannerData/${safeComponentName}`,
     );
-    const smapiToken = await this.entraIdService.getOboToken(entraIdToken);
-
-    if (!smapiToken) {
-      throw new Error('Failed to fetch token for Security-metrics API');
+    if (endpointResult.isLeft()) {
+      return Left.create(endpointResult.error);
     }
 
-    try {
-      const response = await fetch(`${endpointUrl}`, {
+    return this.request(
+      endpointResult.value,
+      entraIdToken,
+      {
         method: 'GET',
         headers: {
-          Accept: 'application/json',
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${smapiToken}`,
         },
-      });
-      if (response.ok) {
-        const repository: Repository = await response.json();
-        return Right.create(repository);
-      }
-      return errorHandling(response);
-    } catch (error) {
-      this.logger.error(
-        `Security-metrics API returned error ${error} from endpoint ${endpointUrl}`,
-      );
-      return Left.create({
-        statusCode: 500,
-        frontendMessage: OurOwnErrorMessages.UNKNOWN_ERROR,
-        error: error,
-      });
+      },
+      response => response.json(),
+      'Tjenesten for sikkerhetsmetrikker er utilgjengelig akkurat nå. Prøv igjen senere.',
+    );
+  }
+
+  async fetchMetricsUpdateStatus(
+    entraIdToken: string,
+  ): Promise<Either<ErrorResponse, MetricsUpdateStatus>> {
+    const endpointResult = this.buildEndpoint('/api/scannerData/status');
+    if (endpointResult.isLeft()) {
+      return Left.create(endpointResult.error);
     }
+
+    return this.request(
+      endpointResult.value,
+      entraIdToken,
+      {
+        method: 'GET',
+      },
+      response => response.json(),
+      'Kunne ikke hente oppdateringsstatus fordi tjenesten for sikkerhetsmetrikker er utilgjengelig.',
+    );
   }
 
   async fetchVulnerabilityTrendsData(
@@ -184,49 +200,35 @@ export class ApiService {
     fromDate: Date,
     toDate: Date,
     entraIdToken: string,
-  ): Promise<Either<ApiError, SeverityCounts[]>> {
-    const endpointUrl = new URL(`${this.baseUrl}/api/scannerData/trends`);
-    const smapiToken = await this.entraIdService.getOboToken(entraIdToken);
-
-    if (!smapiToken) {
-      throw new Error('Failed to fetch token for Security-metrics API');
+  ): Promise<Either<ErrorResponse, SeverityCounts[]>> {
+    const endpointResult = this.buildEndpoint('/api/scannerData/trends');
+    if (endpointResult.isLeft()) {
+      return Left.create(endpointResult.error);
     }
 
-    try {
-      const response = await fetch(`${endpointUrl}`, {
+    return this.request(
+      endpointResult.value,
+      entraIdToken,
+      {
         method: 'POST',
         headers: {
-          Accept: 'application/json',
-          Authorization: `Bearer ${smapiToken}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          componentNames: componentNames,
-          fromDate: fromDate,
-          toDate: toDate,
+          componentNames,
+          fromDate,
+          toDate,
         }),
-      });
-
-      if (response.ok) {
+      },
+      async response => {
         const severityCounts: VulnerabilitySeverityCounts[] =
           await response.json();
-        return Right.create(
-          severityCounts.flatMap(
-            repositoryCounts => repositoryCounts.severityCounts,
-          ),
+        return severityCounts.flatMap(
+          repositoryCounts => repositoryCounts.severityCounts,
         );
-      }
-      return errorHandling(response);
-    } catch (error) {
-      this.logger.error(
-        `Security-metrics API returned error ${error} from endpoint ${endpointUrl}`,
-      );
-      return Left.create({
-        statusCode: 500,
-        frontendMessage: OurOwnErrorMessages.UNKNOWN_ERROR,
-        error: error,
-      });
-    }
+      },
+      'Kunne ikke hente trenddata fordi tjenesten for sikkerhetsmetrikker er utilgjengelig.',
+    );
   }
 
   async changeStatusVulnerability(
@@ -236,21 +238,21 @@ export class ApiService {
     comment: string | undefined,
     changedBy: string | undefined,
     entraIdToken: string,
-  ): Promise<Either<ApiError, void>> {
-    const endpointUrl = `${this.baseUrl}/api/oppdateringer/alertsMetadata/status`;
-    const smapiToken = await this.entraIdService.getOboToken(entraIdToken);
-
-    if (!smapiToken) {
-      throw new Error('Failed to fetch token for Security-metrics API');
+  ): Promise<Either<ErrorResponse, void>> {
+    const endpointResult = this.buildEndpoint(
+      '/api/oppdateringer/alertsMetadata/status',
+    );
+    if (endpointResult.isLeft()) {
+      return Left.create(endpointResult.error);
     }
 
-    try {
-      const response = await fetch(endpointUrl, {
+    return this.request(
+      endpointResult.value,
+      entraIdToken,
+      {
         method: 'PUT',
         headers: {
-          Accept: 'application/json',
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${smapiToken}`,
         },
         body: JSON.stringify({
           componentName,
@@ -259,22 +261,10 @@ export class ApiService {
           comment,
           changedBy,
         }),
-      });
-
-      if (response.status === 204) {
-        return Right.create(undefined);
-      }
-      return errorHandling(response);
-    } catch (error) {
-      this.logger.error(
-        `Security-metrics API returned error ${error} from endpoint ${endpointUrl}`,
-      );
-      return Left.create({
-        statusCode: 500,
-        frontendMessage: OurOwnErrorMessages.UNKNOWN_ERROR,
-        error,
-      });
-    }
+      },
+      async () => undefined,
+      'Kunne ikke endre status fordi tjenesten for sikkerhetsmetrikker er utilgjengelig.',
+    );
   }
 
   async configureNotifications(
@@ -283,21 +273,21 @@ export class ApiService {
     channelId: string,
     entraIdToken: string,
     severity?: string[],
-  ): Promise<Either<ApiError, void>> {
-    const endpointUrl = `${this.baseUrl}/api/slack/configure-notifications`;
-    const smapiToken = await this.entraIdService.getOboToken(entraIdToken);
-
-    if (!smapiToken) {
-      throw new Error('Failed to fetch token for Security-metrics API');
+  ): Promise<Either<ErrorResponse, void>> {
+    const endpointResult = this.buildEndpoint(
+      '/api/slack/configure-notifications',
+    );
+    if (endpointResult.isLeft()) {
+      return Left.create(endpointResult.error);
     }
 
-    try {
-      const response = await fetch(endpointUrl, {
+    return this.request(
+      endpointResult.value,
+      entraIdToken,
+      {
         method: 'PUT',
         headers: {
-          Accept: 'application/json',
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${smapiToken}`,
         },
         body: JSON.stringify({
           teamName,
@@ -305,56 +295,32 @@ export class ApiService {
           channelId,
           severity,
         }),
-      });
-
-      if (response.ok) {
-        return Right.create(undefined);
-      }
-      return errorHandling(response);
-    } catch (error) {
-      this.logger.error(
-        `Security-metrics API returned error ${error} from endpoint ${endpointUrl}`,
-      );
-      return Left.create({
-        statusCode: 500,
-        frontendMessage: OurOwnErrorMessages.UNKNOWN_ERROR,
-        error,
-      });
-    }
+      },
+      async () => undefined,
+      'Kunne ikke konfigurere varslinger fordi tjenesten for sikkerhetsmetrikker er utilgjengelig.',
+    );
   }
 
   async getNotificationsConfig(
     teamName: string,
     entraIdToken: string,
-  ): Promise<Either<ApiError, SlackNotificationConfig>> {
-    const endpointUrl = `${this.baseUrl}/api/slack/configure-notifications?teamName=${encodeURIComponent(teamName)}`;
-    const smapiToken = await this.entraIdService.getOboToken(entraIdToken);
-
-    if (!smapiToken)
-      throw new Error('Failed to fetch token for Security-metrics API');
-
-    try {
-      const response = await fetch(endpointUrl, {
-        method: 'GET',
-        headers: {
-          Accept: 'application/json',
-          Authorization: `Bearer ${smapiToken}`,
-        },
-      });
-
-      if (response.ok) {
-        return Right.create(await response.json());
-      }
-      return errorHandling(response);
-    } catch (error) {
-      this.logger.error(
-        `Security-metrics API returned error ${error} from endpoint ${endpointUrl}`,
-      );
-      return Left.create({
-        statusCode: 500,
-        frontendMessage: OurOwnErrorMessages.UNKNOWN_ERROR,
-        error,
-      });
+  ): Promise<Either<ErrorResponse, SlackNotificationConfig>> {
+    const endpointResult = this.buildEndpoint(
+      '/api/slack/configure-notifications',
+      { teamName },
+    );
+    if (endpointResult.isLeft()) {
+      return Left.create(endpointResult.error);
     }
+
+    return this.request(
+      endpointResult.value,
+      entraIdToken,
+      {
+        method: 'GET',
+      },
+      response => response.json(),
+      'Kunne ikke hente konfigurasjon for varslinger fordi tjenesten for sikkerhetsmetrikker er utilgjengelig.',
+    );
   }
 }

--- a/plugins/security-metrics-backend/src/services/ApiService/router.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/router.ts
@@ -77,7 +77,7 @@ export const createRouter = async (
       logger,
       'Failed to fetch metrics update status',
       async (req, res) => {
-        const authError = requireBackstageToken(req, auth);
+        const authError = await requireBackstageToken(req, auth);
         if (authError) {
           return res.status(authError.status).send(authError);
         }
@@ -102,7 +102,7 @@ export const createRouter = async (
       logger,
       'Failed to fetch metrics data',
       async (req, res) => {
-        const authError = requireBackstageToken(req, auth);
+        const authError = await requireBackstageToken(req, auth);
         if (authError) {
           return res.status(authError.status).send(authError);
         }
@@ -124,7 +124,7 @@ export const createRouter = async (
       logger,
       'Failed to fetch metrics data',
       async (req, res) => {
-        const authError = requireBackstageToken(req, auth);
+        const authError = await requireBackstageToken(req, auth);
         if (authError) {
           return res.status(authError.status).send(authError);
         }
@@ -163,7 +163,7 @@ export const createRouter = async (
       logger,
       'Failed to fetch vulnerability trends data',
       async (req, res) => {
-        const authError = requireBackstageToken(req, auth);
+        const authError = await requireBackstageToken(req, auth);
         if (authError) {
           return res.status(authError.status).send(authError);
         }
@@ -187,7 +187,7 @@ export const createRouter = async (
       logger,
       'Failed to change status of vulnerability',
       async (req, res) => {
-        const authError = requireBackstageToken(req, auth);
+        const authError = await requireBackstageToken(req, auth);
         if (authError) {
           return res.status(authError.status).send(authError);
         }
@@ -214,7 +214,7 @@ export const createRouter = async (
       logger,
       'Failed to configure notifications',
       async (req, res) => {
-        const authError = requireBackstageToken(req, auth);
+        const authError = await requireBackstageToken(req, auth);
         if (authError) {
           return res.status(authError.status).send(authError);
         }
@@ -240,7 +240,7 @@ export const createRouter = async (
       logger,
       'Failed to fetch notifications config',
       async (req, res) => {
-        const authError = requireBackstageToken(req, auth);
+        const authError = await requireBackstageToken(req, auth);
         if (authError) {
           return res.status(authError.status).send(authError);
         }

--- a/plugins/security-metrics-backend/src/services/ApiService/router.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/router.ts
@@ -11,34 +11,19 @@ import {
   FetchTrendsRequestBody,
 } from './typesBackend';
 import { getBackendConfig } from '../config';
+import {
+  errorResponse,
+  requireBackstageToken,
+  requireHeader,
+  sendEither,
+  withErrorHandling,
+} from './routerUtils';
 
 export interface RouterOptions {
   auth: AuthService;
   logger: LoggerService;
   config: Config;
 }
-
-const formatToken = (token: string | undefined): string | null => {
-  if (!token || !token.startsWith('Bearer')) {
-    return null;
-  }
-  return token.substring(7).trim();
-};
-
-const validateToken = (
-  token: string | undefined,
-  auth: AuthService,
-): string | null => {
-  const formattedToken = formatToken(token);
-  if (!formattedToken) {
-    return null;
-  }
-  const credentials = auth.authenticate(formattedToken);
-  if (!credentials) {
-    return null;
-  }
-  return formattedToken;
-};
 
 export const createRouter = async (
   options: RouterOptions,
@@ -86,294 +71,201 @@ export const createRouter = async (
     next();
   });
 
-  router.get('/proxy/metrics-update-status/', async (req, res) => {
-    try {
-      const backstageToken = req.header('Authorization');
-      const validToken = validateToken(backstageToken, auth);
-      const entraIdToken = req.header('EntraId');
-
-      if (!validToken || !backstageToken || !entraIdToken) {
-        res.status(401).send({ frontendMessage: 'Token is not valid' });
-        return;
-      }
-
-      const statusData =
-        await apiService.fetchMetricsUpdateStatus(entraIdToken);
-
-      if (statusData.isRight()) {
-        res.status(200).send(statusData.value);
-      } else {
-        res.status(statusData.error.statusCode).send({
-          frontendMessage: statusData.error.frontendMessage,
-        });
-        logger.error(statusData.error.error);
-      }
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      logger.error(`Failed to fetch metrics update status: ${error}`);
-      res.status(500).send({
-        frontendMessage: `Failed to fetch metrics update status: ${errorMessage}`,
-      });
-    }
-  });
-
-  router.post('/proxy/fetch-security-champions/', async (req, res) => {
-    try {
-      const backstageToken = req.header('Authorization');
-      const validToken = validateToken(backstageToken, auth);
-      const request = req.body;
-      if (!validToken || !backstageToken) {
-        res.status(401).send({
-          frontendMessage: 'Token is not valid',
-        });
-      } else {
-        const securityChampion = await apiService.fetchSecurityChampionInfo(
-          request.repositoryNames,
-          request.entraIdToken,
-        );
-        if (securityChampion.isRight()) {
-          res.status(200).send(securityChampion.value);
-        } else {
-          res.status(securityChampion.error.statusCode).send({
-            frontendMessage: securityChampion.error.frontendMessage,
-          });
-          logger.error(securityChampion.error.error);
+  router.get(
+    '/proxy/metrics-update-status/',
+    withErrorHandling(
+      logger,
+      'Failed to fetch metrics update status',
+      async (req, res) => {
+        const authError = requireBackstageToken(req, auth);
+        if (authError) {
+          return res.status(authError.status).send(authError);
         }
-      }
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      logger.error(`Failed to fetch security champion data: ${error}`);
-      res.status(500).send({
-        frontendMessage: `Failed to fetch security champion data: ${errorMessage}`,
-      });
-    }
-  });
 
-  router.post('/proxy/fetch-metrics/', async (req, res) => {
-    try {
-      const backstageToken = req.header('Authorization');
-      const validToken = validateToken(backstageToken, auth);
-      const request = req.body as FetchMetricsRequestBody;
-      if (!validToken || !backstageToken) {
-        res.status(401).send({
-          frontendMessage: 'Token is not valid',
-        });
-      } else {
-        const metricsData = await apiService.fetchMetricsData(
+        const entraIdToken = req.header('EntraId');
+        if (!entraIdToken) {
+          return res
+            .status(400)
+            .send(errorResponse(400, 'BAD_REQUEST', 'EntraId is required'));
+        }
+
+        const result = await apiService.fetchMetricsUpdateStatus(entraIdToken);
+
+        return sendEither(res, result);
+      },
+    ),
+  );
+
+  router.post(
+    '/proxy/fetch-metrics/',
+    withErrorHandling(
+      logger,
+      'Failed to fetch metrics data',
+      async (req, res) => {
+        const authError = requireBackstageToken(req, auth);
+        if (authError) {
+          return res.status(authError.status).send(authError);
+        }
+
+        const request = req.body as FetchMetricsRequestBody;
+        const result = await apiService.fetchMetricsData(
           request.componentNames,
           request.entraIdToken,
         );
 
-        if (metricsData.isRight()) {
-          res.status(200).send(metricsData.value);
-        } else {
-          res.status(metricsData.error.statusCode).send({
-            frontendMessage: metricsData.error.frontendMessage,
-          });
-          logger.error(metricsData.error.error);
+        return sendEither(res, result);
+      },
+    ),
+  );
+
+  router.get(
+    '/proxy/fetch-component-metrics/',
+    withErrorHandling(
+      logger,
+      'Failed to fetch metrics data',
+      async (req, res) => {
+        const authError = requireBackstageToken(req, auth);
+        if (authError) {
+          return res.status(authError.status).send(authError);
         }
-      }
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      logger.error(`Failed to fetch metrics data: ${error}`);
-      res.status(500).send({
-        frontendMessage: `Failed to fetch metrics data: ${errorMessage}`,
-      });
-    }
-  });
 
-  router.get('/proxy/fetch-component-metrics/', async (req, res) => {
-    try {
-      const backstageToken = req.header('Authorization');
-      const validToken = validateToken(backstageToken, auth);
-      const entraIdToken = req.header('EntraId');
-      const componentName = req.query.componentName as string | undefined;
-
-      if (!componentName || !validToken || !backstageToken || !entraIdToken) {
+        const componentName = req.query.componentName as string | undefined;
         if (!componentName) {
-          res.status(401).send({
-            frontendMessage: 'Missing componentName query parameter',
-          });
+          return res
+            .status(400)
+            .send(
+              errorResponse(
+                400,
+                'BAD_REQUEST',
+                'Mangler componentName query parameter',
+              ),
+            );
         }
-        res.status(401).send({
-          frontendMessage: 'Token is not valid',
-        });
-      } else {
-        const metricsData = await apiService.fetchComponentMetricsData(
+
+        const entraIdHeader = requireHeader(req.header('EntraId'), 'EntraId');
+        if (typeof entraIdHeader !== 'string') {
+          return res.status(entraIdHeader.status).send(entraIdHeader);
+        }
+
+        const result = await apiService.fetchComponentMetricsData(
           componentName,
-          entraIdToken,
+          entraIdHeader,
         );
 
-        if (metricsData.isRight()) {
-          res.status(200).send(metricsData.value);
-        } else {
-          res.status(metricsData.error.statusCode).send({
-            frontendMessage: metricsData.error.frontendMessage,
-          });
-          logger.error(metricsData.error.error);
+        return sendEither(res, result);
+      },
+    ),
+  );
+
+  router.post(
+    '/proxy/fetch-trends/',
+    withErrorHandling(
+      logger,
+      'Failed to fetch vulnerability trends data',
+      async (req, res) => {
+        const authError = requireBackstageToken(req, auth);
+        if (authError) {
+          return res.status(authError.status).send(authError);
         }
-      }
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      logger.error(`Failed to fetch metrics data: ${error}`);
-      res.status(500).send({
-        frontendMessage: `Failed to fetch metrics data: ${errorMessage}`,
-      });
-    }
-  });
 
-  router.post('/proxy/fetch-trends/', async (req, res) => {
-    try {
-      const backstageToken = req.header('Authorization');
-      const validToken = validateToken(backstageToken, auth);
-      const request = req.body as FetchTrendsRequestBody;
-
-      if (!validToken || !backstageToken) {
-        res.sendStatus(401).send({
-          frontendMessage: 'Token is not valid',
-        });
-      } else {
-        const severityCounts = await apiService.fetchVulnerabilityTrendsData(
+        const request = req.body as FetchTrendsRequestBody;
+        const result = await apiService.fetchVulnerabilityTrendsData(
           request.componentNames,
           request.fromDate,
           request.toDate,
           request.entraIdToken,
         );
-        if (severityCounts.isRight()) {
-          res.status(200).send(severityCounts.value);
-        } else {
-          res.status(severityCounts.error.statusCode).send({
-            frontendMessage: severityCounts.error.frontendMessage,
-          });
-          logger.error(severityCounts.error.error);
+
+        return sendEither(res, result);
+      },
+    ),
+  );
+
+  router.put(
+    '/proxy/change-status-vulnerability/',
+    withErrorHandling(
+      logger,
+      'Failed to change status of vulnerability',
+      async (req, res) => {
+        const authError = requireBackstageToken(req, auth);
+        if (authError) {
+          return res.status(authError.status).send(authError);
         }
-      }
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      logger.error(`Failed to fetch vulnerability trends data: ${error}`);
-      res.status(500).send({
-        frontendMessage: `Failed to fetch vulnerability trends data: ${errorMessage}`,
-      });
-    }
-  });
 
-  router.put('/proxy/change-status-vulnerability/', async (req, res) => {
-    try {
-      const backstageToken = req.header('Authorization');
-      const validToken = validateToken(backstageToken, auth);
-      const request = req.body as ChangeStatusRequestBody;
+        const request = req.body as ChangeStatusRequestBody;
 
-      if (!validToken || !backstageToken) {
-        res.status(401).send({ frontendMessage: 'Token is not valid' });
-        return;
-      }
+        const result = await apiService.changeStatusVulnerability(
+          request.componentName,
+          request.vulnerabilityId,
+          request.status,
+          request.comment,
+          request.changedBy,
+          request.entraIdToken,
+        );
 
-      const apiResult = await apiService.changeStatusVulnerability(
-        request.componentName,
-        request.vulnerabilityId,
-        request.status,
-        request.comment,
-        request.changedBy,
-        request.entraIdToken,
-      );
+        return sendEither(res, result, 204);
+      },
+    ),
+  );
 
-      if (apiResult.isRight()) {
-        res.sendStatus(204);
-      } else {
-        res.status(apiResult.error.statusCode).send({
-          frontendMessage: apiResult.error.frontendMessage,
-        });
-        logger.error(apiResult.error.error);
-      }
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      logger.error(`Failed to change status of vulnerability: ${error}`);
-      throw new Error(errorMessage);
-    }
-  });
+  router.put(
+    '/proxy/configure-notifications/',
+    withErrorHandling(
+      logger,
+      'Failed to configure notifications',
+      async (req, res) => {
+        const authError = requireBackstageToken(req, auth);
+        if (authError) {
+          return res.status(authError.status).send(authError);
+        }
 
-  router.put('/proxy/configure-notifications/', async (req, res) => {
-    try {
-      const backstageToken = req.header('Authorization');
-      const validToken = validateToken(backstageToken, auth);
-      const request = req.body as ConfigureNotificationsRequestBody;
+        const request = req.body as ConfigureNotificationsRequestBody;
 
-      if (!validToken || !backstageToken) {
-        res.status(401).send({ frontendMessage: 'Token is not valid' });
-        return;
-      }
+        const result = await apiService.configureNotifications(
+          request.teamName,
+          request.componentNames,
+          request.channelId,
+          request.entraIdToken,
+          request.severity,
+        );
 
-      const apiResult = await apiService.configureNotifications(
-        request.teamName,
-        request.componentNames,
-        request.channelId,
-        request.entraIdToken,
-        request.severity,
-      );
+        return sendEither(res, result, 204);
+      },
+    ),
+  );
 
-      if (apiResult.isRight()) {
-        console.log('Notifications configured successfully');
-        res.sendStatus(204);
-      } else if (apiResult.error.statusCode === 400) {
-        res.status(400).send('Kunne ikke nå ønsket slack-kanal');
-        logger.error(apiResult.error.error);
-      } else {
-        res.status(apiResult.error.statusCode).send({
-          frontendMessage: apiResult.error.frontendMessage,
-        });
-        logger.error(apiResult.error.error);
-      }
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      logger.error(`Failed to configure notifications: ${error}`);
-      throw new Error(errorMessage);
-    }
-  });
+  router.get(
+    '/proxy/configure-notifications/',
+    withErrorHandling(
+      logger,
+      'Failed to fetch notifications config',
+      async (req, res) => {
+        const authError = requireBackstageToken(req, auth);
+        if (authError) {
+          return res.status(authError.status).send(authError);
+        }
 
-  router.get('/proxy/configure-notifications/', async (req, res) => {
-    const backstageToken = req.header('Authorization');
-    const validToken = validateToken(backstageToken, auth);
+        const teamName = String(req.query.teamName ?? '');
+        if (!teamName) {
+          return res
+            .status(400)
+            .send(errorResponse(400, 'BAD_REQUEST', 'teamName is required'));
+        }
 
-    const teamName = String(req.query.teamName ?? '');
-    const entraIdToken = req.header('EntraId') ?? '';
+        const entraIdHeader = requireHeader(req.header('EntraId'), 'EntraId');
+        if (typeof entraIdHeader !== 'string') {
+          return res.status(entraIdHeader.status).send(entraIdHeader);
+        }
 
-    if (!validToken || !backstageToken) {
-      res.status(401).send({ frontendMessage: 'Token is not valid' });
-      return;
-    }
+        const result = await apiService.getNotificationsConfig(
+          teamName,
+          entraIdHeader,
+        );
 
-    if (!teamName) {
-      res.status(400).send({ frontendMessage: 'teamName is required' });
-      return;
-    }
-
-    if (!entraIdToken) {
-      res.status(400).send({ frontendMessage: 'entraIdToken is required' });
-      return;
-    }
-
-    const apiResult = await apiService.getNotificationsConfig(
-      teamName,
-      entraIdToken,
-    );
-
-    if (apiResult.isRight()) {
-      console.log('Notifications config fetched successfully');
-      res.status(200).json(apiResult.value);
-    } else {
-      res.status(apiResult.error.statusCode).send({
-        frontendMessage: apiResult.error.frontendMessage,
-      });
-      logger.error(apiResult.error.error);
-    }
-  });
+        return sendEither(res, result);
+      },
+    ),
+  );
 
   return router;
 };

--- a/plugins/security-metrics-backend/src/services/ApiService/routerUtils.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/routerUtils.ts
@@ -16,38 +16,34 @@ export const errorResponse = (
 export const unknownErrorResponse = (message: string): ErrorResponse =>
   errorResponse(500, 'UNKNOWN_ERROR', message);
 
-const validateToken = (
+const validateToken = async (
   token: string | undefined,
   auth: AuthService,
-): string | null => {
+): Promise<string | null> => {
   if (!token?.startsWith('Bearer ')) {
     return null;
   }
-
   const formattedToken = token.substring(7).trim();
   if (!formattedToken) {
     return null;
   }
-
-  const credentials = auth.authenticate(formattedToken);
-  if (!credentials) {
+  try {
+    await auth.authenticate(formattedToken);
+  } catch {
     return null;
   }
-
   return formattedToken;
 };
 
-export const requireBackstageToken = (
+export const requireBackstageToken = async (
   req: express.Request,
   auth: AuthService,
-): ErrorResponse | null => {
+): Promise<ErrorResponse | null> => {
   const backstageToken = req.header('Authorization');
-  const validToken = validateToken(backstageToken, auth);
-
+  const validToken = await validateToken(backstageToken, auth);
   if (!validToken || !backstageToken) {
     return errorResponse(401, 'UNAUTHORIZED', 'Token is not valid');
   }
-
   return null;
 };
 

--- a/plugins/security-metrics-backend/src/services/ApiService/routerUtils.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/routerUtils.ts
@@ -1,0 +1,93 @@
+import { AuthService, LoggerService } from '@backstage/backend-plugin-api';
+import { Either } from '../../Either';
+import { ErrorResponse } from './typesBackend';
+import express from 'express';
+
+export const errorResponse = (
+  status: number,
+  code: string,
+  message: string,
+): ErrorResponse => ({
+  status,
+  code,
+  message,
+});
+
+export const unknownErrorResponse = (message: string): ErrorResponse =>
+  errorResponse(500, 'UNKNOWN_ERROR', message);
+
+const validateToken = (
+  token: string | undefined,
+  auth: AuthService,
+): string | null => {
+  if (!token?.startsWith('Bearer ')) {
+    return null;
+  }
+
+  const formattedToken = token.substring(7).trim();
+  if (!formattedToken) {
+    return null;
+  }
+
+  const credentials = auth.authenticate(formattedToken);
+  if (!credentials) {
+    return null;
+  }
+
+  return formattedToken;
+};
+
+export const requireBackstageToken = (
+  req: express.Request,
+  auth: AuthService,
+): ErrorResponse | null => {
+  const backstageToken = req.header('Authorization');
+  const validToken = validateToken(backstageToken, auth);
+
+  if (!validToken || !backstageToken) {
+    return errorResponse(401, 'UNAUTHORIZED', 'Token is not valid');
+  }
+
+  return null;
+};
+
+export const requireHeader = (
+  value: string | undefined,
+  name: string,
+): string | ErrorResponse =>
+  value ? value : errorResponse(400, 'BAD_REQUEST', `${name} is required`);
+
+export const sendEither = <T>(
+  res: express.Response,
+  result: Either<ErrorResponse, T>,
+  successStatus = 200,
+) => {
+  if (result.isRight()) {
+    if (successStatus === 204) {
+      return res.sendStatus(204);
+    }
+
+    return res.status(successStatus).send(result.value);
+  }
+
+  return res.status(result.error.status).send(result.error);
+};
+
+export const withErrorHandling =
+  (
+    logger: LoggerService,
+    errorMessage: string,
+    handler: (req: express.Request, res: express.Response) => Promise<unknown>,
+  ) =>
+  async (req: express.Request, res: express.Response) => {
+    try {
+      return await handler(req, res);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error(`${errorMessage}: ${error}`);
+
+      return res
+        .status(500)
+        .send(unknownErrorResponse(`${errorMessage}: ${message}`));
+    }
+  };

--- a/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
@@ -193,3 +193,15 @@ export type SlackNotificationConfig = {
   severity: string[];
   componentNames: string[];
 };
+
+export type ErrorResponse = {
+  status: number;
+  code: string;
+  message: string;
+};
+
+export type ErrorBody = {
+  status?: number;
+  code?: string;
+  message?: string;
+};

--- a/plugins/security-metrics/src/api/client.ts
+++ b/plugins/security-metrics/src/api/client.ts
@@ -1,34 +1,71 @@
-const ERROR_MESSAGES: Record<number, string> = {
+import { ErrorResponse } from '../typesFrontend';
+
+class ApiClientError extends Error {
+  status: number;
+  code: string;
+
+  constructor(error: ErrorResponse) {
+    super(error.message);
+    this.name = 'ApiClientError';
+    this.status = error.status;
+    this.code = error.code;
+  }
+}
+
+const FALLBACK_ERROR_MESSAGES: Record<number, string> = {
   401: 'Mangler autentisering. Vennligst logg inn.',
-  403: 'Det ser ut som du ikke har tilgang til metrikker for denne ressursen.',
-  404: 'Vi fant ikke ressursen du leter etter.',
-  500: 'Kunne ikke hente metrikker for denne ressursen på grunn av en server-feil.',
-  502: 'Kunne ikke hente metrikker for denne ressursen på grunn av en server-feil.',
-  503: 'Kunne ikke hente metrikker for denne ressursen på grunn av en server-feil.',
-  504: 'Kunne ikke hente metrikker for denne ressursen på grunn av en server-feil.',
+  403: 'Du har ikke tilgang til sikkerhetsmetrikker for denne komponenten.',
+  404: 'Sikkerhetsmetrikker for denne komponenten er ikke tilgjengelige ennå.',
+  409: 'Sikkerhetsmetrikker for denne komponenten er ikke klare ennå.',
+  500: 'Noe gikk galt ved henting av sikkerhetsmetrikker.',
+  502: 'Tjenesten for sikkerhetsmetrikker er midlertidig utilgjengelig.',
+  503: 'Tjenesten for sikkerhetsmetrikker er midlertidig utilgjengelig.',
+  504: 'Tjenesten for sikkerhetsmetrikker svarte ikke.',
 };
 
 const DEFAULT_ERROR_MESSAGE =
   'Kunne ikke hente metrikker for denne ressursen på grunn av en ukjent feil.';
 
+const isErrorResponse = (value: unknown): value is ErrorResponse => {
+  if (!value || typeof value !== 'object') return false;
+
+  const error = value as Record<string, unknown>;
+  return (
+    typeof error.status === 'number' &&
+    typeof error.code === 'string' &&
+    typeof error.message === 'string'
+  );
+};
+
+const toFallbackError = (response: Response): ErrorResponse => ({
+  status: response.status,
+  code: 'UNKNOWN_ERROR',
+  message: FALLBACK_ERROR_MESSAGES[response.status] ?? DEFAULT_ERROR_MESSAGE,
+});
+
 const handleResponse = async <ResponseBody>(
   response: Response,
-  parse: (response: Response) => Promise<ResponseBody>,
-  preferBodyText = false,
+  parse: (response: Response) => Promise<unknown>,
 ): Promise<ResponseBody> => {
   const result = await parse(response);
 
   if (!response.ok) {
-    const bodyText =
-      preferBodyText && typeof result === 'string' && result.trim()
-        ? result.trim()
-        : undefined;
-    const message =
-      bodyText ?? ERROR_MESSAGES[response.status] ?? DEFAULT_ERROR_MESSAGE;
-    throw new Error(message);
+    if (isErrorResponse(result)) {
+      throw new ApiClientError(result);
+    }
+
+    if (typeof result === 'string' && result.trim()) {
+      throw new ApiClientError({
+        status: response.status,
+        code: 'UNKNOWN_ERROR',
+        message: result.trim(),
+      });
+    }
+
+    throw new ApiClientError(toFallbackError(response));
   }
 
-  return result;
+  return result as ResponseBody;
 };
 
 export const post = async <RequestBody, ResponseBody>(
@@ -45,9 +82,14 @@ export const post = async <RequestBody, ResponseBody>(
     body: JSON.stringify(requestBody),
   });
 
-  return handleResponse<ResponseBody>(response, async res =>
-    res.status === 204 ? (res.text() as unknown as ResponseBody) : res.json(),
-  );
+  return handleResponse<ResponseBody>(response, async res => {
+    if (res.status === 204) return undefined;
+
+    const ct = res.headers.get('content-type') ?? '';
+    if (ct.includes('application/json')) return res.json();
+
+    return res.text();
+  });
 };
 
 export const put = async <RequestBody, ResponseBody>(
@@ -64,20 +106,14 @@ export const put = async <RequestBody, ResponseBody>(
     body: JSON.stringify(requestBody),
   });
 
-  return handleResponse<ResponseBody>(
-    response,
-    async res => {
-      if (res.status === 204) return undefined as unknown as ResponseBody;
+  return handleResponse<ResponseBody>(response, async res => {
+    if (res.status === 204) return undefined;
 
-      const ct = res.headers.get('content-type') ?? '';
-      if (ct.includes('application/json'))
-        return (await res.json()) as ResponseBody;
+    const ct = res.headers.get('content-type') ?? '';
+    if (ct.includes('application/json')) return res.json();
 
-      const text = await res.text();
-      return text as unknown as ResponseBody;
-    },
-    true,
-  );
+    return res.text();
+  });
 };
 
 export const get = async <ResponseBody>(
@@ -93,5 +129,12 @@ export const get = async <ResponseBody>(
     },
   });
 
-  return handleResponse<ResponseBody>(response, res => res.json());
+  return handleResponse<ResponseBody>(response, async res => {
+    if (res.status === 204) return undefined;
+
+    const ct = res.headers.get('content-type') ?? '';
+    if (ct.includes('application/json')) return res.json();
+
+    return res.text();
+  });
 };

--- a/plugins/security-metrics/src/components/Views/GroupPage.tsx
+++ b/plugins/security-metrics/src/components/Views/GroupPage.tsx
@@ -30,6 +30,7 @@ import { useShowTrendTotal } from '../../hooks/useShowTrendTotal';
 import { ViewSettingsDialog } from '../ViewSettingsDialog';
 import SettingsIcon from '@mui/icons-material/Settings';
 import { MetricsStatus } from '../MetricsStatus';
+import Alert from '@mui/material/Alert';
 
 enum TabEnum {
   COMPONENT = 0,
@@ -67,6 +68,13 @@ export const GroupPage = () => {
   const filteredPermitted = permitted.filter(p =>
     p.componentNames.some(n => visibleRefs.has(`component:default/${n}`)),
   );
+
+  if (componentNames.length === 0 || data?.length === 0)
+    return (
+      <Alert severity="info">
+        Finner ingen komponenter som har sikkerhetsmetrikker
+      </Alert>
+    );
 
   if (error || componentNamesError)
     return (

--- a/plugins/security-metrics/src/components/Views/GroupPage.tsx
+++ b/plugins/security-metrics/src/components/Views/GroupPage.tsx
@@ -69,12 +69,7 @@ export const GroupPage = () => {
     p.componentNames.some(n => visibleRefs.has(`component:default/${n}`)),
   );
 
-  if (componentNames.length === 0 || data?.length === 0)
-    return (
-      <Alert severity="info">
-        Finner ingen komponenter som har sikkerhetsmetrikker
-      </Alert>
-    );
+  if (componentNamesIsLoading || isPending) return <Progress />;
 
   if (error || componentNamesError)
     return (
@@ -84,7 +79,12 @@ export const GroupPage = () => {
       />
     );
 
-  if (componentNamesIsLoading || isPending) return <Progress />;
+  if (componentNames.length === 0 || data?.length === 0)
+    return (
+      <Alert severity="info">
+        Finner ingen komponenter som har sikkerhetsmetrikker
+      </Alert>
+    );
 
   const filteredSystemsData = filterSystemsByComponents(
     data,

--- a/plugins/security-metrics/src/typesFrontend.ts
+++ b/plugins/security-metrics/src/typesFrontend.ts
@@ -187,3 +187,9 @@ export type MetricsUpdateStatus = {
   secretScanning: boolean;
   riscMetrics: boolean;
 };
+
+export type ErrorResponse = {
+  status: number;
+  code: string;
+  message: string;
+};


### PR DESCRIPTION
## 🔒 Bakgrunn

Jira: https://kartverket.atlassian.net/jira/software/projects/EDSKVIS/boards/177?selectedIssue=EDSKVIS-948

Viser ikke tydelig feilmelding dersom APIet ikke får noen komponenter eller den ikke finner noen metrikker for komponentene man sender inn. Fant også forbedringspotensiale i feilhåndtering i hele flyten ved debugging.

## 🔑 Løsning

- Vis info alert dersom man ikke finner noen komponenter
- Rydder opp i feilhåndtering i hele flyten
- Refaktorerer og rydder opp i logikken i `security-metrics-backend`

Koblet til https://github.com/kartverket/sikkerhetsmetrikker/pull/940/changes

## 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| <img width="405" height="253" alt="Screenshot 2026-03-30 at 12 09 59" src="https://github.com/user-attachments/assets/f881dff7-8f41-4465-abab-cb551ae4550a" /> | <img width="406" height="246" alt="Screenshot 2026-03-30 at 12 09 47" src="https://github.com/user-attachments/assets/a51a6509-abb1-4840-bf39-961fee7e5f94" /> |