### PR TITLE
Viser oppdatert symbol kun fra siste døgn

### DIFF
--- a/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTableRow.tsx
+++ b/plugins/security-metrics/src/components/VulnerabilityTable/VulnerabilityTableRow.tsx
@@ -126,7 +126,7 @@ export const VulnerabilityTableRow = ({
         <TableCell sx={{ verticalAlign: 'middle' }}>
           <Stack direction="row" alignItems="center" spacing={1}>
             <SeverityTag severity={vulnerability.severity} />
-            {isRecent(vulnerability.severityUpdatedAt, 1) && (
+            {isRecent(vulnerability.severityUpdatedAt, 0) && (
               <Typography
                 variant="body2"
                 component="span"


### PR DESCRIPTION
## 🔒 Bakgrunn
Når alvorlighetsgraden til en sårbarhet oppdateres, sendes det et Slack-varsel med lenke til den aktuelle komponenten på kartverket.dev. Hensikten er at brukeren enkelt skal kunne se hvilken sårbarhet som har fått endret alvorlighetsgrad.

Det var imidlertid et avvik mellom Slack-varslingen og dashboardet. Oppdateringssymbolet i dashboardet ble vist for sårbarheter som var oppdatert de siste 0–2 dagene, mens Slack-varsler kun sendes for oppdateringer som har skjedd det siste døgnet. Dette kunne føre til at brukeren så flere markerte sårbarheter i dashboardet enn det som faktisk var varslet om.

## 🔑 Løsning

Endrer parameteren som sendes inn til isRecent() fra 1 til 0. Dette gjør at funksjonen kun vurderer sårbarheter som er oppdatert det siste døgnet som nylig oppdaterte, slik at dashboardet samsvarer med Slack-varslingene.