### PR TITLE
Add search plugin to mkdocs configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ edit_uri: edit/main/docs
 
 plugins:
   - techdocs-core
+  - search
 
 nav:
   - Kartverket.dev:


### PR DESCRIPTION
## 🔒 Bakgrunn

Får følgende feilmelding i Grafana

```
GET 404 /api/techdocs/static/docs/default/component/kartverket.dev/search/search_index.json trace=35f69567c18ed79dd4bb5041460d74a6
```

## 🔑 Løsning

Legger til search eksplisitt i mkdocs 

## 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| Bilde | Bilde |