### PR TITLE
Add metrics per owner tab in group view

### DIFF
--- a/plugins/security-metrics-backend/src/services/ApiService/api.service.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/api.service.ts
@@ -12,6 +12,7 @@ import {
   Status,
   VulnerabilitySeverityCounts,
 } from './typesBackend';
+import { SikkerhetsmetrikkerOwnerTotal } from '@kartverket/backstage-plugin-security-metrics-frontend/src/typesFrontend';
 
 export class ApiService {
   private readonly baseUrl: string;
@@ -174,6 +175,30 @@ export class ApiService {
         headers: {
           'Content-Type': 'application/json',
         },
+      },
+      response => response.json(),
+      'Tjenesten for sikkerhetsmetrikker er utilgjengelig akkurat nå. Prøv igjen senere.',
+    );
+  }
+
+  async fetchOwnerMetricsData(
+    componentNames: string[],
+    entraIdToken: string,
+  ): Promise<Either<ErrorResponse, SikkerhetsmetrikkerOwnerTotal>> {
+    const endpointResult = this.buildEndpoint(`/api/scannerData/owners`);
+    if (endpointResult.isLeft()) {
+      return Left.create(endpointResult.error);
+    }
+
+    return this.request(
+      endpointResult.value,
+      entraIdToken,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ componentNames }),
       },
       response => response.json(),
       'Tjenesten for sikkerhetsmetrikker er utilgjengelig akkurat nå. Prøv igjen senere.',

--- a/plugins/security-metrics-backend/src/services/ApiService/api.service.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/api.service.ts
@@ -11,8 +11,8 @@ import {
   SlackNotificationConfig,
   Status,
   VulnerabilitySeverityCounts,
+  SikkerhetsmetrikkerOwnerTotal,
 } from './typesBackend';
-import { SikkerhetsmetrikkerOwnerTotal } from '@kartverket/backstage-plugin-security-metrics-frontend/src/typesFrontend';
 
 export class ApiService {
   private readonly baseUrl: string;

--- a/plugins/security-metrics-backend/src/services/ApiService/router.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/router.ts
@@ -188,6 +188,29 @@ export const createRouter = async (
   );
 
   router.post(
+    '/proxy/fetch-owners-metrics/',
+    withErrorHandling(
+      logger,
+      'Failed to fetch metrics data',
+      async (req, res) => {
+        const authError = await requireBackstageToken(req, auth);
+        if (authError) {
+          return res.status(authError.status).send(authError);
+        }
+
+        const request = req.body as FetchMetricsRequestBody;
+
+        const result = await apiService.fetchOwnerMetricsData(
+          request.componentNames,
+          request.entraIdToken,
+        );
+
+        return sendEither(res, result);
+      },
+    ),
+  );
+
+  router.post(
     '/proxy/fetch-trends/',
     withErrorHandling(
       logger,

--- a/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
@@ -130,6 +130,16 @@ export type SikkerhetsmetrikkerSystemTotal = {
   metrics: SikkerhetsmetrikkerTotal;
 };
 
+export type SikkerhetsmetrikkerOwnerTotal = {
+  permittedOwnerMetrics: OwnerSeverityCounts[];
+  notPermittedOwners: string[];
+};
+
+export type OwnerSeverityCounts = {
+  owner: string;
+  severityCount: SeverityCount;
+};
+
 export type AggregatedSikkerhetsmetrikker = {
   systems: SikkerhetsmetrikkerSystemTotal[];
   vulnerabilityOverview: SystemVulnerabilityOverview;

--- a/plugins/security-metrics/src/components/OwnerTable/OwnerTable.tsx
+++ b/plugins/security-metrics/src/components/OwnerTable/OwnerTable.tsx
@@ -1,0 +1,81 @@
+import TableContainer from '@mui/material/TableContainer';
+import Paper from '@mui/material/Paper';
+import Table from '@mui/material/Table';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import TableCell from '@mui/material/TableCell';
+import TableBody from '@mui/material/TableBody';
+import { useOwnerMetrics } from '../../hooks/useOwnerMetrics';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { NoAccessRow } from '../RepositoriesTable/NoAccessRow';
+import { OwnerTableRow } from './OwnerTableRow';
+import { getTotalVulnerabilityCount } from '../../mapping/getSeverityCounts';
+
+import { Progress } from '@backstage/core-components';
+import Alert from '@mui/material/Alert';
+import { ErrorBanner } from '../ErrorBanner';
+
+export const OwnerTable = ({ onNavigate }: { onNavigate: () => void }) => {
+  const { entity } = useEntity();
+
+  const { data, isLoading, isEmpty, error, errorTitle } =
+    useOwnerMetrics(entity);
+
+  if (error) {
+    return <ErrorBanner errorTitle={errorTitle} errorMessage={error.message} />;
+  }
+
+  if (isLoading || !data) return <Progress />;
+
+  console.log('owner metrics', data);
+
+  if (isEmpty) {
+    return (
+      <Alert severity="info">
+        Finner ingen komponenter som har sikkerhetsmetrikker
+      </Alert>
+    );
+  }
+
+  const highestVulnerabilityCount =
+    data?.permittedTeams?.reduce(
+      (max, s) => Math.max(max, getTotalVulnerabilityCount(s.severityCount)),
+      0,
+    ) ?? 0;
+
+  return (
+    <TableContainer component={Paper}>
+      <Table sx={{ minWidth: '900px' }} size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell width="20%">Eier</TableCell>
+            <TableCell width="50%">Sårbarheter</TableCell>
+            <TableCell width="30%" />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {data?.permittedTeams
+            ?.sort(
+              (a, b) =>
+                getTotalVulnerabilityCount(b.severityCount) -
+                getTotalVulnerabilityCount(a.severityCount),
+            )
+            .map(teams => {
+              return (
+                <OwnerTableRow
+                  key={teams.team}
+                  teamId={teams.team}
+                  severityCount={teams.severityCount}
+                  highestVulnerabilityCount={highestVulnerabilityCount}
+                  onNavigate={onNavigate}
+                />
+              );
+            })}
+          {data?.notPermittedTeams?.map(teams => {
+            return <NoAccessRow repositoryName={teams} />;
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};

--- a/plugins/security-metrics/src/components/OwnerTable/OwnerTable.tsx
+++ b/plugins/security-metrics/src/components/OwnerTable/OwnerTable.tsx
@@ -26,8 +26,6 @@ export const OwnerTable = ({ onNavigate }: { onNavigate: () => void }) => {
 
   if (isLoading || !data) return <Progress />;
 
-  console.log('owner metrics', data);
-
   if (isEmpty) {
     return (
       <Alert severity="info">

--- a/plugins/security-metrics/src/components/OwnerTable/OwnerTable.tsx
+++ b/plugins/security-metrics/src/components/OwnerTable/OwnerTable.tsx
@@ -7,8 +7,7 @@ import TableCell from '@mui/material/TableCell';
 import TableBody from '@mui/material/TableBody';
 import { useOwnerMetrics } from '../../hooks/useOwnerMetrics';
 import { useEntity } from '@backstage/plugin-catalog-react';
-import { NoAccessRow } from '../RepositoriesTable/NoAccessRow';
-import { OwnerTableRow } from './OwnerTableRow';
+import { NoAccessOwnerRow, OwnerTableRow } from './OwnerTableRow';
 import { getTotalVulnerabilityCount } from '../../mapping/getSeverityCounts';
 
 import { Progress } from '@backstage/core-components';
@@ -72,7 +71,7 @@ export const OwnerTable = ({ onNavigate }: { onNavigate: () => void }) => {
               );
             })}
           {data?.notPermittedOwners?.map(owner => {
-            return <NoAccessRow repositoryName={owner} />;
+            return <NoAccessOwnerRow key={owner} ownerId={owner} />;
           })}
         </TableBody>
       </Table>

--- a/plugins/security-metrics/src/components/OwnerTable/OwnerTable.tsx
+++ b/plugins/security-metrics/src/components/OwnerTable/OwnerTable.tsx
@@ -12,7 +12,7 @@ import { getTotalVulnerabilityCount } from '../../mapping/getSeverityCounts';
 
 import { Progress } from '@backstage/core-components';
 import Alert from '@mui/material/Alert';
-import { ErrorBanner } from '../ErrorBanner';
+import { ErrorBanner } from '../shared/ErrorBanner';
 
 export const OwnerTable = ({ onNavigate }: { onNavigate: () => void }) => {
   const { entity } = useEntity();

--- a/plugins/security-metrics/src/components/OwnerTable/OwnerTable.tsx
+++ b/plugins/security-metrics/src/components/OwnerTable/OwnerTable.tsx
@@ -38,7 +38,7 @@ export const OwnerTable = ({ onNavigate }: { onNavigate: () => void }) => {
   }
 
   const highestVulnerabilityCount =
-    data?.permittedTeams?.reduce(
+    data?.permittedOwnerMetrics?.reduce(
       (max, s) => Math.max(max, getTotalVulnerabilityCount(s.severityCount)),
       0,
     ) ?? 0;
@@ -54,25 +54,25 @@ export const OwnerTable = ({ onNavigate }: { onNavigate: () => void }) => {
           </TableRow>
         </TableHead>
         <TableBody>
-          {data?.permittedTeams
+          {data?.permittedOwnerMetrics
             ?.sort(
               (a, b) =>
                 getTotalVulnerabilityCount(b.severityCount) -
                 getTotalVulnerabilityCount(a.severityCount),
             )
-            .map(teams => {
+            .map(ownerMetrics => {
               return (
                 <OwnerTableRow
-                  key={teams.team}
-                  teamId={teams.team}
-                  severityCount={teams.severityCount}
+                  key={ownerMetrics.owner}
+                  ownerId={ownerMetrics.owner}
+                  severityCount={ownerMetrics.severityCount}
                   highestVulnerabilityCount={highestVulnerabilityCount}
                   onNavigate={onNavigate}
                 />
               );
             })}
-          {data?.notPermittedTeams?.map(teams => {
-            return <NoAccessRow repositoryName={teams} />;
+          {data?.notPermittedOwners?.map(owner => {
+            return <NoAccessRow repositoryName={owner} />;
           })}
         </TableBody>
       </Table>

--- a/plugins/security-metrics/src/components/OwnerTable/OwnerTableRow.tsx
+++ b/plugins/security-metrics/src/components/OwnerTable/OwnerTableRow.tsx
@@ -1,0 +1,69 @@
+import Typography from '@mui/material/Typography';
+import { Box, Stack } from '@mui/system';
+import type { SeverityCount } from '../../typesFrontend';
+import { StyledTableRow } from '../TableRow';
+import { VulnerabilityDistribution } from '../VulnerabilityDistribution';
+import { useNavigate } from 'react-router-dom';
+import TableCell from '@mui/material/TableCell';
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+import { useGroupInfo } from '../../hooks/useUserInfo';
+
+type Props = {
+  teamId: string;
+  severityCount: SeverityCount;
+  highestVulnerabilityCount: number;
+  onNavigate: () => void;
+};
+
+export const OwnerTableRow = ({
+  teamId,
+  severityCount,
+  highestVulnerabilityCount,
+  onNavigate,
+}: Props) => {
+  const navigate = useNavigate();
+
+  const { data: team } = useGroupInfo(teamId);
+
+  const { critical, high, medium, low, negligible, unknown } = severityCount;
+  const total = critical + high + medium + low + negligible + unknown;
+
+  return (
+    <>
+      <StyledTableRow
+        key={teamId}
+        hover
+        sx={{ cursor: 'pointer' }}
+        onClick={() => {
+          navigate(
+            `/catalog/default/group/${team?.metadata?.name}/securityMetrics`,
+          );
+          onNavigate();
+        }}
+      >
+        <TableCell>
+          <Typography>{team?.metadata?.name || teamId}</Typography>
+        </TableCell>
+        <TableCell>
+          {total > 0 ? (
+            <Stack direction="row" maxWidth="500px" gap={2} alignItems="center">
+              <Typography width={50}>{total}</Typography>
+              <Box width="100%">
+                <VulnerabilityDistribution
+                  severityCount={severityCount}
+                  highestVulnerabilityCount={highestVulnerabilityCount}
+                />
+              </Box>
+            </Stack>
+          ) : (
+            <Typography>Ingen sårbarheter</Typography>
+          )}
+        </TableCell>
+
+        <TableCell align="right">
+          <ArrowForwardIosIcon fontSize="small" />
+        </TableCell>
+      </StyledTableRow>
+    </>
+  );
+};

--- a/plugins/security-metrics/src/components/OwnerTable/OwnerTableRow.tsx
+++ b/plugins/security-metrics/src/components/OwnerTable/OwnerTableRow.tsx
@@ -1,8 +1,8 @@
 import Typography from '@mui/material/Typography';
 import { Box, Stack } from '@mui/system';
 import type { SeverityCount } from '../../typesFrontend';
-import { StyledTableRow } from '../TableRow';
-import { VulnerabilityDistribution } from '../VulnerabilityDistribution';
+import { StyledTableRow } from '../shared/StyledTableRow';
+import { VulnerabilityDistribution } from '../shared/VulnerabilityDistribution';
 import { useNavigate } from 'react-router-dom';
 import TableCell from '@mui/material/TableCell';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';

--- a/plugins/security-metrics/src/components/OwnerTable/OwnerTableRow.tsx
+++ b/plugins/security-metrics/src/components/OwnerTable/OwnerTableRow.tsx
@@ -8,6 +8,7 @@ import TableCell from '@mui/material/TableCell';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import { useGroupInfo } from '../../hooks/useUserInfo';
 import { NoAccessRow } from '../RepositoriesTable/NoAccessRow';
+import Skeleton from '@mui/material/Skeleton';
 
 type Props = {
   ownerId: string;
@@ -24,48 +25,58 @@ export const OwnerTableRow = ({
 }: Props) => {
   const navigate = useNavigate();
 
-  const { data: group } = useGroupInfo(ownerId);
+  const { data: group, isLoading } = useGroupInfo(ownerId);
 
   const { critical, high, medium, low, negligible, unknown } = severityCount;
   const total = critical + high + medium + low + negligible + unknown;
 
-  return (
-    <>
-      <StyledTableRow
-        key={ownerId}
-        hover
-        sx={{ cursor: 'pointer' }}
-        onClick={() => {
-          navigate(
-            `/catalog/default/group/${group?.metadata?.name}/securityMetrics`,
-          );
-          onNavigate();
-        }}
-      >
+  if (isLoading)
+    return (
+      <StyledTableRow>
         <TableCell>
-          <Typography>{group?.metadata?.name || ownerId}</Typography>
+          <Skeleton variant="text" width={120} />
         </TableCell>
         <TableCell>
-          {total > 0 ? (
-            <Stack direction="row" maxWidth="500px" gap={2} alignItems="center">
-              <Typography width={50}>{total}</Typography>
-              <Box width="100%">
-                <VulnerabilityDistribution
-                  severityCount={severityCount}
-                  highestVulnerabilityCount={highestVulnerabilityCount}
-                />
-              </Box>
-            </Stack>
-          ) : (
-            <Typography>Ingen sårbarheter</Typography>
-          )}
-        </TableCell>
-
-        <TableCell align="right">
-          <ArrowForwardIosIcon fontSize="small" />
+          <Skeleton variant="rounded" width={300} height={20} />
         </TableCell>
       </StyledTableRow>
-    </>
+    );
+
+  return (
+    <StyledTableRow
+      key={ownerId}
+      hover
+      sx={{ cursor: 'pointer' }}
+      onClick={() => {
+        navigate(
+          `/catalog/default/group/${group?.metadata?.name}/securityMetrics`,
+        );
+        onNavigate();
+      }}
+    >
+      <TableCell>
+        <Typography>{group?.metadata?.name || ownerId}</Typography>
+      </TableCell>
+      <TableCell>
+        {total > 0 ? (
+          <Stack direction="row" maxWidth="500px" gap={2} alignItems="center">
+            <Typography width={50}>{total}</Typography>
+            <Box width="100%">
+              <VulnerabilityDistribution
+                severityCount={severityCount}
+                highestVulnerabilityCount={highestVulnerabilityCount}
+              />
+            </Box>
+          </Stack>
+        ) : (
+          <Typography>Ingen sårbarheter</Typography>
+        )}
+      </TableCell>
+
+      <TableCell align="right">
+        <ArrowForwardIosIcon fontSize="small" />
+      </TableCell>
+    </StyledTableRow>
   );
 };
 

--- a/plugins/security-metrics/src/components/OwnerTable/OwnerTableRow.tsx
+++ b/plugins/security-metrics/src/components/OwnerTable/OwnerTableRow.tsx
@@ -9,21 +9,21 @@ import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import { useGroupInfo } from '../../hooks/useUserInfo';
 
 type Props = {
-  teamId: string;
+  ownerId: string;
   severityCount: SeverityCount;
   highestVulnerabilityCount: number;
   onNavigate: () => void;
 };
 
 export const OwnerTableRow = ({
-  teamId,
+  ownerId,
   severityCount,
   highestVulnerabilityCount,
   onNavigate,
 }: Props) => {
   const navigate = useNavigate();
 
-  const { data: team } = useGroupInfo(teamId);
+  const { data: group } = useGroupInfo(ownerId);
 
   const { critical, high, medium, low, negligible, unknown } = severityCount;
   const total = critical + high + medium + low + negligible + unknown;
@@ -31,18 +31,18 @@ export const OwnerTableRow = ({
   return (
     <>
       <StyledTableRow
-        key={teamId}
+        key={ownerId}
         hover
         sx={{ cursor: 'pointer' }}
         onClick={() => {
           navigate(
-            `/catalog/default/group/${team?.metadata?.name}/securityMetrics`,
+            `/catalog/default/group/${group?.metadata?.name}/securityMetrics`,
           );
           onNavigate();
         }}
       >
         <TableCell>
-          <Typography>{team?.metadata?.name || teamId}</Typography>
+          <Typography>{group?.metadata?.name || ownerId}</Typography>
         </TableCell>
         <TableCell>
           {total > 0 ? (

--- a/plugins/security-metrics/src/components/OwnerTable/OwnerTableRow.tsx
+++ b/plugins/security-metrics/src/components/OwnerTable/OwnerTableRow.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router-dom';
 import TableCell from '@mui/material/TableCell';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import { useGroupInfo } from '../../hooks/useUserInfo';
+import { NoAccessRow } from '../RepositoriesTable/NoAccessRow';
 
 type Props = {
   ownerId: string;
@@ -65,5 +66,17 @@ export const OwnerTableRow = ({
         </TableCell>
       </StyledTableRow>
     </>
+  );
+};
+
+export const NoAccessOwnerRow = ({ ownerId }: { ownerId: string }) => {
+  const { data: group } = useGroupInfo(ownerId);
+
+  return (
+    <NoAccessRow
+      name={group?.metadata?.name || ownerId}
+      message="Du har ikke tilgang til metrikker for denne eieren"
+      colSpan={2}
+    />
   );
 };

--- a/plugins/security-metrics/src/components/RepositoriesTable/NoAccessRow.tsx
+++ b/plugins/security-metrics/src/components/RepositoriesTable/NoAccessRow.tsx
@@ -4,19 +4,23 @@ import TableCell from '@mui/material/TableCell';
 import Alert from '@mui/material/Alert';
 
 type Props = {
-  repositoryName: string;
+  name: string;
+  message?: string;
+  colSpan?: number;
 };
 
-export const NoAccessRow = ({ repositoryName }: Props) => {
+export const NoAccessRow = ({
+  name,
+  message = 'Du har ikke tilgang til metrikker for denne komponenten',
+  colSpan = 5,
+}: Props) => {
   return (
-    <StyledTableRow key={repositoryName}>
+    <StyledTableRow key={name}>
       <TableCell>
-        <Typography>{repositoryName}</Typography>
+        <Typography>{name}</Typography>
       </TableCell>
-      <TableCell colSpan={5}>
-        <Alert severity="warning">
-          Du har ikke tilgang til metrikker for denne komponenten
-        </Alert>
+      <TableCell colSpan={colSpan}>
+        <Alert severity="warning">{message}</Alert>
       </TableCell>
     </StyledTableRow>
   );

--- a/plugins/security-metrics/src/components/RepositoriesTable/RepositoriesTable.tsx
+++ b/plugins/security-metrics/src/components/RepositoriesTable/RepositoriesTable.tsx
@@ -75,7 +75,7 @@ export const RepositoriesTable = ({
             .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
             .map(row =>
               typeof row === 'string' ? (
-                <NoAccessRow key={row} repositoryName={row} />
+                <NoAccessRow key={row} name={row} />
               ) : (
                 <RepositoriesTableRow
                   key={row.repoName}

--- a/plugins/security-metrics/src/components/SystemsTable/SystemsTableRow.tsx
+++ b/plugins/security-metrics/src/components/SystemsTable/SystemsTableRow.tsx
@@ -40,7 +40,7 @@ export const SystemsTableRow = ({
   const noSystem = noSystemComponents.length > 0;
 
   if (!hasPermittedMetrics) {
-    return <NoAccessRow repositoryName={systemName} />;
+    return <NoAccessRow name={systemName} />;
   }
 
   const { critical, high, medium, low, negligible, unknown } = severityCount;

--- a/plugins/security-metrics/src/components/Views/GroupPage.tsx
+++ b/plugins/security-metrics/src/components/Views/GroupPage.tsx
@@ -29,11 +29,13 @@ import { useGroupMetrics } from '../../hooks/useGroupMetrics';
 import { VulnerabilityOverviewTable } from '../VulnerabilityOverviewTable/VulnerabilityOverviewTable';
 import { PageHeader } from '../shared/PageHeader';
 import { MetricsGrid } from '../shared/MetricsGrid';
+import { OwnerTable } from '../OwnerTable/OwnerTable';
 
 enum TabEnum {
   COMPONENT = 0,
   SYSTEM = 1,
-  VULNERABILITIES = 2,
+  OWNER = 2,
+  VULNERABILITIES = 3,
 }
 
 export const GroupPage = () => {
@@ -158,6 +160,9 @@ export const GroupPage = () => {
       >
         <Tab label="Metrikker per komponent" value={TabEnum.COMPONENT} />
         <Tab label="Metrikker per system" value={TabEnum.SYSTEM} />
+        {entity.spec?.type !== 'team' && (
+          <Tab label="Metrikker per eier" value={TabEnum.OWNER} />
+        )}
         <Tab label="Unike sårbarheter" value={TabEnum.VULNERABILITIES} />
       </Tabs>
 
@@ -174,6 +179,22 @@ export const GroupPage = () => {
       )}
       {selectedTab === TabEnum.SYSTEM && filteredSystemsData && (
         <SystemsTable data={filteredSystemsData} showOpen={showOpen} />
+      )}
+
+      {selectedTab === TabEnum.OWNER && (
+        <OwnerTable
+          onNavigate={() => {
+            setSelectedTab(TabEnum.COMPONENT);
+          }}
+        />
+      )}
+
+      {selectedTab === TabEnum.OWNER && (
+        <OwnerTable
+          onNavigate={() => {
+            setSelectedTab(TabEnum.COMPONENT);
+          }}
+        />
       )}
     </Stack>
   );

--- a/plugins/security-metrics/src/components/Views/GroupPage.tsx
+++ b/plugins/security-metrics/src/components/Views/GroupPage.tsx
@@ -188,14 +188,6 @@ export const GroupPage = () => {
           }}
         />
       )}
-
-      {selectedTab === TabEnum.OWNER && (
-        <OwnerTable
-          onNavigate={() => {
-            setSelectedTab(TabEnum.COMPONENT);
-          }}
-        />
-      )}
     </Stack>
   );
 };

--- a/plugins/security-metrics/src/hooks/useOwnerMetrics.ts
+++ b/plugins/security-metrics/src/hooks/useOwnerMetrics.ts
@@ -1,0 +1,70 @@
+import { useQuery } from '@tanstack/react-query';
+import { getAuthenticationTokens } from '../utils/authenticationUtils';
+import { MetricTypes } from '../utils/MetricTypes';
+import { useConfig } from './getConfig';
+import { SikkerhetsmetrikkerOwnerTotal } from '../typesFrontend';
+import { post } from '../api/client';
+import { useFetchComponentNamesByGroup } from './useFetchComponentNames';
+import { Entity } from '@backstage/catalog-model';
+
+type UseOwnerMetricsResult = {
+  data: SikkerhetsmetrikkerOwnerTotal | undefined;
+  isLoading: boolean;
+  isEmpty: boolean;
+  error: Error | null;
+  errorTitle: string;
+};
+
+export const useOwnerMetrics = (entity: Entity): UseOwnerMetricsResult => {
+  const { componentNames, componentNamesIsLoading, componentNamesError } =
+    useFetchComponentNamesByGroup(entity);
+  const { data, isPending, error } = useOwnerQuery(componentNames);
+
+  const isLoading =
+    componentNamesIsLoading || (componentNames.length > 0 && isPending);
+
+  const isEmpty =
+    !componentNamesIsLoading &&
+    !componentNamesError &&
+    componentNames.length === 0;
+
+  const combinedError = componentNamesError ?? error ?? null;
+  const errorTitle = componentNamesError
+    ? `Kunne ikke hente reponavn for ${entity.metadata.name}`
+    : `Kunne ikke hente metrikker for ${entity.metadata.name}`;
+
+  return {
+    data,
+    isLoading,
+    isEmpty,
+    error: combinedError,
+    errorTitle,
+  };
+};
+
+const useOwnerQuery = (componentNames: string[]) => {
+  const { config, backstageAuthApi, microsoftAuthApi, endpointUrl } = useConfig(
+    MetricTypes.ownerMetrics,
+  );
+
+  return useQuery<SikkerhetsmetrikkerOwnerTotal, Error>({
+    queryKey: ['ownerMetrics', componentNames],
+    queryFn: async () => {
+      const { entraIdToken, backstageToken } = await getAuthenticationTokens(
+        config,
+        backstageAuthApi,
+        microsoftAuthApi,
+      );
+      return post<
+        { componentNames: string[]; entraIdToken: string },
+        SikkerhetsmetrikkerOwnerTotal
+      >(endpointUrl, backstageToken, {
+        componentNames,
+        entraIdToken,
+      });
+    },
+    retry: 1,
+    enabled: componentNames.length !== 0,
+    staleTime: 3600000,
+  });
+};

--- a/plugins/security-metrics/src/hooks/useOwnerMetrics.ts
+++ b/plugins/security-metrics/src/hooks/useOwnerMetrics.ts
@@ -15,33 +15,6 @@ type UseOwnerMetricsResult = {
   errorTitle: string;
 };
 
-export const useOwnerMetrics = (entity: Entity): UseOwnerMetricsResult => {
-  const { componentNames, componentNamesIsLoading, componentNamesError } =
-    useFetchComponentNamesByGroup(entity);
-  const { data, isPending, error } = useOwnerQuery(componentNames);
-
-  const isLoading =
-    componentNamesIsLoading || (componentNames.length > 0 && isPending);
-
-  const isEmpty =
-    !componentNamesIsLoading &&
-    !componentNamesError &&
-    componentNames.length === 0;
-
-  const combinedError = componentNamesError ?? error ?? null;
-  const errorTitle = componentNamesError
-    ? `Kunne ikke hente reponavn for ${entity.metadata.name}`
-    : `Kunne ikke hente metrikker for ${entity.metadata.name}`;
-
-  return {
-    data,
-    isLoading,
-    isEmpty,
-    error: combinedError,
-    errorTitle,
-  };
-};
-
 const useOwnerQuery = (componentNames: string[]) => {
   const { config, backstageAuthApi, microsoftAuthApi, endpointUrl } = useConfig(
     MetricTypes.ownerMetrics,
@@ -67,4 +40,31 @@ const useOwnerQuery = (componentNames: string[]) => {
     enabled: componentNames.length !== 0,
     staleTime: 3600000,
   });
+};
+
+export const useOwnerMetrics = (entity: Entity): UseOwnerMetricsResult => {
+  const { componentNames, componentNamesIsLoading, componentNamesError } =
+    useFetchComponentNamesByGroup(entity);
+  const { data, isPending, error } = useOwnerQuery(componentNames);
+
+  const isLoading =
+    componentNamesIsLoading || (componentNames.length > 0 && isPending);
+
+  const isEmpty =
+    !componentNamesIsLoading &&
+    !componentNamesError &&
+    componentNames.length === 0;
+
+  const combinedError = componentNamesError ?? error ?? null;
+  const errorTitle = componentNamesError
+    ? `Kunne ikke hente reponavn for ${entity.metadata.name}`
+    : `Kunne ikke hente metrikker for ${entity.metadata.name}`;
+
+  return {
+    data,
+    isLoading,
+    isEmpty,
+    error: combinedError,
+    errorTitle,
+  };
 };

--- a/plugins/security-metrics/src/hooks/useUserInfo.ts
+++ b/plugins/security-metrics/src/hooks/useUserInfo.ts
@@ -1,7 +1,7 @@
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { useApi } from '@backstage/core-plugin-api';
 import { useQuery } from '@tanstack/react-query';
-import { UserEntity } from '@backstage/catalog-model';
+import { GroupEntity, UserEntity } from '@backstage/catalog-model';
 
 export const useUserInfo = (id: string) => {
   const catalogApi = useApi(catalogApiRef);
@@ -16,6 +16,24 @@ export const useUserInfo = (id: string) => {
         },
       });
       return users.items[0] as UserEntity | undefined;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+};
+
+export const useGroupInfo = (groupId: string) => {
+  const catalogApi = useApi(catalogApiRef);
+
+  return useQuery({
+    queryKey: ['group', groupId],
+    queryFn: async () => {
+      const groups = await catalogApi.getEntities({
+        filter: {
+          kind: 'Group',
+          'metadata.annotations.graph.microsoft.com/group-id': groupId,
+        },
+      });
+      return groups.items[0] as GroupEntity | undefined;
     },
     staleTime: 5 * 60 * 1000,
   });

--- a/plugins/security-metrics/src/typesFrontend.ts
+++ b/plugins/security-metrics/src/typesFrontend.ts
@@ -121,6 +121,16 @@ export type SikkerhetsmetrikkerTotal = {
   notPermittedComponents: string[];
 };
 
+export type SikkerhetsmetrikkerOwnerTotal = {
+  permittedTeams: OwnerSeverityCounts[];
+  notPermittedTeams: string[];
+};
+
+export type OwnerSeverityCounts = {
+  team: string;
+  severityCount: SeverityCount;
+};
+
 export type SikkerhetsmetrikkerSystemTotal = {
   systemName: string;
   metrics: SikkerhetsmetrikkerTotal;

--- a/plugins/security-metrics/src/typesFrontend.ts
+++ b/plugins/security-metrics/src/typesFrontend.ts
@@ -122,12 +122,12 @@ export type SikkerhetsmetrikkerTotal = {
 };
 
 export type SikkerhetsmetrikkerOwnerTotal = {
-  permittedTeams: OwnerSeverityCounts[];
-  notPermittedTeams: string[];
+  permittedOwnerMetrics: OwnerSeverityCounts[];
+  notPermittedOwners: string[];
 };
 
 export type OwnerSeverityCounts = {
-  team: string;
+  owner: string;
   severityCount: SeverityCount;
 };
 

--- a/plugins/security-metrics/src/utils/MetricTypes.ts
+++ b/plugins/security-metrics/src/utils/MetricTypes.ts
@@ -1,5 +1,6 @@
 export enum MetricTypes {
   componentMetrics = 'component-metrics',
+  ownerMetrics = 'owners-metrics',
   metrics = 'metrics',
   trends = 'trends',
   riscStatus = 'risc-status',


### PR DESCRIPTION
## 🔒 Bakgrunn
[Jira](https://kartverket.atlassian.net/jira/software/projects/EDSKVIS/boards/177?selectedIssue=EDSKVIS-984&visitedUserSeg=true)

Etter tilbakemelding fra brukere med oppfølgingsvar på et høyere nivå enn team-nivå, kom det frem et behov for å kunne se sikkerhetsmetrikker per team (eier) på group-pagen, slik at man enklet for oversikt over sårbarhets-tilstanden samlet per team. 

## 🔑 Løsning
Lagt til en eier-tab på group-view som vises så group-entiten sin type ikke er team, men da heller feks buiness unit eller product area. Her henter den metrikker fra owner endepunktet i smapi på child-components til n-te grad ned i treet til gruppen man har gått inn på. Smapi  henyer fra disse child-componentsene alle unike eiere og aggrere sårbarhetene til komponetene på eier. 


avhengig av tilsvarende pullrequest i SMAPI 



## 📸 Bilder

<img width="821" height="73" alt="image" src="https://github.com/user-attachments/assets/45f6450f-d0c5-4dc4-97de-0c0e771cac27" /> |

<img width="1544" height="314" alt="image" src="https://github.com/user-attachments/assets/8263811b-19c1-4b96-b364-47c4892df6b1" />
