### PR TITLE
Fixes login-problem

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -29,6 +29,9 @@ backend:
   listen:
     port: 7007
     host: 0.0.0.0
+  server:
+    # Mitigates intermittent ERR_STREAM_PREMATURE_CLOSE on internal loopback fetches in containerized runtimes.
+    maxRequestsPerSocket: 1
   csp:
     connect-src: ["'self'", 'http:', 'https:']
     img-src: ["'self'", 'data:']


### PR DESCRIPTION
## 🔒 Bakgrunn

Innlogging i Docker-baserte miljøer feiler med `ERR_STREAM_PREMATURE_CLOSE / Premature close` under kall i authflyten. Problemet oppstod ikke stabilt ved lokal kjøring uten Docker, noe som tyder på at dette var relatert til HTTP/socket-gjenbruk i container-runtime og ikke til selve autentiseringsoppsettet.

## 🔑 Løsning
Denne endringen setter `backend.server.maxRequestsPerSocket: 1` for å hindre gjenbruk av sockets i backend. Det reduserer risikoen for premature socket-lukking.

## 📸 Bilder

| Før   | 
| ----- | 
|<img width="434" height="337" alt="Screenshot 2026-06-24 at 14 06 56" src="https://github.com/user-attachments/assets/5b46970e-2bba-4762-b352-a8e3332ebd04" /> | 