### PR TITLE
Adds domain support to Component forms, updates schema and translations

### DIFF
--- a/plugins/catalog-creator/src/components/CatalogForm/CatalogForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/CatalogForm.tsx
@@ -249,6 +249,7 @@ export const CatalogForm = ({
             errors={errors?.entities?.[index] as EntityErrors<'Component'>}
             setValue={setValue}
             systems={fetchSystems}
+            domains={fetchDomains}
             groups={fetchGroups}
             componentsAndResources={componentsAndResources}
           />

--- a/plugins/catalog-creator/src/components/CatalogForm/Forms/ComponentForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/Forms/ComponentForm.tsx
@@ -26,6 +26,11 @@ type ComponentFormProps = {
     error: Error | undefined;
     value: Entity[];
   };
+  domains: {
+    loading: boolean;
+    error: Error | undefined;
+    value: Entity[];
+  };
   groups: {
     loading: boolean;
     error: Error | undefined;
@@ -44,6 +49,7 @@ export const ComponentForm = ({
   setValue,
   errors,
   systems,
+  domains,
   groups,
   componentsAndResources,
 }: ComponentFormProps) => {
@@ -57,6 +63,11 @@ export const ComponentForm = ({
   const providesApisVal = useWatch({
     control,
     name: `entities.${index}.providesApis`,
+  });
+
+  const domainVal = useWatch({
+    control,
+    name: `entities.${index}.domain`,
   });
 
   const consumesApisVal = useWatch({
@@ -81,6 +92,13 @@ export const ComponentForm = ({
     fetchAPIs,
     providesApisVal,
     `entities.${index}.providesApis`,
+    setValue,
+  );
+
+  useUpdateDependentFormFields(
+    domains,
+    domainVal ? [domainVal] : undefined,
+    `entities.${index}.domain`,
     setValue,
   );
 
@@ -143,6 +161,16 @@ export const ComponentForm = ({
           formname="componentForm"
           fieldname="system"
           entities={systems.value || []}
+        />
+      </div>
+      <div>
+        <SingleEntityAutocomplete
+          index={index}
+          control={control}
+          errors={errors}
+          formname="componentForm"
+          fieldname="domain"
+          entities={domains.value || []}
         />
       </div>
       <div>

--- a/plugins/catalog-creator/src/schemas/formSchema.ts
+++ b/plugins/catalog-creator/src/schemas/formSchema.ts
@@ -55,6 +55,14 @@ const componentSchema = baseEntitySchema.extend({
         message: 'form.errors.systemNoSpace',
       }),
   ),
+  domain: z.optional(
+    z
+      .string()
+      .trim()
+      .refine(s => !s.includes(' '), {
+        message: 'form.errors.domainNoSpace',
+      }),
+  ),
 
   lifecycle: z.enum(AllowedLifecycleStages, {
     message: 'form.errors.noLifecycle',

--- a/plugins/catalog-creator/src/translator/translator.ts
+++ b/plugins/catalog-creator/src/translator/translator.ts
@@ -36,6 +36,10 @@ export const updateYaml = (
             form.system?.length === 0
               ? undefined
               : form.system || initial.spec.system,
+          domain:
+            form.domain?.length === 0
+              ? undefined
+              : form.domain || initial.spec.domain,
           type: form.entityType! || initial.spec.type,
           providesApis:
             form.providesApis?.length === 0

--- a/plugins/catalog-creator/src/utils/translations.ts
+++ b/plugins/catalog-creator/src/utils/translations.ts
@@ -73,6 +73,11 @@ const catalogCreatorMessages = {
         tooltipText: 'Reference to the system which the component belongs to.',
         placeholder: 'Select system',
       },
+      domain: {
+        fieldName: 'Domain',
+        tooltipText: 'Reference to the domain which the component is part of.',
+        placeholder: 'Select domain',
+      },
       providesApis: {
         fieldName: 'Provides APIs',
         tooltipText:
@@ -337,6 +342,11 @@ export const catalogCreatorNorwegianTranslation = createTranslationResource({
           'form.componentForm.system.tooltipText':
             'Referanse til systemet som komponenten tilhører.',
           'form.componentForm.system.placeholder': 'Velg system',
+
+          'form.componentForm.domain.fieldName': 'Domene',
+          'form.componentForm.domain.tooltipText':
+            'Referanse til domenet som komponenten tilhører.',
+          'form.componentForm.domain.placeholder': 'Velg domene',
 
           'form.componentForm.providesApis.fieldName': 'Tilbyr APIer',
           'form.componentForm.providesApis.tooltipText':


### PR DESCRIPTION
## 🔒 Bakgrunn
Ønske om å kunne koble komponent til subdomain og domain

## 🔑 Løsning
Legger til frivillig felt i skjemaet hvor brukeren kan spesifisere hvilket domene komponenten tilhører.


## 📸 Bilder

| Før   | Etter |
| ----- | ----- |
|<img width="808" height="229" alt="Screenshot 2026-06-11 at 13 12 47" src="https://github.com/user-attachments/assets/94f1ec57-edd6-4fb2-a569-0be4dcb88c60" />| <img width="848" height="337" alt="Screenshot 2026-06-11 at 13 12 00" src="https://github.com/user-attachments/assets/d748c96e-4025-4f43-a1cd-d39e598e0f8c" /> |
