### PR TITLE
Allow creation of multiple team-forms

### DIFF
--- a/plugins/frontend-custom-components/src/components/FunctionSecurityFormsCard/translation.ts
+++ b/plugins/frontend-custom-components/src/components/FunctionSecurityFormsCard/translation.ts
@@ -50,11 +50,14 @@ export const functionLinkCardTranslationRef = createTranslationRef({
     'groupFormCard.createNewFunctionForm': 'Create new form for function',
     'groupFormCard.selectForm': 'Select form',
     'groupFormCard.selectFunction': 'Select function',
+    'groupFormCard.name': 'Name',
     'groupFormCard.create': 'Create',
     'groupFormCard.creating': 'Creating...',
     'groupFormCard.cancel': 'Cancel',
     'groupFormCard.formCreatedSuccess': 'Form was created',
     'groupFormCard.createError': 'Could not create form',
+    'groupFormCard.createConflictError':
+      'A form with this name already exists for the selected form type. Please use a unique name.',
     'groupFormCard.allFormsCreated':
       'All form types already created for this function',
     'formMetrics.answered': '{{answered}}/{{total}} answered',
@@ -98,11 +101,14 @@ export const functionLinkCardNorwegianTranslation = createTranslationResource({
             'Opprett nytt skjema til funksjon',
           'groupFormCard.selectForm': 'Velg skjema',
           'groupFormCard.selectFunction': 'Velg funksjon',
+          'groupFormCard.name': 'Navn',
           'groupFormCard.create': 'Opprett',
           'groupFormCard.creating': 'Oppretter...',
           'groupFormCard.cancel': 'Avbryt',
           'groupFormCard.formCreatedSuccess': 'Skjema ble opprettet',
           'groupFormCard.createError': 'Kunne ikke opprette skjema',
+          'groupFormCard.createConflictError':
+            'Det finnes allerede et skjema med dette navnet. Navnet må være unikt for den valgte skjematypen.',
           'groupFormCard.allFormsCreated':
             'Alle skjematyper er allerede opprettet for denne funksjonen',
           'formMetrics.answered': '{{answered}}/{{total}} besvart',

--- a/plugins/frontend-custom-components/src/components/GroupSecurityFormsCard/CreateFormSection.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupSecurityFormsCard/CreateFormSection.tsx
@@ -66,7 +66,11 @@ export function CreateFormSection({
   } = useRegelrettCreateContextMutation();
 
   const handleSubmit = () => {
-    const params = onBuildMutationParams(selectedFormId, secondaryValue, contextName);
+    const params = onBuildMutationParams(
+      selectedFormId,
+      secondaryValue,
+      contextName,
+    );
     if (!params) return;
 
     mutate(params, {

--- a/plugins/frontend-custom-components/src/components/GroupSecurityFormsCard/CreateFormSection.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupSecurityFormsCard/CreateFormSection.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { Button, Flex } from '@backstage/ui';
+import { Button, Flex, TextField } from '@backstage/ui';
 import FormControl from '@mui/material/FormControl';
 import MuiSelect, { SelectChangeEvent } from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
@@ -8,6 +8,7 @@ import Alert from '@mui/material/Alert';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { functionLinkCardTranslationRef } from '../FunctionSecurityFormsCard/translation';
 import { useRegelrettCreateContextMutation } from '../../hooks/useRegelrettCreateContextMutation';
+import type { RegelrettApiError } from '../../hooks/useRegelrettCreateContextMutation';
 
 interface SelectOption {
   value: string;
@@ -28,11 +29,13 @@ interface CreateFormSectionProps {
   onBuildMutationParams: (
     formId: string,
     secondaryValue?: string,
+    contextName?: string,
   ) => { functionName: string; formId: string; teamId: string } | undefined;
   /** Called after a successful form creation */
   onSuccess: () => void;
   /** Optional custom label for the create button */
   createButtonLabel?: string;
+  includeNameField?: boolean;
 }
 
 export function CreateFormSection({
@@ -41,11 +44,13 @@ export function CreateFormSection({
   onBuildMutationParams,
   onSuccess,
   createButtonLabel,
+  includeNameField,
 }: CreateFormSectionProps) {
   const { t } = useTranslationRef(functionLinkCardTranslationRef);
 
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [selectedFormId, setSelectedFormId] = useState('');
+  const [contextName, setContextName] = useState('');
   const [secondaryValue, setSecondaryValue] = useState('');
   const [showSuccessMessage, setShowSuccessMessage] = useState(false);
   const successTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
@@ -61,7 +66,7 @@ export function CreateFormSection({
   } = useRegelrettCreateContextMutation();
 
   const handleSubmit = () => {
-    const params = onBuildMutationParams(selectedFormId, secondaryValue);
+    const params = onBuildMutationParams(selectedFormId, secondaryValue, contextName);
     if (!params) return;
 
     mutate(params, {
@@ -69,6 +74,7 @@ export function CreateFormSection({
         onSuccess();
         setSelectedFormId('');
         setSecondaryValue('');
+        setContextName('');
         setShowCreateForm(false);
         setShowSuccessMessage(true);
         successTimeoutRef.current = setTimeout(
@@ -86,7 +92,10 @@ export function CreateFormSection({
   };
 
   const isSubmitDisabled =
-    !selectedFormId || isCreating || (secondarySelect && !secondaryValue);
+    !selectedFormId ||
+    isCreating ||
+    (secondarySelect && !secondaryValue) ||
+    (includeNameField && !contextName.trim());
 
   return (
     <div style={{ marginTop: '1rem' }}>
@@ -178,6 +187,19 @@ export function CreateFormSection({
                 </MuiSelect>
               </FormControl>
 
+              {includeNameField && (
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <TextField
+                    size="small"
+                    placeholder={t('groupFormCard.name')}
+                    name="contextName"
+                    value={contextName}
+                    isDisabled={isCreating}
+                    onChange={e => setContextName(e)}
+                  />
+                </div>
+              )}
+
               <Button
                 variant="primary"
                 isDisabled={!!isSubmitDisabled}
@@ -197,6 +219,7 @@ export function CreateFormSection({
               setShowCreateForm(false);
               setSelectedFormId('');
               setSecondaryValue('');
+              setContextName('');
             }}
           >
             {t('groupFormCard.cancel')}
@@ -208,7 +231,9 @@ export function CreateFormSection({
 
       {createError && (
         <Alert severity="error" style={{ margin: '1rem 0 0' }}>
-          {t('groupFormCard.createError')}
+          {(createError as RegelrettApiError).status === 409
+            ? t('groupFormCard.createConflictError')
+            : t('groupFormCard.createError')}
         </Alert>
       )}
     </div>

--- a/plugins/frontend-custom-components/src/components/GroupSecurityFormsCard/GroupSecurityFormsCard.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupSecurityFormsCard/GroupSecurityFormsCard.tsx
@@ -209,7 +209,6 @@ function GroupSecurityFormsCardWrapper() {
             forms={teamForms}
             regelrettBaseUrl={regelrettBaseUrl}
             teamId={teamId}
-            teamName={teamName}
             onFormCreated={refetch}
             formTypeMap={formTypeMap}
           />

--- a/plugins/frontend-custom-components/src/components/GroupSecurityFormsCard/GroupSecurityFormsCard.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupSecurityFormsCard/GroupSecurityFormsCard.tsx
@@ -101,7 +101,6 @@ function GroupSecurityFormsCardWrapper() {
 
   const teamId =
     entity.metadata.annotations?.['graph.microsoft.com/group-id'] ?? '';
-  const teamName = entity.metadata.title ?? entity.metadata.name;
 
   const groupRef = `${entity.kind}:${entity.metadata.namespace ?? 'default'}/${entity.metadata.name}`;
 

--- a/plugins/frontend-custom-components/src/components/GroupSecurityFormsCard/TeamFormsTabContent.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupSecurityFormsCard/TeamFormsTabContent.tsx
@@ -66,7 +66,6 @@ interface TeamFormsTabContentProps {
   forms: RegelrettForm[];
   regelrettBaseUrl: string;
   teamId: string;
-  teamName: string;
   onFormCreated: () => void;
   formTypeMap: Record<string, string>;
 }
@@ -75,7 +74,6 @@ export function TeamFormsTabContent({
   forms,
   regelrettBaseUrl,
   teamId,
-  teamName,
   onFormCreated,
   formTypeMap,
 }: TeamFormsTabContentProps) {

--- a/plugins/frontend-custom-components/src/components/GroupSecurityFormsCard/TeamFormsTabContent.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupSecurityFormsCard/TeamFormsTabContent.tsx
@@ -83,10 +83,9 @@ export function TeamFormsTabContent({
   const { t } = useTranslationRef(functionLinkCardTranslationRef);
   const getFormType = (formId: string) => formTypeMap[formId] || 'Unknown';
 
-  const existingFormIds = new Set(forms.map(f => f.formId));
-  const availableFormOptions = Object.entries(formTypeMap)
-    .filter(([formId]) => !existingFormIds.has(formId))
-    .map(([formId, formName]) => ({ value: formId, label: formName }));
+  const availableFormOptions = Object.entries(formTypeMap).map(
+    ([formId, formName]) => ({ value: formId, label: formName }),
+  );
 
   return (
     <>
@@ -132,8 +131,11 @@ export function TeamFormsTabContent({
         <CreateFormSection
           formTypeOptions={availableFormOptions}
           createButtonLabel={t('groupFormCard.createNewTeamForm')}
-          onBuildMutationParams={formId =>
-            teamId ? { functionName: teamName, formId, teamId } : undefined
+          includeNameField
+          onBuildMutationParams={(formId, _secondary, contextName) =>
+            teamId && contextName
+              ? { functionName: contextName, formId, teamId }
+              : undefined
           }
           onSuccess={onFormCreated}
         />

--- a/plugins/frontend-custom-components/src/hooks/useRegelrettCreateContextMutation.ts
+++ b/plugins/frontend-custom-components/src/hooks/useRegelrettCreateContextMutation.ts
@@ -8,9 +8,8 @@ import {
 } from '@backstage/frontend-plugin-api';
 import { RegelrettForm } from '../types';
 
-export interface RegelrettApiError {
+export interface RegelrettApiError extends Error {
   status: number;
-  message: string;
 }
 
 export const useRegelrettCreateContextMutation = () => {
@@ -20,6 +19,7 @@ export const useRegelrettCreateContextMutation = () => {
 
   return useMutation<
     RegelrettForm,
+    RegelrettApiError,
     { functionName: string; formId: string; teamId: string }
   >({
     mutationFn: async ({ functionName, formId, teamId }) => {
@@ -51,9 +51,9 @@ export const useRegelrettCreateContextMutation = () => {
         return data;
       }
 
-      if (!response.ok) {
-        throw new Error('Network response was not ok');
-      }
+      throw Object.assign(new Error(data?.message ?? response.statusText), {
+        status: response.status,
+      });
     },
   });
 };

--- a/plugins/frontend-custom-components/src/hooks/useRegelrettCreateContextMutation.ts
+++ b/plugins/frontend-custom-components/src/hooks/useRegelrettCreateContextMutation.ts
@@ -20,7 +20,6 @@ export const useRegelrettCreateContextMutation = () => {
 
   return useMutation<
     RegelrettForm,
-    RegelrettApiError,
     { functionName: string; formId: string; teamId: string }
   >({
     mutationFn: async ({ functionName, formId, teamId }) => {
@@ -51,10 +50,10 @@ export const useRegelrettCreateContextMutation = () => {
       if (response.ok) {
         return data;
       }
-      throw {
-        status: response.status,
-        message: data?.message ?? response.statusText,
-      } satisfies RegelrettApiError;
+
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
+      }
     },
   });
 };

--- a/plugins/frontend-custom-components/src/hooks/useRegelrettCreateContextMutation.ts
+++ b/plugins/frontend-custom-components/src/hooks/useRegelrettCreateContextMutation.ts
@@ -8,6 +8,11 @@ import {
 } from '@backstage/frontend-plugin-api';
 import { RegelrettForm } from '../types';
 
+export interface RegelrettApiError {
+  status: number;
+  message: string;
+}
+
 export const useRegelrettCreateContextMutation = () => {
   const config = useApi(configApiRef);
   const backstageAuthApi = useApi(identityApiRef);
@@ -15,7 +20,7 @@ export const useRegelrettCreateContextMutation = () => {
 
   return useMutation<
     RegelrettForm,
-    Error,
+    RegelrettApiError,
     { functionName: string; formId: string; teamId: string }
   >({
     mutationFn: async ({ functionName, formId, teamId }) => {
@@ -46,7 +51,10 @@ export const useRegelrettCreateContextMutation = () => {
       if (response.ok) {
         return data;
       }
-      throw data ?? { message: response.statusText };
+      throw {
+        status: response.status,
+        message: data?.message ?? response.statusText,
+      } satisfies RegelrettApiError;
     },
   });
 };


### PR DESCRIPTION
## 🔒 Bakgrunn

[jira](https://kartverket.atlassian.net/jira/software/projects/EDSKVIS/boards/177?selectedIssue=EDSKVIS-1052&visitedUserSeg=true)

Ved bruk av skjemaer som ikke skal knyttes funksjoner, men hellerfeks  kodebaser, er man nødt til å kunne opprette flere skjemautfyllinger av samme skjema på samme team. Ref de nye KI-bruk skjemaene. 

Kartverket.dev tillot ikke å opprette flere skjemaer per team per skjema. Ved oppprettelse av team-skjema gav den team-navnet som skjamutfyllingsnavn (contextName). 

## 🔑 Løsning

Regelrett krever at skjemanavnet er unikt for et skjema og team. Derfor må man legge til mulighet for å gi skjemautfyllingen et navn som ikke er team-navnet. 
La derfor til et inputfelt for navn når man trykker på opprett form for team på group-pagen. Dette kommer ikke opp når man skal lage et skjema til en funksjon - da navngis den etter funksjonsnavn. 

I tillegg fjernet jeg filtereringen på listen som sendes inn som form-options, hvor man før filtererte ut et skjema hvis det fantes en skjemautfylling av den typen på det teamet.Dette var eneste sperren på å opprette flere skjemautfyllinger per skjema på et team. 

## 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| <img width="610" height="604" alt="image" src="https://github.com/user-attachments/assets/498b3ce9-7d20-4fee-9de9-812504f8a70e" /> | <img width="589" height="538" alt="image" src="https://github.com/user-attachments/assets/a6582f67-79f5-4575-9e39-9771e8e844af" /> |
| | <img width="605" height="634" alt="image" src="https://github.com/user-attachments/assets/b8d7bc44-2900-46ab-b913-45b105aa79ea" /> |