### PR TITLE
[Sikkerhetsmetrikker-plugin] Move unique vulnerabilities to own endpoint

### DIFF
--- a/plugins/security-metrics-backend/src/services/ApiService/api.service.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/api.service.ts
@@ -7,11 +7,12 @@ import {
   MetricsUpdateStatus,
   Repository,
   SeverityCounts,
-  AggregatedSikkerhetsmetrikker,
   SlackNotificationConfig,
   Status,
+  SystemVulnerabilityOverview,
   VulnerabilitySeverityCounts,
   SikkerhetsmetrikkerOwnerTotal,
+  SikkerhetsmetrikkerSystemTotal,
 } from './typesBackend';
 
 export class ApiService {
@@ -131,10 +132,38 @@ export class ApiService {
     entityName: string,
     componentNames: string[],
     entraIdToken: string,
-  ): Promise<Either<ErrorResponse, AggregatedSikkerhetsmetrikker>> {
+  ): Promise<Either<ErrorResponse, SikkerhetsmetrikkerSystemTotal[]>> {
     const safeEntityName = encodeURIComponent(entityName);
     const endpointResult = this.buildEndpoint(
       `/api/scannerData/${safeEntityName}`,
+    );
+    if (endpointResult.isLeft()) {
+      return Left.create(endpointResult.error);
+    }
+
+    return this.request(
+      endpointResult.value,
+      entraIdToken,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ componentNames }),
+      },
+      response => response.json(),
+      'Tjenesten for sikkerhetsmetrikker er utilgjengelig akkurat nå. Prøv igjen senere.',
+    );
+  }
+
+  async fetchVulnerabilityOverview(
+    entityName: string,
+    componentNames: string[],
+    entraIdToken: string,
+  ): Promise<Either<ErrorResponse, SystemVulnerabilityOverview>> {
+    const safeEntityName = encodeURIComponent(entityName);
+    const endpointResult = this.buildEndpoint(
+      `/api/scannerData/${safeEntityName}/vulnerabilityOverview`,
     );
     if (endpointResult.isLeft()) {
       return Left.create(endpointResult.error);

--- a/plugins/security-metrics-backend/src/services/ApiService/router.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/router.ts
@@ -148,6 +148,42 @@ export const createRouter = async (
     ),
   );
 
+  router.post(
+    '/proxy/fetch-vulnerability-overview/',
+    withErrorHandling(
+      logger,
+      'Failed to fetch vulnerability overview data',
+      async (req, res) => {
+        const authError = await requireBackstageToken(req, auth);
+        if (authError) {
+          return res.status(authError.status).send(authError);
+        }
+
+        const entityName = req.query.entityName as string | undefined;
+        const request = req.body as FetchMetricsRequestBody;
+        if (!entityName) {
+          return res
+            .status(400)
+            .send(
+              errorResponse(
+                400,
+                'BAD_REQUEST',
+                'Mangler entityName query parameter',
+              ),
+            );
+        }
+
+        const result = await apiService.fetchVulnerabilityOverview(
+          entityName,
+          request.componentNames,
+          request.entraIdToken,
+        );
+
+        return sendEither(res, result);
+      },
+    ),
+  );
+
   router.get(
     '/proxy/fetch-component-metrics/',
     withErrorHandling(

--- a/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
@@ -140,11 +140,6 @@ export type OwnerSeverityCounts = {
   severityCount: SeverityCount;
 };
 
-export type AggregatedSikkerhetsmetrikker = {
-  systems: SikkerhetsmetrikkerSystemTotal[];
-  vulnerabilityOverview: SystemVulnerabilityOverview;
-};
-
 export type SystemVulnerabilityOverview = {
   totalCount: number;
   vulnerabilities: AggregatedVulnerability[];

--- a/plugins/security-metrics/src/components/Views/GroupPage.tsx
+++ b/plugins/security-metrics/src/components/Views/GroupPage.tsx
@@ -49,8 +49,16 @@ export const GroupPage = () => {
   const { showTotal, showOpen, toggleShowTotal, toggleShowOpen } =
     useSecurityMetricsViewSettings();
 
-  const { data, isLoading, isEmpty, error, errorTitle } =
-    useGroupMetrics(entity);
+  const {
+    data,
+    vulnerabilityOverviewData,
+    isVulnerabilityOverviewLoading,
+    vulnerabilityOverviewError,
+    isLoading,
+    isEmpty,
+    error,
+    errorTitle,
+  } = useGroupMetrics(entity, selectedTab === TabEnum.VULNERABILITIES);
 
   const permitted: RepositorySummary[] = data
     ? getAllPermittedMetrics(data)
@@ -58,7 +66,7 @@ export const GroupPage = () => {
   const notPermitted: string[] = data ? getAllNotPermittedComponents(data) : [];
   const secrets: Secrets[] = data ? getAllSecrets(data) : [];
   const aggregatedVulnerabilities =
-    data?.vulnerabilityOverview?.vulnerabilities ?? [];
+    vulnerabilityOverviewData?.vulnerabilities ?? [];
 
   const allComponentRefs = permitted.flatMap(p =>
     p.componentNames.map(n => `component:default/${n}`),
@@ -75,7 +83,7 @@ export const GroupPage = () => {
   );
 
   const filteredSystemsData = filterSystemsByComponents(
-    data?.systems ?? [],
+    data ?? [],
     new Set(filteredPermitted.map(c => c.repoName)),
     effectiveFilter,
   );
@@ -166,9 +174,20 @@ export const GroupPage = () => {
         <Tab label="Unike sårbarheter" value={TabEnum.VULNERABILITIES} />
       </Tabs>
 
-      {selectedTab === TabEnum.VULNERABILITIES && (
-        <VulnerabilityOverviewTable data={aggregatedVulnerabilities} />
-      )}
+      {selectedTab === TabEnum.VULNERABILITIES &&
+        isVulnerabilityOverviewLoading && <Progress />}
+      {selectedTab === TabEnum.VULNERABILITIES &&
+        vulnerabilityOverviewError && (
+          <ErrorBanner
+            errorTitle={`Kunne ikke hente sårbarhetsoversikt for ${entity.metadata.name}`}
+            errorMessage={vulnerabilityOverviewError.message}
+          />
+        )}
+      {selectedTab === TabEnum.VULNERABILITIES &&
+        !isVulnerabilityOverviewLoading &&
+        !vulnerabilityOverviewError && (
+          <VulnerabilityOverviewTable data={aggregatedVulnerabilities} />
+        )}
 
       {selectedTab === TabEnum.COMPONENT && (
         <RepositoriesTable

--- a/plugins/security-metrics/src/hooks/useGroupMetrics.ts
+++ b/plugins/security-metrics/src/hooks/useGroupMetrics.ts
@@ -1,22 +1,41 @@
 import { Entity } from '@backstage/catalog-model';
-import { AggregatedSikkerhetsmetrikker } from '../typesFrontend';
+import {
+  SikkerhetsmetrikkerSystemTotal,
+  SystemVulnerabilityOverview,
+} from '../typesFrontend';
 import { useFetchComponentNamesByGroup } from './useFetchComponentNames';
 import { useMetricsQuery } from './useMetricsQuery';
+import { useVulnerabilityOverviewQuery } from './useVulnerabilityOverviewQuery';
 
 type UseGroupMetricsResult = {
-  data: AggregatedSikkerhetsmetrikker | undefined;
+  data: SikkerhetsmetrikkerSystemTotal[] | undefined;
+  vulnerabilityOverviewData: SystemVulnerabilityOverview | undefined;
+  isVulnerabilityOverviewLoading: boolean;
+  vulnerabilityOverviewError: Error | null;
   isLoading: boolean;
   isEmpty: boolean;
   error: Error | null;
   errorTitle: string;
 };
 
-export const useGroupMetrics = (entity: Entity): UseGroupMetricsResult => {
+export const useGroupMetrics = (
+  entity: Entity,
+  fetchVulnerabilityOverview = false,
+): UseGroupMetricsResult => {
   const { componentNames, componentNamesIsLoading, componentNamesError } =
     useFetchComponentNamesByGroup(entity);
   const { data, isPending, error } = useMetricsQuery(
     entity.metadata.name,
     componentNames,
+  );
+  const {
+    data: vulnerabilityOverviewData,
+    isPending: isVulnerabilityOverviewLoading,
+    error: vulnerabilityOverviewError,
+  } = useVulnerabilityOverviewQuery(
+    entity.metadata.name,
+    componentNames,
+    fetchVulnerabilityOverview,
   );
 
   const isLoading =
@@ -34,6 +53,9 @@ export const useGroupMetrics = (entity: Entity): UseGroupMetricsResult => {
 
   return {
     data,
+    vulnerabilityOverviewData,
+    isVulnerabilityOverviewLoading,
+    vulnerabilityOverviewError,
     isLoading,
     isEmpty,
     error: combinedError,

--- a/plugins/security-metrics/src/hooks/useVulnerabilityOverviewQuery.ts
+++ b/plugins/security-metrics/src/hooks/useVulnerabilityOverviewQuery.ts
@@ -2,23 +2,24 @@ import { useQuery } from '@tanstack/react-query';
 import { getAuthenticationTokens } from '../utils/authenticationUtils';
 import { MetricTypes } from '../utils/MetricTypes';
 import { useConfig } from './getConfig';
-import { SikkerhetsmetrikkerSystemTotal } from '../typesFrontend';
+import { SystemVulnerabilityOverview } from '../typesFrontend';
 import { post } from '../api/client';
 
-const metricsQueryKeys = {
-  metrics: (entityName: string) => ['metrics', entityName],
+const vulnerabilityOverviewQueryKeys = {
+  overview: (entityName: string) => ['vulnerabilityOverview', entityName],
 };
 
-export const useMetricsQuery = (
+export const useVulnerabilityOverviewQuery = (
   entityName: string,
   componentNames: string[],
+  enabled: boolean,
 ) => {
   const { config, backstageAuthApi, microsoftAuthApi, endpointUrl } = useConfig(
-    MetricTypes.metrics,
+    MetricTypes.vulnerabilityOverview,
   );
 
-  return useQuery<SikkerhetsmetrikkerSystemTotal[], Error>({
-    queryKey: metricsQueryKeys.metrics(entityName),
+  return useQuery<SystemVulnerabilityOverview, Error>({
+    queryKey: vulnerabilityOverviewQueryKeys.overview(entityName),
     queryFn: async () => {
       const { entraIdToken, backstageToken } = await getAuthenticationTokens(
         config,
@@ -28,11 +29,11 @@ export const useMetricsQuery = (
       endpointUrl.searchParams.set('entityName', entityName);
       return post<
         { componentNames: string[]; entraIdToken: string },
-        SikkerhetsmetrikkerSystemTotal[]
+        SystemVulnerabilityOverview
       >(endpointUrl, backstageToken, { componentNames, entraIdToken });
     },
     retry: 1,
-    enabled: componentNames.length !== 0,
+    enabled: enabled && componentNames.length !== 0,
     staleTime: 3600000,
   });
 };

--- a/plugins/security-metrics/src/mapping/getGroupedData.ts
+++ b/plugins/security-metrics/src/mapping/getGroupedData.ts
@@ -1,15 +1,15 @@
 import { Secrets } from '../components/SecretsOverview/SecretsDialog';
 import {
-  AggregatedSikkerhetsmetrikker,
   RepositorySummary,
+  SikkerhetsmetrikkerSystemTotal,
 } from '../typesFrontend';
 
 export const getAllSecrets = (
-  data: AggregatedSikkerhetsmetrikker,
+  data: SikkerhetsmetrikkerSystemTotal[],
 ): Secrets[] => {
   const seen = new Set<string>();
 
-  return data.systems
+  return data
     .flatMap(system => system.metrics?.permittedMetrics ?? [])
     .filter(repo => {
       if (seen.has(repo.repoName)) {
@@ -27,11 +27,11 @@ export const getAllSecrets = (
 };
 
 export const getAllPermittedMetrics = (
-  data: AggregatedSikkerhetsmetrikker,
+  data: SikkerhetsmetrikkerSystemTotal[],
 ): RepositorySummary[] => {
   const repoMap = new Map<string, RepositorySummary>();
 
-  for (const item of data.systems.flatMap(
+  for (const item of data.flatMap(
     system => system.metrics?.permittedMetrics ?? [],
   )) {
     const existing = repoMap.get(item.repoName);
@@ -56,6 +56,6 @@ export const getAllPermittedMetrics = (
 };
 
 export const getAllNotPermittedComponents = (
-  data: AggregatedSikkerhetsmetrikker,
+  data: SikkerhetsmetrikkerSystemTotal[],
 ): string[] =>
-  data.systems.flatMap(system => system.metrics?.notPermittedComponents ?? []);
+  data.flatMap(system => system.metrics?.notPermittedComponents ?? []);

--- a/plugins/security-metrics/src/typesFrontend.ts
+++ b/plugins/security-metrics/src/typesFrontend.ts
@@ -136,11 +136,6 @@ export type SikkerhetsmetrikkerSystemTotal = {
   metrics: SikkerhetsmetrikkerTotal;
 };
 
-export type AggregatedSikkerhetsmetrikker = {
-  systems: SikkerhetsmetrikkerSystemTotal[];
-  vulnerabilityOverview: SystemVulnerabilityOverview;
-};
-
 export type SystemVulnerabilityOverview = {
   totalCount: number;
   vulnerabilities: AggregatedVulnerability[];

--- a/plugins/security-metrics/src/utils/MetricTypes.ts
+++ b/plugins/security-metrics/src/utils/MetricTypes.ts
@@ -2,6 +2,7 @@ export enum MetricTypes {
   componentMetrics = 'component-metrics',
   ownerMetrics = 'owners-metrics',
   metrics = 'metrics',
+  vulnerabilityOverview = 'vulnerability-overview',
   trends = 'trends',
   riscStatus = 'risc-status',
   changeStatusVulnerability = 'change-status-vulnerability',


### PR DESCRIPTION
## 🔒 Bakgrunn

Jira: https://kartverket.atlassian.net/jira/software/projects/EDSKVIS/boards/177?selectedIssue=EDSKVIS-1057

Å laste inn sikkerhetsmetrikker-plugin på gruppenivå eller høyere tar veldig lang tid, på grunn av at henting av alle unike sårbarheter innenfor entiteten krever mye.

## 🔑 Løsning

Flytter data om unike sårbarheter til eget endepunkt, som bare hentes dersom man åpner den spesifikke tab'en.
Ved lokal testing halveres lastetiden.

Avhengig av: https://github.com/kartverket/sikkerhetsmetrikker/pull/986