### PR TITLE
[Sikkerhetsmetrikker-plugin] 2nd attempt to fix correct loading and info banner

### DIFF
--- a/plugins/security-metrics/src/components/Views/GroupPage.tsx
+++ b/plugins/security-metrics/src/components/Views/GroupPage.tsx
@@ -17,8 +17,6 @@ import {
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import { SystemsTable } from '../SystemsTable/SystemsTable';
-import { useMetricsQuery } from '../../hooks/useMetricsQuery';
-import { useFetchComponentNamesByGroup } from '../../hooks/useFetchComponentNames';
 import NoAccessAlert from '../NoAccessAlert';
 import Button from '@mui/material/Button';
 import TuneIcon from '@mui/icons-material/Tune';
@@ -31,6 +29,7 @@ import { ViewSettingsDialog } from '../ViewSettingsDialog';
 import SettingsIcon from '@mui/icons-material/Settings';
 import { MetricsStatus } from '../MetricsStatus';
 import Alert from '@mui/material/Alert';
+import { useGroupMetrics } from '../../hooks/useGroupMetrics';
 
 enum TabEnum {
   COMPONENT = 0,
@@ -48,12 +47,16 @@ export const GroupPage = () => {
 
   const { showTotal, toggleShowTotal } = useShowTrendTotal();
 
-  const { componentNames, componentNamesIsLoading, componentNamesError } =
-    useFetchComponentNamesByGroup(entity);
-  const { data, isPending, error } = useMetricsQuery(componentNames);
+  const {
+    data = [],
+    isLoading,
+    isEmpty,
+    error,
+    errorTitle,
+  } = useGroupMetrics(entity);
 
-  const permitted: RepositorySummary[] = getAllPermittedMetrics(data ?? []);
-  const notPermitted: string[] = getAllNotPermittedComponents(data ?? []);
+  const permitted: RepositorySummary[] = getAllPermittedMetrics(data);
+  const notPermitted: string[] = getAllNotPermittedComponents(data);
 
   const allComponentRefs = permitted.flatMap(p =>
     p.componentNames.map(n => `component:default/${n}`),
@@ -69,33 +72,6 @@ export const GroupPage = () => {
     p.componentNames.some(n => visibleRefs.has(`component:default/${n}`)),
   );
 
-  if (componentNamesIsLoading) return <Progress />;
-
-  if (componentNamesError)
-    return (
-      <ErrorBanner
-        errorTitle={`Kunne ikke hente reponavn for ${entity.metadata.name}`}
-        errorMessage={componentNamesError.message}
-      />
-    );
-
-  if (componentNames.length === 0)
-    return (
-      <Alert severity="info">
-        Finner ingen komponenter som har sikkerhetsmetrikker
-      </Alert>
-    );
-
-  if (isPending) return <Progress />;
-
-  if (error)
-    return (
-      <ErrorBanner
-        errorTitle={`Kunne ikke hente metrikker for ${entity.metadata.name}`}
-        errorMessage={error.message}
-      />
-    );
-
   const filteredSystemsData = filterSystemsByComponents(
     data,
     new Set(filteredPermitted.map(c => c.repoName)),
@@ -103,6 +79,20 @@ export const GroupPage = () => {
   );
 
   const secrets: Secrets[] = getAllSecrets(data);
+
+  if (isLoading) return <Progress />;
+
+  if (error) {
+    return <ErrorBanner errorTitle={errorTitle} errorMessage={error.message} />;
+  }
+
+  if (isEmpty) {
+    return (
+      <Alert severity="info">
+        Finner ingen komponenter som har sikkerhetsmetrikker
+      </Alert>
+    );
+  }
 
   return (
     <Stack gap={2}>

--- a/plugins/security-metrics/src/components/Views/GroupPage.tsx
+++ b/plugins/security-metrics/src/components/Views/GroupPage.tsx
@@ -69,6 +69,16 @@ export const GroupPage = () => {
     p.componentNames.some(n => visibleRefs.has(`component:default/${n}`)),
   );
 
+  if (componentNamesIsLoading) return <Progress />;
+
+  if (componentNamesError)
+    return (
+      <ErrorBanner
+        errorTitle={`Kunne ikke hente reponavn for ${entity.metadata.name}`}
+        errorMessage={componentNamesError.message}
+      />
+    );
+
   if (componentNames.length === 0)
     return (
       <Alert severity="info">
@@ -76,13 +86,13 @@ export const GroupPage = () => {
       </Alert>
     );
 
-  if (componentNamesIsLoading || isPending) return <Progress />;
+  if (isPending) return <Progress />;
 
-  if (error || componentNamesError)
+  if (error)
     return (
       <ErrorBanner
-        errorTitle={`Kunne ikke hente ${error ? 'metrikker' : 'reponavn'} for ${entity.metadata.name}`}
-        errorMessage={error ? error.message : componentNamesError?.message}
+        errorTitle={`Kunne ikke hente metrikker for ${entity.metadata.name}`}
+        errorMessage={error.message}
       />
     );
 

--- a/plugins/security-metrics/src/hooks/useGroupMetrics.ts
+++ b/plugins/security-metrics/src/hooks/useGroupMetrics.ts
@@ -1,0 +1,39 @@
+import { Entity } from '@backstage/catalog-model';
+import { SikkerhetsmetrikkerSystemTotal } from '../typesFrontend';
+import { useFetchComponentNamesByGroup } from './useFetchComponentNames';
+import { useMetricsQuery } from './useMetricsQuery';
+
+type UseGroupMetricsResult = {
+  data: SikkerhetsmetrikkerSystemTotal[] | undefined;
+  isLoading: boolean;
+  isEmpty: boolean;
+  error: Error | null;
+  errorTitle: string;
+};
+
+export const useGroupMetrics = (entity: Entity): UseGroupMetricsResult => {
+  const { componentNames, componentNamesIsLoading, componentNamesError } =
+    useFetchComponentNamesByGroup(entity);
+  const { data, isPending, error } = useMetricsQuery(componentNames);
+
+  const isLoading =
+    componentNamesIsLoading || (componentNames.length > 0 && isPending);
+
+  const isEmpty =
+    !componentNamesIsLoading &&
+    !componentNamesError &&
+    componentNames.length === 0;
+
+  const combinedError = componentNamesError ?? error ?? null;
+  const errorTitle = componentNamesError
+    ? `Kunne ikke hente reponavn for ${entity.metadata.name}`
+    : `Kunne ikke hente metrikker for ${entity.metadata.name}`;
+
+  return {
+    data,
+    isLoading,
+    isEmpty,
+    error: combinedError,
+    errorTitle,
+  };
+};


### PR DESCRIPTION
## 🔒 Bakgrunn

Info-banner vises i stedet for loading når man åpner sikkerhetsmetrikker-plugin, på grunn av at `componentNames` er tom før lasting er ferdig, så tom-state ble vist for tidlig.

## 🔑 Løsning

Viser info-banner kun når komponentlisten er ferdig lastet og faktisk er tom. Hindrer at tom-state rendres under lasting, samtidig som vi unngår evig loading når ingen komponenter finnes.