### PR TITLE
[Catalog creator plugin] Keep entity-references with non-default namespace

### DIFF
--- a/plugins/catalog-creator/src/components/CatalogForm/Autocompletes/MultipleEntitiesAutocomplete.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/Autocompletes/MultipleEntitiesAutocomplete.tsx
@@ -7,7 +7,7 @@ import z from 'zod/v4';
 import { EntityErrors, Kind, Kinds } from '../../../types/types';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { catalogCreatorTranslationRef } from '../../../utils/translations';
-import { Entity } from '@backstage/catalog-model';
+import { Entity, parseEntityRef } from '@backstage/catalog-model';
 import style from '../../../catalog.module.css';
 
 type MultipleEntitiesAutocompleteProps = {
@@ -108,10 +108,19 @@ export const MultipleEntitiesAutocomplete = ({
               value={
                 (value || [])
                   .map(str => {
-                    return (entities || []).find(entity => {
+                    const found = (entities || []).find(entity => {
                       const entityStr = `${entity.kind.toLowerCase()}:${entity.metadata.namespace?.toLowerCase() ?? 'default'}/${entity.metadata.name}`;
                       return entityStr === str;
                     });
+                    if (found) return found;
+                    const parsed = parseEntityRef(str);
+                    return {
+                      kind: parsed.kind,
+                      metadata: {
+                        name: parsed.name,
+                        namespace: parsed.namespace,
+                      },
+                    } as Entity;
                   })
                   .filter(Boolean) as Entity[]
               }
@@ -156,13 +165,22 @@ export const MultipleEntitiesAutocomplete = ({
                 return option.metadata.title ?? option.metadata.name;
               }}
               isOptionEqualToValue={(option, selectedValue) => {
-                const optionName =
-                  typeof option === 'string' ? option : option.metadata.name;
-                const valueName =
+                if (
+                  typeof option === 'string' &&
                   typeof selectedValue === 'string'
-                    ? selectedValue
-                    : selectedValue.metadata?.name;
-                return optionName === valueName;
+                ) {
+                  return option === selectedValue;
+                }
+                if (
+                  typeof option !== 'string' &&
+                  typeof selectedValue !== 'string'
+                ) {
+                  return (
+                    formatEntityString(option) ===
+                    formatEntityString(selectedValue)
+                  );
+                }
+                return false;
               }}
               size="small"
               renderInput={params => (

--- a/plugins/catalog-creator/src/hooks/useFetchEntities.ts
+++ b/plugins/catalog-creator/src/hooks/useFetchEntities.ts
@@ -50,7 +50,9 @@ export const useFetchEntities = (
             if (
               fromFormEntities
                 .map(entity => `${entity.kind}:default/${entity.metadata.name}`)
-                .includes(`${e.kind}:default/${e.metadata.name}`)
+                .includes(
+                  `${e.kind}:${e.metadata.namespace ?? 'default'}/${e.metadata.name}`,
+                )
             ) {
               return false;
             }
@@ -64,7 +66,7 @@ export const useFetchEntities = (
         e =>
           !fromFormEntities.some(
             formEntity =>
-              `${e.kind}:default/${e.metadata.name}` ===
+              `${e.kind}:${e.metadata.namespace ?? 'default'}/${e.metadata.name}` ===
               `${formEntity.kind}:default/${formEntity.metadata.name}`,
           ),
       );

--- a/plugins/catalog-creator/src/hooks/useUpdateDependentFormFields.ts
+++ b/plugins/catalog-creator/src/hooks/useUpdateDependentFormFields.ts
@@ -19,6 +19,11 @@ export const useUpdateDependentFormFields = (
     return `${entity.kind.toLowerCase()}:${entity.metadata.namespace?.toLowerCase() ?? 'default'}/${entity.metadata.name}`;
   };
 
+  const hasNonDefaultNamespace = (ref: string): boolean => {
+    const match = ref.match(/^[^:]+:([^/]+)\//);
+    return !!match && match[1] !== 'default';
+  };
+
   useEffect(() => {
     if (options.loading) {
       return;
@@ -38,8 +43,15 @@ export const useUpdateDependentFormFields = (
         }
         return [];
       });
+
+      const nonDefaultRefs = valueToWatch.filter(e =>
+        hasNonDefaultNamespace(e),
+      );
+
       const elementsToDelete = [
-        ...valueToWatch.filter(e => !intersection.includes(e)),
+        ...valueToWatch.filter(
+          e => !intersection.includes(e) && !nonDefaultRefs.includes(e),
+        ),
       ];
 
       if (elementsToDelete.length > 0) {
@@ -50,7 +62,9 @@ export const useUpdateDependentFormFields = (
           setValue(fieldPath, '');
         } else {
           setValue(fieldPath, [
-            ...valueToWatch.filter(e => intersection.includes(e)),
+            ...valueToWatch.filter(
+              e => intersection.includes(e) || nonDefaultRefs.includes(e),
+            ),
           ]);
         }
       }

--- a/plugins/catalog-creator/src/utils/toEntityRef.ts
+++ b/plugins/catalog-creator/src/utils/toEntityRef.ts
@@ -1,5 +1,10 @@
 import { Kind } from '../types/types';
 
+function isFullyQualifiedRef(kind: Kind, val: string): boolean {
+  const pattern = new RegExp(`^${kind}:[^/]+/.+$`, 'i');
+  return pattern.test(val);
+}
+
 export function toEntityRefList(
   kind: Kind,
   entityStrings: string | string[] | undefined,
@@ -13,16 +18,16 @@ export function toEntityRefList(
   }
 
   return values.map(val => {
-    if (val.toLowerCase().includes(`${kind}:default/`.toLowerCase())) {
-      return val;
+    if (isFullyQualifiedRef(kind, val)) {
+      return val.toLowerCase();
     }
     return `${kind}:default/${val}`.toLowerCase();
   });
 }
 
 export function toEntityRef(kind: Kind, entityString: string) {
-  if (entityString.toLowerCase().includes(`${kind}:default/`.toLowerCase())) {
-    return entityString;
+  if (isFullyQualifiedRef(kind, entityString)) {
+    return entityString.toLowerCase();
   }
   return `${kind}:default/${entityString}`.toLowerCase();
 }


### PR DESCRIPTION
## 🔒 Bakgrunn

Jira: https://kartverket.atlassian.net/jira/software/projects/EDSKVIS/boards/177?selectedIssue=EDSKVIS-1089

Entity-referanser som `api:external/some-api` ble fjernet ved PR-opprettelse fordi koden antok at alle refs brukte default namespace. Eksempel: https://kartverket.dev/catalog/default/component/registrert-eier-tjeneste.

## 🔑 Løsning

Gjenkjenner nå alle fullt kvalifiserte refs (alle namespaces), ikke bare default.

NB! Krever VPN for å teste henting av eksterne APIer