### PR TITLE
Batch catalog relation notifications by owner

### DIFF
--- a/packages/backend/src/plugins/extensions/catalogNotificationsModule.ts
+++ b/packages/backend/src/plugins/extensions/catalogNotificationsModule.ts
@@ -3,7 +3,6 @@ import {
   createBackendModule,
 } from '@backstage/backend-plugin-api';
 import { notificationService } from '@backstage/plugin-notifications-node';
-import { CatalogClient } from '@backstage/catalog-client';
 import { DatabaseManager } from '@backstage/backend-defaults/database';
 
 type MissingRelationTarget = {
@@ -20,8 +19,6 @@ export const catalogNotificationsModule = createBackendModule({
       deps: {
         logger: coreServices.logger,
         scheduler: coreServices.scheduler,
-        discovery: coreServices.discovery,
-        auth: coreServices.auth,
         db: coreServices.database,
         config: coreServices.rootConfig,
         lifecycle: coreServices.lifecycle,
@@ -33,8 +30,6 @@ export const catalogNotificationsModule = createBackendModule({
         db,
         config,
         lifecycle,
-        discovery,
-        auth,
         notificationService: notification,
       }) {
         const database = await db.getClient();
@@ -101,51 +96,30 @@ export const catalogNotificationsModule = createBackendModule({
               return;
             }
 
-            const { token } = await auth.getPluginRequestToken({
-              onBehalfOf: await auth.getOwnServiceCredentials(),
-              targetPluginId: 'catalog',
-            });
-
-            const catalogClient = new CatalogClient({
-              discoveryApi: discovery,
-            });
-
-            const entities = await catalogClient.getEntitiesByRefs(
-              {
-                entityRefs: query.map(({ ref }) => ref),
-                fields: ['kind', 'metadata.name', 'metadata.namespace'],
-              },
-              { token },
+            logger.info(
+              `catalog-error-monitor: found ${query.length} entities with broken relations`,
             );
+
+            if (query.length === 0) {
+              return;
+            }
 
             const currentScopes = new Set<string>();
 
-            // Group broken entities by owner to send one summary notification per
-            // owner instead of one notification per entity (prevents HTTP flood).
-            type EnrichedItem = {
-              entity: NonNullable<(typeof entities.items)[number]>;
-              missingRelation: MissingRelationTarget;
-            };
-            const byOwner = new Map<string, EnrichedItem[]>();
+            // Group broken entities by owner using only data from the SQL query —
+            // no HTTP calls needed since the entity ref already encodes kind/namespace/name.
+            const byOwner = new Map<string, MissingRelationTarget[]>();
 
-            for (let i = 0; i < entities.items.length; i++) {
-              const entity = entities.items[i];
-              const missingRelation = query[i];
-              if (!entity) {
-                logger.error(`Entity not found for ref: ${query[i]?.ref}`);
-                continue;
-              }
-              if (!missingRelation) {
-                logger.error(`No missing relation found at index ${i}`);
-                continue;
-              }
-
-              const ownerRef =
-                missingRelation.owner_ref ?? 'group:default/skvis';
+            for (const row of query) {
+              const ownerRef = row.owner_ref ?? 'group:default/skvis';
               const group = byOwner.get(ownerRef) ?? [];
-              group.push({ entity, missingRelation });
+              group.push(row);
               byOwner.set(ownerRef, group);
             }
+
+            logger.info(
+              `catalog-error-monitor: ${byOwner.size} owner(s) affected`,
+            );
 
             for (const [ownerRef, items] of byOwner) {
               const notificationScope = `relation-errors:${ownerRef}`;
@@ -153,22 +127,21 @@ export const catalogNotificationsModule = createBackendModule({
 
               const exampleLines = items
                 .slice(0, 5)
-                .map(
-                  ({ entity, missingRelation }) =>
-                    `• ${entity.metadata.name} → ${missingRelation.target_ref}`,
-                )
+                .map(({ ref, target_ref }) => `• ${ref} → ${target_ref}`)
                 .join('\n');
               const moreCount = items.length - 5;
-              const moreSuffix = moreCount > 0 ? `\n…and ${moreCount} more` : '';
-              const description = `${items.length} entity relation(s) point to non-existent catalog entries.\n\n${exampleLines}${moreSuffix}`;
+              const moreSuffix =
+                moreCount > 0 ? `\n…and ${moreCount} more` : '';
+              const description = `${items.length} entity relation(s) owned by ${ownerRef} point to non-existent catalog entries.\n\n${exampleLines}${moreSuffix}`;
 
+              // Always use broadcast: sending to a group entity triggers recursive
+              // member resolution in DefaultNotificationRecipientResolver (Promise.all
+              // over the full group hierarchy), which fans out into many concurrent
+              // catalog HTTP calls and can OOM the backend for large and deeply nested group
               await notification.send({
-                recipients: {
-                  type: 'entity',
-                  entityRef: ownerRef,
-                },
+                recipients: { type: 'broadcast' },
                 payload: {
-                  title: `${items.length} relation error(s) detected`,
+                  title: `[${ownerRef}] ${items.length} relation error(s) detected`,
                   description,
                   severity: 'high',
                   scope: notificationScope,

--- a/packages/backend/src/plugins/extensions/catalogNotificationsModule.ts
+++ b/packages/backend/src/plugins/extensions/catalogNotificationsModule.ts
@@ -120,6 +120,14 @@ export const catalogNotificationsModule = createBackendModule({
 
             const currentScopes = new Set<string>();
 
+            // Group broken entities by owner to send one summary notification per
+            // owner instead of one notification per entity (prevents HTTP flood).
+            type EnrichedItem = {
+              entity: NonNullable<(typeof entities.items)[number]>;
+              missingRelation: MissingRelationTarget;
+            };
+            const byOwner = new Map<string, EnrichedItem[]>();
+
             for (let i = 0; i < entities.items.length; i++) {
               const entity = entities.items[i];
               const missingRelation = query[i];
@@ -132,25 +140,37 @@ export const catalogNotificationsModule = createBackendModule({
                 continue;
               }
 
-              const namespace = entity.metadata.namespace ?? 'default';
-              const entityLink = `/catalog/${namespace}/${entity.kind}/${entity.metadata.name}`;
-              const notificationScope = `${entity.metadata.name}${missingRelation.target_ref}`;
               const ownerRef =
                 missingRelation.owner_ref ?? 'group:default/skvis';
+              const group = byOwner.get(ownerRef) ?? [];
+              group.push({ entity, missingRelation });
+              byOwner.set(ownerRef, group);
+            }
 
+            for (const [ownerRef, items] of byOwner) {
+              const notificationScope = `relation-errors:${ownerRef}`;
               currentScopes.add(notificationScope);
 
-              notification.send({
+              const exampleLines = items
+                .slice(0, 5)
+                .map(
+                  ({ entity, missingRelation }) =>
+                    `• ${entity.metadata.name} → ${missingRelation.target_ref}`,
+                )
+                .join('\n');
+              const moreCount = items.length - 5;
+              const moreSuffix = moreCount > 0 ? `\n…and ${moreCount} more` : '';
+              const description = `${items.length} entity relation(s) point to non-existent catalog entries.\n\n${exampleLines}${moreSuffix}`;
+
+              await notification.send({
                 recipients: {
                   type: 'entity',
                   entityRef: ownerRef,
                 },
                 payload: {
-                  title: `Relation error: ${entity.metadata.name}`,
-                  description: `This entity has relations to other entities, which can't be found in the catalog.
-                                    Entity not found: ${missingRelation.target_ref}`,
+                  title: `${items.length} relation error(s) detected`,
+                  description,
                   severity: 'high',
-                  link: entityLink,
                   scope: notificationScope,
                 },
               });


### PR DESCRIPTION
## 🔒 Bakgrunn

En gang i timen på klokkeslettet **:50 sender kartverket.dev ut ekstreme mengder logger under en kort periode ca.```120 --000``` linjer er observert på 5 minutter der hver logglinje er ```POST /api/catalog/entities/by-refs```. 

Etter litt feilsøkning fant vi ut at loggene ble trigget gjennom `catalogNotificationsModule.ts`

catalogNotificationsModule.ts er en bakgrunnsjobb som kjører hvert 30. minutt og varsler om det finnes feil i catalog-info-filene til kartverket.dev (f.eks. referanser til entiteter som ikke eksisterer).

Problemet oppsto fordi varslingen ble sendt med recipients.type: 'entity' og en gruppe som mottaker. Backstage sin innebygde DefaultNotificationRecipientResolver løser da opp hele gruppehierarkiet rekursivt og finner alle undergrupper og medlemmer via Promise.all, som kjører alle HTTP-kall parallelt. For grupper med mange nivåer eller mange medlemmer resulterte dette i hundrevis av samtidige POST /api/catalog/entities/by-refs-kall, som oversvømte loggene med tusenvis av linjer per sekund og kan i værste fall krasje backenden med heap out-of-memory-feil.


## 🔑 Løsning
 - Bytter til recipients.type: 'broadcast' for alle varsler. Broadcast skriver direkte til databasen uten å slå opp grupper eller medlemmer i katalogen — ingen HTTP-kall, trygt uansett størrelse på eiergruppa.
 - Fjerner CatalogClient. Entitetsnavnene som trengs i varslingsbeskrivelsen hentes gjennom SQL-spørring (ref-feltet inneholder allerede kind:namespace/name).