### PR TITLE
Improve handling vulnerabilities with multiple alerts

### DIFF
--- a/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
@@ -105,7 +105,6 @@ export type Vulnerability = {
   changedAt: Date;
   comment: string;
   changedBy: string;
-  alertCount: number;
   scannerSpecificInfo: ScannerSpecificInfo;
 };
 

--- a/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
@@ -34,29 +34,38 @@ export type SecretAlert = {
   bypassedBy?: GithubBypassed;
 };
 
-export type DependabotSpecificInfo = {
+export type ScannerAlertInfo = {
+  alertId: string;
   htmlUrl: string;
+};
+
+export type DependabotSpecificInfo = {
+  alerts: ScannerAlertInfo[];
+  isFixable: boolean;
   isDirect: boolean;
 };
 
 export type CodeQlSpecificInfo = {
-  htmlUrl: string;
-  branch: string;
+  alerts: ScannerAlertInfo[];
+  branch: string[];
   locations: number;
 };
 
 export type PharosSpecificInfo = {
-  htmlUrl: string;
+  alerts: ScannerAlertInfo[];
   branch: string;
 };
 
 export type SysdigSpecificInfo = {
   htmlUrl: string;
+  findingCount: number;
   containerNames: string[];
   locations: { cluster: string; namespace: string }[];
-  isExploitable: Boolean;
-  isRunning: Boolean;
+  isExploitable: boolean;
+  isRunning: boolean;
   packages: string[];
+  isFixable: boolean;
+  isCisaKEV: boolean;
 };
 
 export type ScannerSpecificInfo = {
@@ -96,6 +105,7 @@ export type Vulnerability = {
   changedAt: Date;
   comment: string;
   changedBy: string;
+  alertCount: number;
   scannerSpecificInfo: ScannerSpecificInfo;
 };
 

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/AlertLinks.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/AlertLinks.tsx
@@ -1,0 +1,43 @@
+import { Link } from '@backstage/core-components';
+import { ScannerAlertInfo } from '../../../typesFrontend';
+import Box from '@mui/material/Box';
+
+type AlertLinksProps = {
+  alerts: ScannerAlertInfo[];
+  label?: string;
+};
+
+const formatUrl = (url: string) =>
+  url.length > 80 ? `${url.slice(0, 30)}...` : url;
+
+export const AlertLinks = ({
+  alerts,
+  label = 'GitHub-alerts',
+}: AlertLinksProps) => {
+  if (alerts.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <strong>{label}: </strong>
+      {alerts.length === 1 ? (
+        <Link to={new URL(alerts[0].htmlUrl).href}>
+          {formatUrl(alerts[0].htmlUrl)}
+        </Link>
+      ) : (
+        <Box component="ul" sx={{ mt: 0.5, mb: 0, pl: 3 }}>
+          {alerts.map(alert => {
+            const link = new URL(alert.htmlUrl).href;
+
+            return (
+              <li key={alert.alertId}>
+                <Link to={link}>{formatUrl(link)}</Link>
+              </li>
+            );
+          })}
+        </Box>
+      )}
+    </>
+  );
+};

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/AlertLinks.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/AlertLinks.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@backstage/core-components';
 import { ScannerAlertInfo } from '../../../typesFrontend';
-import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
 
 type AlertLinksProps = {
   alerts: ScannerAlertInfo[];
@@ -8,11 +8,11 @@ type AlertLinksProps = {
 };
 
 const formatUrl = (url: string) =>
-  url.length > 80 ? `${url.slice(0, 30)}...` : url;
+  url.length > 80 ? `${url.slice(0, 18)}...${url.slice(-40)}` : url;
 
 export const AlertLinks = ({
   alerts,
-  label = 'GitHub-alerts',
+  label = 'GitHub-varsler',
 }: AlertLinksProps) => {
   if (alerts.length === 0) {
     return null;
@@ -26,17 +26,17 @@ export const AlertLinks = ({
           {formatUrl(alerts[0].htmlUrl)}
         </Link>
       ) : (
-        <Box component="ul" sx={{ mt: 0.5, mb: 0, pl: 3 }}>
+        <Stack spacing={0.5} sx={{ mt: 0.5 }}>
           {alerts.map(alert => {
             const link = new URL(alert.htmlUrl).href;
 
             return (
-              <li key={alert.alertId}>
-                <Link to={link}>{formatUrl(link)}</Link>
-              </li>
+              <Link key={alert.alertId} to={link}>
+                {formatUrl(link)}
+              </Link>
             );
           })}
-        </Box>
+        </Stack>
       )}
     </>
   );

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/CodeQLContent.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/CodeQLContent.tsx
@@ -1,9 +1,8 @@
 import Typography from '@mui/material/Typography';
-
 import { Vulnerability } from '../../../typesFrontend';
-import { Link } from '@backstage/core-components';
 import { ErrorBanner } from '../../ErrorBanner';
 import { IdsWithUrls } from './IdsWithUrls';
+import { AlertLinks } from './AlertLinks';
 
 interface CodeQLContentProps {
   vulnerability: Vulnerability;
@@ -11,22 +10,19 @@ interface CodeQLContentProps {
 
 export const CodeQLContent = ({ vulnerability }: CodeQLContentProps) => {
   const info = vulnerability.scannerSpecificInfo.codeQLInfo;
+
   if (!info) {
     return <ErrorBanner />;
   }
-  const link = new URL(info?.htmlUrl).href;
 
   return (
-    <Typography>
-      <strong>GitHub-referanse: </strong>
-      <Link to={link}>
-        {link.length > 80 ? link.slice(0, 30).concat('...') : link}
-      </Link>
+    <Typography component="div">
+      <AlertLinks alerts={info.alerts} />
       <br />
       <IdsWithUrls vulnerabilityIdInfo={vulnerability.vulnerabilityIdInfo} />
       <br />
       <strong>Branch: </strong>
-      {info.branch}
+      {info.branch.join(', ')}
       <br />
       <strong>Antall lokasjoner: </strong>
       {info.locations}

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/DependabotContent.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/DependabotContent.tsx
@@ -1,9 +1,8 @@
 import Typography from '@mui/material/Typography';
-
 import { Vulnerability } from '../../../typesFrontend';
-import { Link } from '@backstage/core-components';
 import { ErrorBanner } from '../../ErrorBanner';
 import { IdsWithUrls } from './IdsWithUrls';
+import { AlertLinks } from './AlertLinks';
 
 interface DependabotContentProps {
   vulnerability: Vulnerability;
@@ -13,17 +12,14 @@ export const DependabotContent = ({
   vulnerability,
 }: DependabotContentProps) => {
   const info = vulnerability.scannerSpecificInfo.dependabotInfo;
+
   if (!info) {
     return <ErrorBanner />;
   }
-  const link = new URL(info?.htmlUrl).href;
 
   return (
-    <Typography>
-      <strong>GitHub-referanse: </strong>
-      <Link to={link}>
-        {link.length > 80 ? link.slice(0, 30).concat('...') : link}
-      </Link>
+    <Typography component="div">
+      <AlertLinks alerts={info.alerts} />
       <br />
       <IdsWithUrls vulnerabilityIdInfo={vulnerability.vulnerabilityIdInfo} />
     </Typography>

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/IdsWithUrls.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/IdsWithUrls.tsx
@@ -20,7 +20,7 @@ export const IdsWithUrls = ({ vulnerabilityIdInfo }: IdsWithURLsProps) => {
   }
   return (
     <>
-      <strong>Referanser: </strong>
+      <strong>Sårbarhets-referanser: </strong>
       {idInfoWithUrl.map(id => (
         <>
           {idInfoWithUrl.length > 1 && <br />}

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/IdsWithUrls.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/IdsWithUrls.tsx
@@ -20,7 +20,7 @@ export const IdsWithUrls = ({ vulnerabilityIdInfo }: IdsWithURLsProps) => {
   }
   return (
     <>
-      <strong>Sårbarhets-referanser: </strong>
+      <strong>Referanser: </strong>
       {idInfoWithUrl.map(id => (
         <>
           {idInfoWithUrl.length > 1 && <br />}

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/PharosContent.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/PharosContent.tsx
@@ -1,9 +1,8 @@
 import Typography from '@mui/material/Typography';
-
 import { Vulnerability } from '../../../typesFrontend';
-import { Link } from '@backstage/core-components';
 import { ErrorBanner } from '../../ErrorBanner';
 import { IdsWithUrls } from './IdsWithUrls';
+import { AlertLinks } from './AlertLinks';
 
 interface PharosContentProps {
   vulnerability: Vulnerability;
@@ -11,17 +10,14 @@ interface PharosContentProps {
 
 export const PharosContent = ({ vulnerability }: PharosContentProps) => {
   const info = vulnerability.scannerSpecificInfo.pharosInfo;
+
   if (!info) {
     return <ErrorBanner />;
   }
-  const link = new URL(info?.htmlUrl).href;
 
   return (
-    <Typography>
-      <strong>GitHub-referanse: </strong>
-      <Link to={link}>
-        {link.length > 80 ? link.slice(0, 30).concat('...') : link}
-      </Link>
+    <Typography component="div">
+      <AlertLinks alerts={info.alerts} />
       <br />
       <IdsWithUrls vulnerabilityIdInfo={vulnerability.vulnerabilityIdInfo} />
       <br />

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/ScannerCard.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/ScannerCard.tsx
@@ -9,9 +9,10 @@ import { ScannerTag } from '../ScannerTag';
 type Props = {
   scanner: Scanner;
   children: ReactNode;
+  count: number;
 };
 
-export const ScannerCard = ({ scanner, children }: Props) => {
+export const ScannerCard = ({ scanner, children, count }: Props) => {
   const theme = useTheme();
   const isDarkMode = theme.palette.mode === 'dark';
 
@@ -28,7 +29,7 @@ export const ScannerCard = ({ scanner, children }: Props) => {
     >
       <Box display="flex" flexDirection="column" gap={1}>
         <Box display="flex" alignItems="center" gap={1}>
-          <ScannerTag scanner={scanner} />
+          <ScannerTag scanner={scanner} count={count} />
         </Box>
         {children}
       </Box>

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/ScannerCard.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/ScannerCard.tsx
@@ -14,6 +14,7 @@ type Props = {
 export const ScannerCard = ({ scanner, children }: Props) => {
   const theme = useTheme();
   const isDarkMode = theme.palette.mode === 'dark';
+
   return (
     <Box
       m={1}
@@ -26,7 +27,9 @@ export const ScannerCard = ({ scanner, children }: Props) => {
       }}
     >
       <Box display="flex" flexDirection="column" gap={1}>
-        <ScannerTag scanner={scanner} />
+        <Box display="flex" alignItems="center" gap={1}>
+          <ScannerTag scanner={scanner} />
+        </Box>
         {children}
       </Box>
     </Box>

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/ScannerDetails.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/ScannerDetails.tsx
@@ -4,6 +4,7 @@ import { CodeQLContent } from './CodeQLContent';
 import { DependabotContent } from './DependabotContent';
 import { PharosContent } from './PharosContent';
 import { SysdigContent } from './SysdigContent';
+import { getScannerCount } from '../utils';
 
 type ScannerProps = {
   vulnerability: Vulnerability;
@@ -12,7 +13,10 @@ type ScannerProps = {
 
 export const ScannerDetails = ({ vulnerability, scanner }: ScannerProps) => {
   return (
-    <ScannerCard scanner={scanner}>
+    <ScannerCard
+      scanner={scanner}
+      count={getScannerCount(vulnerability, scanner)}
+    >
       {scanner === Scanner.CodeQL && (
         <CodeQLContent vulnerability={vulnerability} />
       )}

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/SysdigContent.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/SysdigContent.tsx
@@ -1,5 +1,4 @@
 import Typography from '@mui/material/Typography';
-
 import { Vulnerability } from '../../../typesFrontend';
 import { Link } from '@backstage/core-components';
 import { ErrorBanner } from '../../ErrorBanner';
@@ -11,6 +10,7 @@ interface SysdigContentProps {
 
 export const SysdigContent = ({ vulnerability }: SysdigContentProps) => {
   const info = vulnerability.scannerSpecificInfo.sysdigInfo;
+
   if (!info) {
     return <ErrorBanner />;
   }
@@ -29,16 +29,19 @@ export const SysdigContent = ({ vulnerability }: SysdigContentProps) => {
     <Typography>
       <strong>Sysdig-referanse: </strong>
       <Link to={link}>
-        {link.length > 80 ? link.slice(0, 30).concat('...') : link}
+        {link.length > 80 ? link.slice(0, 40).concat('...') : link}
       </Link>
       <br />
       <IdsWithUrls vulnerabilityIdInfo={vulnerability.vulnerabilityIdInfo} />
+
       <br />
       <strong>Pakker: </strong>
       {info.packages.join(', ')}
+
       <br />
       <strong>Containere: </strong>
       {info.containerNames.join(', ')}
+
       <br />
       <strong>Lokasjoner: </strong>
       {Object.entries(clusterToNamespaces).map(([cluster, nsSet]) => (

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/SysdigContent.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerDetails/SysdigContent.tsx
@@ -27,7 +27,7 @@ export const SysdigContent = ({ vulnerability }: SysdigContentProps) => {
 
   return (
     <Typography>
-      <strong>Sysdig-referanse: </strong>
+      <strong>Sysdig-varsler: </strong>
       <Link to={link}>
         {link.length > 80 ? link.slice(0, 40).concat('...') : link}
       </Link>

--- a/plugins/security-metrics/src/components/VulnerabilityTable/ScannerTag.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/ScannerTag.tsx
@@ -7,18 +7,43 @@ import Stack from '@mui/material/Stack';
 
 type Props = {
   scanner: Scanner;
+  count: number;
 };
 
-export const ScannerTag = ({ scanner }: Props) => {
+export const ScannerTag = ({ scanner, count = 0 }: Props) => {
   return (
-    <Stack key={scanner} flexDirection="row" alignItems="center" gap={1}>
+    <Stack
+      direction="row"
+      alignItems="center"
+      gap={1}
+      sx={{ whiteSpace: 'nowrap' }}
+    >
       <Box
         width={10}
         height={10}
         borderRadius="50%"
         bgcolor={getScannerColor(scanner)}
       />
-      <Typography>{scanner}</Typography>
+
+      <Typography variant="body2">{scanner}</Typography>
+
+      {count > 1 && (
+        <Box
+          component="span"
+          sx={{
+            px: 0.75,
+            py: 0.125,
+            borderRadius: '50%',
+            bgcolor: 'action.hover',
+            color: 'text.secondary',
+            fontSize: '0.7rem',
+            lineHeight: 1.4,
+            fontWeight: 600,
+          }}
+        >
+          {count}
+        </Box>
+      )}
     </Stack>
   );
 };

--- a/plugins/security-metrics/src/components/VulnerabilityTable/SeverityTag.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/SeverityTag.tsx
@@ -11,6 +11,13 @@ export const SeverityTag = ({ severity }: Props) => {
   return (
     <Chip
       label={getStandardSeverityFormat(severity)}
+      slotProps={{
+        label: {
+          sx: {
+            fontSize: '0.8rem',
+          },
+        },
+      }}
       sx={{
         color:
           severity === 'low' || severity === 'negligible'

--- a/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTable.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTable.tsx
@@ -50,7 +50,7 @@ export const VulnerabilityTable = ({
       <Table size="small" sx={{ tableLayout: 'fixed', minWidth: 800 }}>
         <TableHead>
           <TableRow>
-            <TableCell>Id</TableCell>
+            <TableCell width="15%">Id</TableCell>
             <TableCell width="25%">Beskrivelse</TableCell>
             {sortableHeaders.map(header => (
               <TableCell key={header} sortDirection={sortDir}>

--- a/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTable.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTable.tsx
@@ -66,7 +66,7 @@ export const VulnerabilityTable = ({
                     {header}
                   </TableSortLabel>
                   {header === 'Dato' && (
-                    <Tooltip title="Datoen da sårbarheten først ble oppdaget av sikkerhetsmetrikker-APIet, eller sist ble oppdatert.">
+                    <Tooltip title="Datoen da sårbarheten først ble oppdaget av sikkerhetsmetrikker-APIet, eller sist ble oppdatert. Ny betyr at sårbarheten har kommet inn siste 7 dagene.">
                       <InfoIcon fontSize="small" sx={{ ml: 0.5 }} />
                     </Tooltip>
                   )}

--- a/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTable.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTable.tsx
@@ -1,23 +1,23 @@
-import { useState } from 'react';
-import { usePaginationProps } from '../../hooks/usePagination';
-import { Vulnerability } from '../../typesFrontend';
-import { SortableHeader, sortableHeaders, sortVulnerabilities } from './utils';
-import { VulnerabilityTableRow } from './VulnerabilityTableRow';
-import TableContainer from '@mui/material/TableContainer';
-import Paper from '@mui/material/Paper';
-import Table from '@mui/material/Table';
-import TableHead from '@mui/material/TableHead';
-import TableRow from '@mui/material/TableRow';
-import TableCell from '@mui/material/TableCell';
-import TableSortLabel from '@mui/material/TableSortLabel';
-import TableBody from '@mui/material/TableBody';
-import TableFooter from '@mui/material/TableFooter';
-import TablePagination from '@mui/material/TablePagination';
-import Tooltip from '@mui/material/Tooltip';
 import InfoIcon from '@mui/icons-material/Info';
 import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableFooter from '@mui/material/TableFooter';
+import TableHead from '@mui/material/TableHead';
+import TablePagination from '@mui/material/TablePagination';
+import TableRow from '@mui/material/TableRow';
+import TableSortLabel from '@mui/material/TableSortLabel';
+import Tooltip from '@mui/material/Tooltip';
+import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { usePaginationProps } from '../../hooks/usePagination';
+import { Vulnerability } from '../../typesFrontend';
 import { ContextDescriptions } from './ContextDescriptions';
+import { SortableHeader, sortVulnerabilities } from './utils';
+import { VulnerabilityTableRow } from './VulnerabilityTableRow';
 
 type Props = {
   vulnerabilities: Vulnerability[];
@@ -45,44 +45,62 @@ export const VulnerabilityTable = ({
   );
   const { page, rowsPerPage } = paginationProps;
 
+  const handleSort = (header: SortableHeader) => {
+    setSortDir(sortType === header && sortDir === 'asc' ? 'desc' : 'asc');
+    setSortType(header);
+  };
+
+  const renderSortableHeader = (header: SortableHeader) => (
+    <TableCell
+      key={header}
+      sortDirection={sortType === header ? sortDir : false}
+    >
+      <Box display="flex" alignItems="center" minWidth={0}>
+        <TableSortLabel
+          active={sortType === header}
+          direction={sortDir}
+          onClick={() => handleSort(header)}
+        >
+          {header}
+        </TableSortLabel>
+
+        {header === 'Dato' && (
+          <Tooltip title="Datoen da sårbarheten først ble oppdaget av sikkerhetsmetrikker-APIet, eller sist ble oppdatert. Ny betyr at sårbarheten har kommet inn i løpet av de siste 7 dagene.">
+            <InfoIcon fontSize="small" sx={{ ml: 0.5, flexShrink: 0 }} />
+          </Tooltip>
+        )}
+
+        {header === 'Kontekst' && (
+          <Tooltip title={<ContextDescriptions />}>
+            <InfoIcon fontSize="small" sx={{ ml: 0.5, flexShrink: 0 }} />
+          </Tooltip>
+        )}
+      </Box>
+    </TableCell>
+  );
+
   return (
     <TableContainer component={Paper}>
-      <Table size="small" sx={{ tableLayout: 'fixed', minWidth: 800 }}>
+      <Table size="small" sx={{ tableLayout: 'fixed', minWidth: 1050 }}>
         <TableHead>
           <TableRow>
-            <TableCell width="15%">Id</TableCell>
-            <TableCell width="25%">Beskrivelse</TableCell>
-            {sortableHeaders.map(header => (
-              <TableCell key={header} sortDirection={sortDir}>
-                <Box display="flex" alignItems="center">
-                  <TableSortLabel
-                    active={sortType === header}
-                    direction={sortDir}
-                    onClick={() => {
-                      setSortDir(sortDir === 'asc' ? 'desc' : 'asc');
-                      setSortType(header);
-                    }}
-                  >
-                    {header}
-                  </TableSortLabel>
-                  {header === 'Dato' && (
-                    <Tooltip title="Datoen da sårbarheten først ble oppdaget av sikkerhetsmetrikker-APIet, eller sist ble oppdatert. Ny betyr at sårbarheten har kommet inn siste 7 dagene.">
-                      <InfoIcon fontSize="small" sx={{ ml: 0.5 }} />
-                    </Tooltip>
-                  )}
-                  {header === 'Kontekst' && (
-                    <Tooltip title={<ContextDescriptions />}>
-                      <InfoIcon fontSize="small" sx={{ ml: 0.5 }} />
-                    </Tooltip>
-                  )}
-                </Box>
-              </TableCell>
-            ))}
+            <TableCell sx={{ width: '12%' }}>Id</TableCell>
+            <TableCell sx={{ width: '25%' }}>Beskrivelse</TableCell>
+
+            {renderSortableHeader('Dato')}
+            {renderSortableHeader('Alvorlighetsgrad')}
+            {renderSortableHeader('Kontekst')}
+
+            <TableCell sx={{ width: '12%' }}>Skannere</TableCell>
+
+            {renderSortableHeader('Status')}
+
             <TableCell sx={{ width: 56, p: 0 }} />
           </TableRow>
         </TableHead>
+
         <TableBody>
-          {vulnerabilities
+          {[...vulnerabilities]
             .sort((a, b) => sortVulnerabilities(a, b, sortType, sortDir))
             .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
             .map(vulnerability => (
@@ -93,6 +111,7 @@ export const VulnerabilityTable = ({
               />
             ))}
         </TableBody>
+
         <TableFooter>
           <TableRow>
             <TablePagination colSpan={8} {...paginationProps} />

--- a/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTableRow.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTableRow.tsx
@@ -90,6 +90,32 @@ export const VulnerabilityTableRow = ({
             <Typography component="span">
               {vulnerability.vulnerabilityId}
             </Typography>
+            {vulnerability.alertCount > 1 && (
+              <Typography
+                variant="body2"
+                component="span"
+                sx={{
+                  color: 'success.main',
+                  wordBreak: 'keep-all',
+                }}
+              >
+                {vulnerability.alertCount} alerts
+              </Typography>
+            )}
+          </Stack>
+        </TableCell>
+
+        <TableCell>
+          <Typography>{vulnerability.summary}</Typography>
+        </TableCell>
+
+        <TableCell>
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <Typography>
+              {vulnerability.dateFirstSeen
+                ? formatDate(vulnerability.dateFirstSeen, 'dd.MM.yyyy')
+                : '–'}
+            </Typography>
             {isRecent(vulnerability.dateFirstSeen, 7) && (
               <Typography
                 variant="body2"
@@ -104,18 +130,6 @@ export const VulnerabilityTableRow = ({
               </Typography>
             )}
           </Stack>
-        </TableCell>
-
-        <TableCell>
-          <Typography>{vulnerability.summary}</Typography>
-        </TableCell>
-
-        <TableCell>
-          <Typography>
-            {vulnerability.dateFirstSeen
-              ? formatDate(vulnerability.dateFirstSeen, 'dd.MM.yyyy')
-              : '–'}
-          </Typography>
         </TableCell>
 
         <TableCell>

--- a/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTableRow.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTableRow.tsx
@@ -21,6 +21,7 @@ import Box from '@mui/material/Box';
 import { VulnerabilityContext } from './VulnerabilityContext';
 import ErrorIcon from '@mui/icons-material/Error';
 import UpdateIcon from '@mui/icons-material/Update';
+import { getDuplicateAlertCount } from './utils';
 
 const StatusLabel: Record<Status, string> = {
   IKKE_STARTET: 'Ikke startet',
@@ -82,6 +83,8 @@ export const VulnerabilityTableRow = ({
     setOpenStatusDialog(false);
   };
 
+  const alertCount = getDuplicateAlertCount(vulnerability);
+
   return (
     <>
       <StyledTableRow accepted={status === 'AKSEPTERT'}>
@@ -90,17 +93,25 @@ export const VulnerabilityTableRow = ({
             <Typography component="span">
               {vulnerability.vulnerabilityId}
             </Typography>
-            {vulnerability.alertCount > 1 && (
-              <Typography
-                variant="body2"
-                component="span"
-                sx={{
-                  color: 'success.main',
-                  wordBreak: 'keep-all',
-                }}
-              >
-                {vulnerability.alertCount} alerts
-              </Typography>
+
+            {alertCount > 1 && (
+              <Tooltip title="Flere funn fra samme skanner er slått sammen i denne raden">
+                <Typography
+                  variant="caption"
+                  component="span"
+                  color="text.secondary"
+                  sx={{
+                    whiteSpace: 'nowrap',
+                    flexShrink: 0,
+                    px: 0.75,
+                    py: 0.25,
+                    borderRadius: 1,
+                    bgcolor: 'action.hover',
+                  }}
+                >
+                  {alertCount} funn
+                </Typography>
+              </Tooltip>
             )}
           </Stack>
         </TableCell>

--- a/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTableRow.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTableRow.tsx
@@ -21,7 +21,7 @@ import Box from '@mui/material/Box';
 import { VulnerabilityContext } from './VulnerabilityContext';
 import ErrorIcon from '@mui/icons-material/Error';
 import UpdateIcon from '@mui/icons-material/Update';
-import { getDuplicateAlertCount } from './utils';
+import { getScannerCount } from './utils';
 
 const StatusLabel: Record<Status, string> = {
   IKKE_STARTET: 'Ikke startet',
@@ -83,50 +83,30 @@ export const VulnerabilityTableRow = ({
     setOpenStatusDialog(false);
   };
 
-  const alertCount = getDuplicateAlertCount(vulnerability);
-
   return (
     <>
       <StyledTableRow accepted={status === 'AKSEPTERT'}>
         <TableCell>
           <Stack direction="row" alignItems="center" spacing={1}>
-            <Typography component="span">
+            <Box component="span" sx={{ lineHeight: 1.5 }}>
               {vulnerability.vulnerabilityId}
-            </Typography>
-
-            {alertCount > 1 && (
-              <Tooltip title="Flere funn fra samme skanner er slått sammen i denne raden">
-                <Typography
-                  variant="caption"
-                  component="span"
-                  color="text.secondary"
-                  sx={{
-                    whiteSpace: 'nowrap',
-                    flexShrink: 0,
-                    px: 0.75,
-                    py: 0.25,
-                    borderRadius: 1,
-                    bgcolor: 'action.hover',
-                  }}
-                >
-                  {alertCount} funn
-                </Typography>
-              </Tooltip>
-            )}
+            </Box>
           </Stack>
         </TableCell>
 
         <TableCell>
-          <Typography>{vulnerability.summary}</Typography>
+          <Box component="span" sx={{ lineHeight: 1.5 }}>
+            {vulnerability.summary}
+          </Box>
         </TableCell>
 
         <TableCell>
           <Stack direction="row" alignItems="center" spacing={1}>
-            <Typography>
+            <Box component="span">
               {vulnerability.dateFirstSeen
                 ? formatDate(vulnerability.dateFirstSeen, 'dd.MM.yyyy')
                 : '–'}
-            </Typography>
+            </Box>
             {isRecent(vulnerability.dateFirstSeen, 7) && (
               <Typography
                 variant="body2"
@@ -140,14 +120,6 @@ export const VulnerabilityTableRow = ({
                 Ny
               </Typography>
             )}
-          </Stack>
-        </TableCell>
-
-        <TableCell>
-          <Stack gap={1}>
-            {vulnerability.scanners.map(s => (
-              <ScannerTag key={s} scanner={s} />
-            ))}
           </Stack>
         </TableCell>
 
@@ -174,6 +146,18 @@ export const VulnerabilityTableRow = ({
 
         <TableCell sx={{ verticalAlign: 'middle' }}>
           <VulnerabilityContext vulnerability={vulnerability} />
+        </TableCell>
+
+        <TableCell>
+          <Stack direction="column" gap={0.75} alignItems="flex-start">
+            {vulnerability.scanners.map(scanner => (
+              <ScannerTag
+                key={scanner}
+                scanner={scanner}
+                count={getScannerCount(vulnerability, scanner)}
+              />
+            ))}
+          </Stack>
         </TableCell>
 
         <TableCell sx={{ verticalAlign: 'middle' }}>

--- a/plugins/security-metrics/src/components/VulnerabilityTable/utils.ts
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/utils.ts
@@ -1,4 +1,4 @@
-import { Severity, Vulnerability } from '../../typesFrontend';
+import { Scanner, Severity, Vulnerability } from '../../typesFrontend';
 
 const severityOrder: Record<Severity, number> = {
   ['critical']: 1,
@@ -88,15 +88,22 @@ export const sortVulnerabilities = (
   }
 };
 
-export const getDuplicateAlertCount = (vulnerability: Vulnerability) => {
-  const counts = [
-    vulnerability.scannerSpecificInfo.dependabotInfo?.alerts.length ?? 0,
-    vulnerability.scannerSpecificInfo.codeQLInfo?.alerts.length ?? 0,
-    vulnerability.scannerSpecificInfo.pharosInfo?.alerts.length ?? 0,
-    vulnerability.scannerSpecificInfo.sysdigInfo?.findingCount ?? 0,
-  ];
+export const getScannerCount = (
+  vulnerability: Vulnerability,
+  scanner: Scanner,
+) => {
+  const info = vulnerability.scannerSpecificInfo;
 
-  return counts
-    .filter(count => count > 1)
-    .reduce((sum, count) => sum + count, 0);
+  switch (scanner) {
+    case Scanner.Dependabot:
+      return info.dependabotInfo?.alerts.length ?? 0;
+    case Scanner.CodeQL:
+      return info.codeQLInfo?.alerts.length ?? 0;
+    case Scanner.Pharos:
+      return info.pharosInfo?.alerts.length ?? 0;
+    case Scanner.Sysdig:
+      return info.sysdigInfo?.findingCount ?? 0;
+    default:
+      return 0;
+  }
 };

--- a/plugins/security-metrics/src/components/VulnerabilityTable/utils.ts
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/utils.ts
@@ -87,3 +87,16 @@ export const sortVulnerabilities = (
       return 0;
   }
 };
+
+export const getDuplicateAlertCount = (vulnerability: Vulnerability) => {
+  const counts = [
+    vulnerability.scannerSpecificInfo.dependabotInfo?.alerts.length ?? 0,
+    vulnerability.scannerSpecificInfo.codeQLInfo?.alerts.length ?? 0,
+    vulnerability.scannerSpecificInfo.pharosInfo?.alerts.length ?? 0,
+    vulnerability.scannerSpecificInfo.sysdigInfo?.findingCount ?? 0,
+  ];
+
+  return counts
+    .filter(count => count > 1)
+    .reduce((sum, count) => sum + count, 0);
+};

--- a/plugins/security-metrics/src/typesFrontend.ts
+++ b/plugins/security-metrics/src/typesFrontend.ts
@@ -73,7 +73,6 @@ export type Vulnerability = {
   dateFirstSeen: string;
   statusInfo: VulnerabilityStatusInfo;
   severityUpdatedAt?: string;
-  alertCount: number;
   scannerSpecificInfo: ScannerSpecificInfo;
 };
 

--- a/plugins/security-metrics/src/typesFrontend.ts
+++ b/plugins/security-metrics/src/typesFrontend.ts
@@ -5,25 +5,31 @@ export enum Scanner {
   Sysdig = 'Sysdig',
 }
 
-export type DependabotSpecificInfo = {
+export type ScannerAlertInfo = {
+  alertId: string;
   htmlUrl: string;
-  isDirect: boolean;
+};
+
+export type DependabotSpecificInfo = {
+  alerts: ScannerAlertInfo[];
   isFixable: boolean;
+  isDirect: boolean;
 };
 
 export type CodeQlSpecificInfo = {
-  htmlUrl: string;
-  branch: string;
+  alerts: ScannerAlertInfo[];
+  branch: string[];
   locations: number;
 };
 
 export type PharosSpecificInfo = {
-  htmlUrl: string;
+  alerts: ScannerAlertInfo[];
   branch: string;
 };
 
 export type SysdigSpecificInfo = {
   htmlUrl: string;
+  findingCount: number;
   containerNames: string[];
   locations: { cluster: string; namespace: string }[];
   isExploitable: boolean;
@@ -67,6 +73,7 @@ export type Vulnerability = {
   dateFirstSeen: string;
   statusInfo: VulnerabilityStatusInfo;
   severityUpdatedAt?: string;
+  alertCount: number;
   scannerSpecificInfo: ScannerSpecificInfo;
 };
 


### PR DESCRIPTION
## 🔒 Bakgrunn

Jira: https://kartverket.atlassian.net/jira/software/projects/EDSKVIS/boards/177?selectedIssue=EDSKVIS-1018

Vi grupperer sårbarheter på `repoId` og `sårbarhetsId`. Det fungerer for å samle funn på tvers av skannere, men skjuler tilfeller der samme repo har flere ulike alerts med samme sårbarhetsId. 

## 🔑 Løsning

- Håndterer flere varsler per skanner bedre, og legger til tall med antall varsler når samme skanner har flere relevante varsler.
- Endret scanner-spesifikk visning til å støtte flere lenker per sårbarhet.
- Sysdig viser én overordnet lenke per CVE, og teller unike pakke-funn i stedet for miljø-/runtime-duplikater.
- Justert tabell-layout og styling for bedre lesbarhet.

## 📸 Bilder

**Før**
<img width="1451" height="283" alt="Screenshot 2026-05-11 at 08 09 24" src="https://github.com/user-attachments/assets/aa2387ed-811a-4c49-ab44-f72767f30eb8" />
**Etter**
<img width="1224" height="332" alt="Screenshot 2026-05-11 at 08 06 50" src="https://github.com/user-attachments/assets/18f0c036-db98-45ba-bf54-04503506037f" />