### PR TITLE
Add date last updated to metrics update status

### DIFF
--- a/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
@@ -1,9 +1,9 @@
 export type MetricsUpdateStatus = {
-  dependabot: boolean;
-  sysdig: boolean;
-  codeScanning: boolean;
-  secretScanning: boolean;
-  riscMetrics: boolean;
+  dependabotLastUpdated: string;
+  sysdigLastUpdated: string;
+  codeScanningLastUpdated: string;
+  secretScanningLastUpdated: string;
+  riscMetricsLastUpdated: string;
 };
 
 export type FetchMetricsRequestBody = {

--- a/plugins/security-metrics/src/components/shared/MetricsStatus.tsx
+++ b/plugins/security-metrics/src/components/shared/MetricsStatus.tsx
@@ -13,19 +13,17 @@ import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
-import InfoIcon from '@mui/icons-material/Info';
-import Box from '@mui/material/Box';
-import Stack from '@mui/material/Stack';
-import Typography from '@mui/material/Typography';
+import { formatDate } from 'date-fns';
 import { useMetricsUpdateStatusQuery } from '../../hooks/useMetricsUpdateStatusQuery';
 import { MetricsUpdateStatus } from '../../typesFrontend';
+import { isRecent } from '../../utils/isRecent';
 
 const SCANNER_LABELS: Record<keyof MetricsUpdateStatus, string> = {
-  dependabot: 'Sårbarheter fra Dependabot',
-  sysdig: 'Sårbarheter fra Sysdig',
-  codeScanning: 'Sårbarheter fra Pharos og CodeQL',
-  secretScanning: 'Eksponerte hemmeligheter',
-  riscMetrics: 'Risiko- og sårbarhetsarbeid',
+  dependabotLastUpdated: 'Sårbarheter fra Dependabot',
+  sysdigLastUpdated: 'Sårbarheter fra Sysdig',
+  codeScanningLastUpdated: 'Sårbarheter fra Pharos og CodeQL',
+  secretScanningLastUpdated: 'Eksponerte hemmeligheter',
+  riscMetricsLastUpdated: 'Status på risiko- og sårbarhetsarbeid',
 };
 
 interface MetricsStatusProps {
@@ -40,8 +38,8 @@ export const MetricsStatus = ({ entityName }: MetricsStatusProps) => {
     return null;
   }
 
-  const sources = Object.keys(data) as (keyof MetricsUpdateStatus)[];
-  const outdatedCount = sources.filter(key => !data[key]).length;
+  const sources = Object.keys(SCANNER_LABELS) as (keyof MetricsUpdateStatus)[];
+  const outdatedCount = sources.filter(key => !isRecent(data[key], 0)).length;
 
   if (!outdatedCount) {
     return null;
@@ -60,44 +58,37 @@ export const MetricsStatus = ({ entityName }: MetricsStatusProps) => {
       </Tooltip>
 
       <Dialog open={open} onClose={() => setOpen(false)}>
-        <DialogTitle>
-          Status på oppdatering av metrikker
-          <Tooltip
-            arrow
-            title={
-              <Box sx={{ py: 0.5 }}>
-                <Stack spacing={1}>
-                  <Stack direction="row" spacing={1} alignItems="center">
-                    <WarningAmberIcon fontSize="small" />
-                    <Typography variant="body2">
-                      Ikke oppdatert i natt
-                    </Typography>
-                  </Stack>
-                  <Stack direction="row" spacing={1} alignItems="center">
-                    <CheckCircleOutlineIcon fontSize="small" />
-                    <Typography variant="body2">Oppdatert i natt</Typography>
-                  </Stack>
-                </Stack>
-              </Box>
-            }
-          >
-            <InfoIcon sx={{ ml: 1, fontSize: 20, color: 'text.secondary' }} />
-          </Tooltip>
-        </DialogTitle>
+        <DialogTitle>Status på oppdatering av metrikker</DialogTitle>
         <DialogContent sx={{ pb: 0 }}>
           <List disablePadding>
-            {sources.map(key => (
-              <ListItem key={key} sx={{ p: 0.5 }}>
-                <ListItemIcon sx={{ minWidth: 32 }}>
-                  {data[key] ? (
-                    <CheckCircleOutlineIcon fontSize="small" color="success" />
-                  ) : (
-                    <WarningAmberIcon fontSize="small" color="warning" />
-                  )}
-                </ListItemIcon>
-                <ListItemText primary={SCANNER_LABELS[key]} />
-              </ListItem>
-            ))}
+            {sources.map(key => {
+              const updated = isRecent(data[key], 0);
+              const getSecondaryText = () => {
+                if (updated) return 'Oppdatert i natt';
+                if (data[key]) {
+                  return `Oppdatert ${formatDate(new Date(data[key]), 'dd.MM.yyyy')}`;
+                }
+                return 'Aldri oppdatert';
+              };
+              return (
+                <ListItem key={key} sx={{ p: 0.5 }}>
+                  <ListItemIcon sx={{ minWidth: 32 }}>
+                    {updated ? (
+                      <CheckCircleOutlineIcon
+                        fontSize="small"
+                        color="success"
+                      />
+                    ) : (
+                      <WarningAmberIcon fontSize="small" color="warning" />
+                    )}
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={SCANNER_LABELS[key]}
+                    secondary={getSecondaryText()}
+                  />
+                </ListItem>
+              );
+            })}
           </List>
         </DialogContent>
         <DialogActions>

--- a/plugins/security-metrics/src/typesFrontend.ts
+++ b/plugins/security-metrics/src/typesFrontend.ts
@@ -226,11 +226,11 @@ export type ClusterMap = Map<string, NamespaceMap>;
 export type FilterEnum = 'all' | 'starred';
 
 export type MetricsUpdateStatus = {
-  dependabot: boolean;
-  sysdig: boolean;
-  codeScanning: boolean;
-  secretScanning: boolean;
-  riscMetrics: boolean;
+  dependabotLastUpdated: string;
+  sysdigLastUpdated: string;
+  codeScanningLastUpdated: string;
+  secretScanningLastUpdated: string;
+  riscMetricsLastUpdated: string;
 };
 
 export type ErrorResponse = {

--- a/plugins/security-metrics/src/utils/isRecent.ts
+++ b/plugins/security-metrics/src/utils/isRecent.ts
@@ -2,6 +2,9 @@ export function isRecent(dateFirstSeen?: string, thresholdDays = 7): boolean {
   if (!dateFirstSeen) return false;
   const t = new Date(dateFirstSeen).getTime();
   if (Number.isNaN(t)) return false;
-  const diffDays = Math.floor((Date.now() - t) / (1000 * 60 * 60 * 24));
-  return diffDays <= thresholdDays;
+
+  const startOfToday = new Date();
+  startOfToday.setHours(0, 0, 0, 0);
+  const cutoff = startOfToday.getTime() - thresholdDays * 24 * 60 * 60 * 1000;
+  return t >= cutoff;
 }


### PR DESCRIPTION
## 🔒 Bakgrunn

Jira: https://kartverket.atlassian.net/jira/software/projects/EDSKVIS/boards/177?selectedIssue=EDSKVIS-1003

Vi registrerer status på nattens tasker i en backend-tabell. Statusen sendes til frontend som en boolean ("er oppdatert"), som varsler brukeren når noe har status `false`.

**Problemet:** hvis en task aldri starter en natt, beholder den forrige status og sender `true` i stedet for `false`. Brukeren får dermed ingen beskjed om at dataen faktisk er utdatert.

# Løsning 🔑

- Frontend tar nå imot et "sist oppdatert"-tidspunkt i stedet for en boolean. 
    - Hvis en metrikk-type ikke er oppdatert siden midnatt, vises en warning sammen med tidspunktet for når den sist ble oppdatert.
- Oppdaterer `isRecent`-funksjonen til å regne "siden midnatt" i stedet for "siste 24 timer", siden metrikkene oppdateres nattlig

## 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| <img width="434" height="304" alt="Screenshot 2026-06-15 at 13 32 46" src="https://github.com/user-attachments/assets/1affe2e7-c3d6-4cd9-9d1b-751c4c4302bd" /> | <img width="366" height="414" alt="Screenshot 2026-06-15 at 13 22 50" src="https://github.com/user-attachments/assets/6ddfd5bb-20a0-4e44-aa4b-75c43e62b500" /> |
