### PR TITLE
[Sikkerhetsmetrikker-plugin] Add entity info to requests to improve error logs

### DIFF
--- a/plugins/security-metrics-backend/src/services/ApiService/api.service.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/api.service.ts
@@ -127,10 +127,14 @@ export class ApiService {
   }
 
   async fetchMetricsData(
+    entityName: string,
     componentNames: string[],
     entraIdToken: string,
   ): Promise<Either<ErrorResponse, AggregatedSikkerhetsmetrikker>> {
-    const endpointResult = this.buildEndpoint('/api/scannerData');
+    const safeEntityName = encodeURIComponent(entityName);
+    const endpointResult = this.buildEndpoint(
+      `/api/scannerData/${safeEntityName}`,
+    );
     if (endpointResult.isLeft()) {
       return Left.create(endpointResult.error);
     }
@@ -177,9 +181,13 @@ export class ApiService {
   }
 
   async fetchMetricsUpdateStatus(
+    entityName: string,
     entraIdToken: string,
   ): Promise<Either<ErrorResponse, MetricsUpdateStatus>> {
-    const endpointResult = this.buildEndpoint('/api/scannerData/status');
+    const safeEntityName = encodeURIComponent(entityName);
+    const endpointResult = this.buildEndpoint(
+      `/api/scannerData/${safeEntityName}/status`,
+    );
     if (endpointResult.isLeft()) {
       return Left.create(endpointResult.error);
     }
@@ -196,12 +204,16 @@ export class ApiService {
   }
 
   async fetchVulnerabilityTrendsData(
+    entityName: string,
     componentNames: string[],
     fromDate: Date,
     toDate: Date,
     entraIdToken: string,
   ): Promise<Either<ErrorResponse, SeverityCounts[]>> {
-    const endpointResult = this.buildEndpoint('/api/scannerData/trends');
+    const safeEntityName = encodeURIComponent(entityName);
+    const endpointResult = this.buildEndpoint(
+      `/api/scannerData/${safeEntityName}/trends`,
+    );
     if (endpointResult.isLeft()) {
       return Left.create(endpointResult.error);
     }

--- a/plugins/security-metrics-backend/src/services/ApiService/router.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/router.ts
@@ -82,6 +82,19 @@ export const createRouter = async (
           return res.status(authError.status).send(authError);
         }
 
+        const entityName = req.query.entityName as string | undefined;
+        if (!entityName) {
+          return res
+            .status(400)
+            .send(
+              errorResponse(
+                400,
+                'BAD_REQUEST',
+                'Mangler entityName query parameter',
+              ),
+            );
+        }
+
         const entraIdToken = req.header('EntraId');
         if (!entraIdToken) {
           return res
@@ -89,7 +102,10 @@ export const createRouter = async (
             .send(errorResponse(400, 'BAD_REQUEST', 'EntraId is required'));
         }
 
-        const result = await apiService.fetchMetricsUpdateStatus(entraIdToken);
+        const result = await apiService.fetchMetricsUpdateStatus(
+          entityName,
+          entraIdToken,
+        );
 
         return sendEither(res, result);
       },
@@ -107,8 +123,22 @@ export const createRouter = async (
           return res.status(authError.status).send(authError);
         }
 
+        const entityName = req.query.entityName as string | undefined;
         const request = req.body as FetchMetricsRequestBody;
+        if (!entityName) {
+          return res
+            .status(400)
+            .send(
+              errorResponse(
+                400,
+                'BAD_REQUEST',
+                'Mangler entityName query parameter',
+              ),
+            );
+        }
+
         const result = await apiService.fetchMetricsData(
+          entityName,
           request.componentNames,
           request.entraIdToken,
         );
@@ -168,8 +198,22 @@ export const createRouter = async (
           return res.status(authError.status).send(authError);
         }
 
+        const entityName = req.query.entityName as string | undefined;
+        if (!entityName) {
+          return res
+            .status(400)
+            .send(
+              errorResponse(
+                400,
+                'BAD_REQUEST',
+                'Mangler entityName query parameter',
+              ),
+            );
+        }
+
         const request = req.body as FetchTrendsRequestBody;
         const result = await apiService.fetchVulnerabilityTrendsData(
+          entityName,
           request.componentNames,
           request.fromDate,
           request.toDate,

--- a/plugins/security-metrics/src/components/MetricsStatus.tsx
+++ b/plugins/security-metrics/src/components/MetricsStatus.tsx
@@ -28,9 +28,13 @@ const SCANNER_LABELS: Record<keyof MetricsUpdateStatus, string> = {
   riscMetrics: 'Risiko- og sårbarhetsarbeid',
 };
 
-export const MetricsStatus = () => {
+interface MetricsStatusProps {
+  entityName: string;
+}
+
+export const MetricsStatus = ({ entityName }: MetricsStatusProps) => {
   const [open, setOpen] = useState(false);
-  const { data, isPending, error } = useMetricsUpdateStatusQuery();
+  const { data, isPending, error } = useMetricsUpdateStatusQuery(entityName);
 
   if (isPending || error || !data) {
     return null;

--- a/plugins/security-metrics/src/components/Trend/Trend.tsx
+++ b/plugins/security-metrics/src/components/Trend/Trend.tsx
@@ -7,6 +7,7 @@ import { CardTitle } from '../CardTitle';
 import { Graph } from './TrendGraph';
 import { GraphLabels } from './GraphLabels';
 import { Progress } from '@backstage/core-components';
+import { useEntity } from '@backstage/plugin-catalog-react';
 
 interface TrendProps {
   componentNames: string[] | string;
@@ -14,6 +15,7 @@ interface TrendProps {
 }
 
 export const Trend = ({ componentNames, showTotal }: TrendProps) => {
+  const { entity } = useEntity();
   const toDate = useRef(new Date()).current;
   const [fromDate, setFromDate] = useState<Date>(() =>
     getFromDate('oneMonth', toDate),
@@ -24,7 +26,12 @@ export const Trend = ({ componentNames, showTotal }: TrendProps) => {
     ? componentNames
     : [componentNames];
 
-  const { data, isPending, error } = useTrendsQuery(items, fromDate, toDate);
+  const { data, isPending, error } = useTrendsQuery(
+    entity.metadata.name,
+    items,
+    fromDate,
+    toDate,
+  );
 
   return (
     <CardTitle title="Trend">

--- a/plugins/security-metrics/src/components/Views/GroupPage.tsx
+++ b/plugins/security-metrics/src/components/Views/GroupPage.tsx
@@ -97,7 +97,7 @@ export const GroupPage = () => {
   return (
     <Stack gap={2}>
       <Stack flexDirection="row" alignItems="center" gap={2}>
-        <MetricsStatus />
+        <MetricsStatus entityName={entity.metadata.name} />
         <Stack
           flexDirection="row"
           gap={2}

--- a/plugins/security-metrics/src/components/Views/SingleComponentPage.tsx
+++ b/plugins/security-metrics/src/components/Views/SingleComponentPage.tsx
@@ -56,7 +56,7 @@ export const SingleComponentPage = () => {
   return (
     <Stack gap={2}>
       <Stack direction="row" alignItems="center" gap={2}>
-        <MetricsStatus />
+        <MetricsStatus entityName={componentName} />
         <Stack
           flexDirection="row"
           gap={2}

--- a/plugins/security-metrics/src/components/Views/SystemPage.tsx
+++ b/plugins/security-metrics/src/components/Views/SystemPage.tsx
@@ -25,20 +25,23 @@ import { useFetchComponentNamesFromSystem } from '../../hooks/useFetchComponentN
 import { MetricsStatus } from '../MetricsStatus';
 
 export const SystemPage = () => {
-  const { entity: system } = useEntity();
+  const { entity } = useEntity();
 
   const { componentNames, componentNamesIsLoading, componentNamesError } =
-    useFetchComponentNamesFromSystem(system);
+    useFetchComponentNamesFromSystem(entity);
 
   const { showTotal, toggleShowTotal } = useShowTrendTotal();
   const [openViewSettings, setOpenViewSettings] = useState(false);
 
-  const { data, isPending, error } = useMetricsQuery(componentNames);
+  const { data, isPending, error } = useMetricsQuery(
+    entity.metadata.name,
+    componentNames,
+  );
 
   if (error || componentNamesError)
     return (
       <ErrorBanner
-        errorTitle={`Kunne ikke hente metrikker for systemet ${system.metadata.name}`}
+        errorTitle={`Kunne ikke hente metrikker for systemet ${entity.metadata.name}`}
         errorMessage={error ? error.message : componentNamesError?.message}
       />
     );
@@ -52,7 +55,7 @@ export const SystemPage = () => {
   return (
     <Stack gap={2}>
       <Stack direction="row" alignItems="center" gap={2}>
-        <MetricsStatus />
+        <MetricsStatus entityName={entity.metadata.name} />
         <Stack
           flexDirection="row"
           gap={2}

--- a/plugins/security-metrics/src/hooks/useGroupMetrics.ts
+++ b/plugins/security-metrics/src/hooks/useGroupMetrics.ts
@@ -14,7 +14,10 @@ type UseGroupMetricsResult = {
 export const useGroupMetrics = (entity: Entity): UseGroupMetricsResult => {
   const { componentNames, componentNamesIsLoading, componentNamesError } =
     useFetchComponentNamesByGroup(entity);
-  const { data, isPending, error } = useMetricsQuery(componentNames);
+  const { data, isPending, error } = useMetricsQuery(
+    entity.metadata.name,
+    componentNames,
+  );
 
   const isLoading =
     componentNamesIsLoading || (componentNames.length > 0 && isPending);

--- a/plugins/security-metrics/src/hooks/useMetricsQuery.ts
+++ b/plugins/security-metrics/src/hooks/useMetricsQuery.ts
@@ -6,22 +6,26 @@ import { AggregatedSikkerhetsmetrikker } from '../typesFrontend';
 import { post } from '../api/client';
 
 const metricsQueryKeys = {
-  metrics: (componentNames: string[]) => ['metrics', componentNames],
+  metrics: (entityName: string) => ['metrics', entityName],
 };
 
-export const useMetricsQuery = (componentNames: string[]) => {
+export const useMetricsQuery = (
+  entityName: string,
+  componentNames: string[],
+) => {
   const { config, backstageAuthApi, microsoftAuthApi, endpointUrl } = useConfig(
     MetricTypes.metrics,
   );
 
   return useQuery<AggregatedSikkerhetsmetrikker, Error>({
-    queryKey: metricsQueryKeys.metrics(componentNames),
+    queryKey: metricsQueryKeys.metrics(entityName),
     queryFn: async () => {
       const { entraIdToken, backstageToken } = await getAuthenticationTokens(
         config,
         backstageAuthApi,
         microsoftAuthApi,
       );
+      endpointUrl.searchParams.set('entityName', entityName);
       return post<
         { componentNames: string[]; entraIdToken: string },
         AggregatedSikkerhetsmetrikker

--- a/plugins/security-metrics/src/hooks/useMetricsUpdateStatusQuery.ts
+++ b/plugins/security-metrics/src/hooks/useMetricsUpdateStatusQuery.ts
@@ -5,7 +5,7 @@ import { useConfig } from './getConfig';
 import { MetricsUpdateStatus } from '../typesFrontend';
 import { get } from '../api/client';
 
-export const useMetricsUpdateStatusQuery = () => {
+export const useMetricsUpdateStatusQuery = (entityName: string) => {
   const { config, backstageAuthApi, microsoftAuthApi, endpointUrl } = useConfig(
     MetricTypes.metricsUpdateStatus,
   );
@@ -18,6 +18,7 @@ export const useMetricsUpdateStatusQuery = () => {
         backstageAuthApi,
         microsoftAuthApi,
       );
+      endpointUrl.searchParams.set('entityName', entityName);
       return get<MetricsUpdateStatus>(
         endpointUrl,
         backstageToken,

--- a/plugins/security-metrics/src/hooks/useTrendsQuery.ts
+++ b/plugins/security-metrics/src/hooks/useTrendsQuery.ts
@@ -6,6 +6,7 @@ import { TrendSeverityCounts } from '../typesFrontend';
 import { post } from '../api/client';
 
 export const useTrendsQuery = (
+  entityName: string,
   componentNames: string[],
   fromDate: Date,
   toDate: Date,
@@ -22,6 +23,7 @@ export const useTrendsQuery = (
         backstageAuthApi,
         microsoftAuthApi,
       );
+      endpointUrl.searchParams.set('entityName', entityName);
       return post<
         {
           componentNames: string[];


### PR DESCRIPTION
## 🔒 Bakgrunn

Jira: https://kartverket.atlassian.net/jira/software/projects/EDSKVIS/boards/177?selectedIssue=EDSKVIS-896

Det har vært vanskelig å debugge feil i SMAPI fordi error-/access-loggene har hatt lite kontekst.

## 🔑 Løsning

Sender med Backstage-entiteten i requestene mot `scannerData`-endepunktene. Dette gir backend mer kontekst om hvilken entitet requesten gjelder, og gjør det enklere å logge og feilsøke.