### PR TITLE
Makes Docker Compose work localy

### DIFF
--- a/app-config.docker.yaml
+++ b/app-config.docker.yaml
@@ -1,6 +1,4 @@
-# Configuration for Docker Compose "production-like" testing
-# This file ONLY overrides the database configuration for PostgreSQL (production-like)
-# All other settings (auth, GitHub, Entra ID, Regelrett) come from app-config.local.yaml
+# Used in docker-compose, overrides app-config.yaml for the backend service
 
 backend:
   database:

--- a/app-config.docker.yaml
+++ b/app-config.docker.yaml
@@ -1,0 +1,16 @@
+# Configuration for Docker Compose "production-like" testing
+# This file ONLY overrides the database configuration for PostgreSQL (production-like)
+# All other settings (auth, GitHub, Entra ID, Regelrett) come from app-config.local.yaml
+
+backend:
+  database:
+    client: pg
+    connection:
+      database: ${POSTGRES_DB}
+      host: ${POSTGRES_HOST}
+      port: ${POSTGRES_PORT}
+      user: ${POSTGRES_USER}
+      password: ${POSTGRES_PASSWORD}
+      # For docker-compose, we don't require SSL
+      ssl: false
+    pluginDivisionMode: schema

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,21 +20,16 @@ services:
       context: .
       dockerfile: packages/backend/Dockerfile
     environment:
-      APP_CONFIG_app_baseUrl: 'http://localhost:7007'
-      APP_CONFIG_backend_baseUrl: 'http://localhost:7007'
-      APP_CONFIG_backend_database_client: 'pg'
-      APP_CONFIG_backend_database_connection_host: 'postgres'
-      APP_CONFIG_backend_database_connection_user: 'admin'
-      APP_CONFIG_backend_database_connection_password: 'adminpw'
-      APP_CONFIG_backend_database_connection_database: 'backstage'
-      APP_CONFIG_backend_cors_origin: 'http://localhost:3000'
-      ENTRA_ID_SP_APP_ID: 432
-      ENTRA_ID_SP_CLIENT_SECRET: 432
-      ENTRA_WEB_APP_ID: 432
-      ENTRA_WEB_CLIENT_SECRET: 432
-      ENTRA_TENANT_ID: 432
-      GOOGLE_OAUTH_CLIENT_ID: 432
-      GOOGLE_OAUTH_CLIENT_SECRET: 432
+      # Database configuration
+      POSTGRES_DB: backstage
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: '5432'
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: adminpw
+
+      # Base URLs (app and backend)
+      BASE_URL: 'http://localhost:7007'
+      CORS_ORIGIN: 'http://localhost:7007'
     ports:
       - '7007:7007' # Expose Backstage on port 7007
     depends_on:
@@ -42,7 +37,19 @@ services:
     networks:
       - backstage-network
     volumes:
-      - ./github-secret.yaml:/app/github-secrets/github-app-backstage-skip-credentials.yaml
+      - ./github-secrets/github-app-backstage-skip-credentials.yaml:/app/github-secrets/github-app-backstage-skip-credentials.yaml:ro
+      - ./app-config.local.yaml:/app/app-config.local.yaml:ro
+    # Use local config with secrets and override database to use PostgreSQL
+    command:
+      [
+        'packages/backend',
+        '--config',
+        'app-config.yaml',
+        '--config',
+        'app-config.local.yaml',
+        '--config',
+        'app-config.docker.yaml',
+      ]
 
 volumes:
   postgres_data: {}


### PR DESCRIPTION
## 🔒 Bakgrunn
Vanskelig å teste et "prod-likt" oppsett lokalt. Ønsker å kunne kjøre appen gjennom docker.

## 🔑 Løsning
Fikser gammelt docker compose oppsett slik at det bare er å kjøre `docker compose up --build` for å få appen til å starte med docker.