### PR TITLE
Upgrade vm2

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "prismjs": "1.30.0",
     "picomatch": "4.0.4",
     "brace-expansion": "2.0.3",
-    "bn.js": "4.12.3"
+    "bn.js": "4.12.3",
+    "vm2": "3.11.2"
   },
   "prettier": "@backstage/cli/config/prettier",
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14464,7 +14464,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.11.0, acorn@npm:^8.14.1, acorn@npm:^8.15.0, acorn@npm:^8.16.0, acorn@npm:^8.4.1, acorn@npm:^8.9.0":
+"acorn@npm:^8.11.0, acorn@npm:^8.15.0, acorn@npm:^8.16.0, acorn@npm:^8.4.1, acorn@npm:^8.9.0":
   version: 8.16.0
   resolution: "acorn@npm:8.16.0"
   bin:
@@ -34958,15 +34958,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vm2@npm:^3.10.0":
-  version: 3.10.2
-  resolution: "vm2@npm:3.10.2"
+"vm2@npm:3.11.2":
+  version: 3.11.2
+  resolution: "vm2@npm:3.11.2"
   dependencies:
-    acorn: "npm:^8.14.1"
+    acorn: "npm:^8.15.0"
     acorn-walk: "npm:^8.3.4"
   bin:
     vm2: bin/vm2
-  checksum: 10c0/28ba477050c0c3ab717c3b0c4940c91d8e58d0badebb58073ff250ea053c545bab97c70f9d892bc52dd871c58e7197a055827f5414be3c54e7b5f14dacb0624e
+  checksum: 10c0/9d3fd4c1e3b2b3c4c50abd5a758090fafd88e523581e1739cdfffcd517c9342390c21ca6d1bd869b73626e7f8e7ab213b3126fd4a0d7c8011d5e535ecf434839
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🔒 Bakgrunn

Mange sårbarheter i transitive `vm2`-versjoner.

## 🔑 Løsning

Oppgradere `vm2` til nyeste versjon med resolutions