### PR TITLE
Increase processing interval to 1 hour to reduce load on upstream APIs

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -101,6 +101,9 @@ scaffolder:
 
 catalog:
   orphanStrategy: delete
+  # Raising processing interval to 1 hour to reduce load on upstream APIs.
+  # Default in Backstage is 100-150s, which causes upstream API spec endpoints (e.g. /api.json) to be re-fetched far too often by the OpenAPI and URL placeholder processors.
+  processingInterval: { hours: 1 }
   rules:
     - allow:
         [


### PR DESCRIPTION
## 🔒 Bakgrunn
[Jira-sak](https://kartverket.atlassian.net/jira/software/projects/EDSKVIS/boards/177?selectedIssue=EDSKVIS-1095)

## 🔑 Løsning
- Øker intervallet mellom hver prosessering av Backstage-entiteter. Ved hver prosessering gjør Backstage oppslag mot tilknyttede API-spesifikasjoner for entiteter som har dette definert.
- Dersom en bruker gjør endringer i kataloginformasjon og ønsker at disse skal reflekteres umiddelbart, kan prosesseringen trigges manuelt i kartverket.dev ved å klikke på oppdateringsikonet på **About**-kortet.
- Hvis dette får uønskede konsekvenser for andre typer entiteter som er avhengige av hyppigere prosessering, bør vi vurdere en dedikert løsning for håndtering og prosessering av API-spesifikasjoner.