### PR TITLE
Add owner to risc status for product areas and business units

### DIFF
--- a/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
@@ -156,6 +156,7 @@ export interface RiscStatusData {
   hasRisc?: boolean;
   lastPublishedRisc?: string;
   commitsSincePublishedRisc?: number;
+  owner?: string;
 }
 
 export type OverviewResponse = {

--- a/plugins/security-metrics/src/components/OwnerTable/OwnerMetricsSection.tsx
+++ b/plugins/security-metrics/src/components/OwnerTable/OwnerMetricsSection.tsx
@@ -10,7 +10,7 @@ import { SystemScannerStatuses } from '../ScannerStatus/SystemScannerStatuses';
 import { VulnerabilityCountsOverview } from '../VulnerabilityCounts/VulnerabilityCountsOverview';
 import { OwnerTrendGraph } from '../Trend/OwnerTrendGraph';
 import { MetricsGrid } from '../shared/MetricsGrid';
-import { RiscStatusCard } from '../RiscStatus/RiscStatusCard.tsx';
+import { RiscStatusCard } from '../RiscStatus/RiscStatusCard';
 
 interface OwnerMetricsSectionProps {
   ownerMetrics: OwnerSeverityCounts;

--- a/plugins/security-metrics/src/components/OwnerTable/OwnerMetricsSection.tsx
+++ b/plugins/security-metrics/src/components/OwnerTable/OwnerMetricsSection.tsx
@@ -7,10 +7,10 @@ import { useNavigate } from 'react-router-dom';
 import { OwnerSeverityCounts } from '../../typesFrontend';
 import { useGroupInfo } from '../../hooks/useUserInfo';
 import { SystemScannerStatuses } from '../ScannerStatus/SystemScannerStatuses';
-import { SystemRiscStatuses } from '../RiscStatus/SystemRiscStatuses';
 import { VulnerabilityCountsOverview } from '../VulnerabilityCounts/VulnerabilityCountsOverview';
 import { OwnerTrendGraph } from '../Trend/OwnerTrendGraph';
 import { MetricsGrid } from '../shared/MetricsGrid';
+import { RiscStatusCard } from '../RiscStatus/RiscStatusCard.tsx';
 
 interface OwnerMetricsSectionProps {
   ownerMetrics: OwnerSeverityCounts;
@@ -59,7 +59,7 @@ export const OwnerMetricsSection = ({
       </Stack>
       <MetricsGrid>
         <SystemScannerStatuses data={ownerMetrics.overview.scannerConfig} />
-        <SystemRiscStatuses data={ownerMetrics.overview.riscStatus} />
+        <RiscStatusCard data={ownerMetrics.overview.riscStatus} />
         <VulnerabilityCountsOverview
           severityCount={ownerMetrics.overview.severityCount}
           openSeverityCount={ownerMetrics.overview.openSeverityCount}

--- a/plugins/security-metrics/src/components/RiscStatus/RiscStatusByTeamCard.tsx
+++ b/plugins/security-metrics/src/components/RiscStatus/RiscStatusByTeamCard.tsx
@@ -1,0 +1,42 @@
+import { RiscStatusData } from '../../typesFrontend';
+import { RiscStatusCardBase } from './RiscStatusCardBase';
+import {
+  OwnerRiscGroup,
+  RiscStatusByTeamDialog,
+} from './RiscStatusByTeamDialog';
+import { UNKNOWN_TEAM } from './TeamRiscSection';
+
+interface Props {
+  data: RiscStatusData[];
+}
+
+const groupByOwner = (statuses: RiscStatusData[]): OwnerRiscGroup[] => {
+  const buckets = new Map<string, RiscStatusData[]>();
+  for (const s of statuses) {
+    const key = s.owner ?? UNKNOWN_TEAM;
+    const bucket = buckets.get(key) ?? [];
+    bucket.push(s);
+    buckets.set(key, bucket);
+  }
+  return [...buckets.entries()]
+    .map(([owner, s]) => ({ owner, statuses: s }))
+    .sort((a, b) => {
+      if (a.owner === UNKNOWN_TEAM) return 1;
+      if (b.owner === UNKNOWN_TEAM) return -1;
+      return b.statuses.length - a.statuses.length;
+    });
+};
+
+export const RiscStatusByTeamCard = ({ data }: Props) => (
+  <RiscStatusCardBase
+    data={data}
+    renderDialog={({ label, statuses, isOpen, setOpen }) => (
+      <RiscStatusByTeamDialog
+        categoryLabel={label}
+        groups={groupByOwner(statuses)}
+        isDialogOpen={isOpen}
+        setIsDialogOpen={setOpen}
+      />
+    )}
+  />
+);

--- a/plugins/security-metrics/src/components/RiscStatus/RiscStatusByTeamDialog.tsx
+++ b/plugins/security-metrics/src/components/RiscStatus/RiscStatusByTeamDialog.tsx
@@ -1,0 +1,62 @@
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { RiscStatusData } from '../../typesFrontend';
+import { TeamRiscSection } from './TeamRiscSection';
+
+export type OwnerRiscGroup = {
+  owner: string;
+  statuses: RiscStatusData[];
+};
+
+type Props = {
+  categoryLabel: string;
+  groups: OwnerRiscGroup[];
+  isDialogOpen: boolean;
+  setIsDialogOpen: (open: boolean) => void;
+};
+
+export const RiscStatusByTeamDialog = ({
+  categoryLabel,
+  groups,
+  isDialogOpen,
+  setIsDialogOpen,
+}: Props) => {
+  const totalCount = groups.reduce((sum, g) => sum + g.statuses.length, 0);
+
+  return (
+    <Dialog
+      open={isDialogOpen}
+      onClose={() => setIsDialogOpen(false)}
+      fullWidth
+    >
+      <DialogContent>
+        <Typography variant="h6" mb={3}>
+          {categoryLabel}
+        </Typography>
+        {categoryLabel === 'Utdatert RoS' && (
+          <Typography variant="body2" mb={2}>
+            RoSer som er mer enn ett år gamle regnes som utdaterte.
+          </Typography>
+        )}
+        {totalCount === 0 ? (
+          <Typography variant="body2" fontStyle="italic">
+            Ingen komponenter {categoryLabel === 'Mangler RoS' ? '' : 'har'}{' '}
+            {categoryLabel.toLowerCase()}
+          </Typography>
+        ) : (
+          <Stack gap={3}>
+            {groups.map(g => (
+              <TeamRiscSection
+                key={g.owner}
+                owner={g.owner}
+                statuses={g.statuses}
+              />
+            ))}
+          </Stack>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/plugins/security-metrics/src/components/RiscStatus/RiscStatusCard.tsx
+++ b/plugins/security-metrics/src/components/RiscStatus/RiscStatusCard.tsx
@@ -1,0 +1,21 @@
+import { RiscStatusData } from '../../typesFrontend';
+import { RiscStatusCardBase } from './RiscStatusCardBase';
+import { RiscStatusDialog } from './RiscStatusDialog';
+
+interface Props {
+  data: RiscStatusData[];
+}
+
+export const RiscStatusCard = ({ data }: Props) => (
+  <RiscStatusCardBase
+    data={data}
+    renderDialog={({ label, statuses, isOpen, setOpen }) => (
+      <RiscStatusDialog
+        categoryLabel={label}
+        riscStatuses={statuses}
+        isDialogOpen={isOpen}
+        setIsDialogOpen={setOpen}
+      />
+    )}
+  />
+);

--- a/plugins/security-metrics/src/components/RiscStatus/RiscStatusCardBase.tsx
+++ b/plugins/security-metrics/src/components/RiscStatus/RiscStatusCardBase.tsx
@@ -1,60 +1,28 @@
 import Box from '@mui/material/Box';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import CheckIcon from '@mui/icons-material/Check';
-import CloseIcon from '@mui/icons-material/Close';
 import Divider from '@mui/material/Divider';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 import { RiscStatusData } from '../../typesFrontend';
 import { CardTitle } from '../shared/CardTitle';
-import { RiscStatusDialog } from './RiscStatusDialog';
-import { calculateDaysSince } from './utils';
-import { SvgIconProps } from '@mui/material/SvgIcon';
 import { StatusRow } from '../shared/StatusRow';
+import { CATEGORIES, RiscCategory, categorise } from './categories';
 
-interface SystemRiscStatusesProps {
-  data: RiscStatusData[];
-}
-
-type RiscCategory = 'mangler' | 'utdatert' | 'oppdatert';
-
-type CategoryConfig = {
-  key: RiscCategory;
+type RenderDialogArgs = {
+  category: RiscCategory;
   label: string;
-  Icon: React.ComponentType<SvgIconProps>;
-  color: SvgIconProps['color'];
+  statuses: RiscStatusData[];
+  isOpen: boolean;
+  setOpen: (open: boolean) => void;
 };
 
-const CATEGORIES: CategoryConfig[] = [
-  {
-    key: 'mangler',
-    label: 'Mangler RoS',
-    Icon: CloseIcon,
-    color: 'error',
-  },
-  {
-    key: 'utdatert',
-    label: 'Utdatert RoS',
-    Icon: CheckIcon,
-    color: 'warning',
-  },
-  {
-    key: 'oppdatert',
-    label: 'Oppdatert RoS',
-    Icon: CheckIcon,
-    color: 'success',
-  },
-];
-
-const categorise = (risc: RiscStatusData): RiscCategory => {
-  if (!risc.hasRisc) return 'mangler';
-  if (!risc.lastPublishedRisc) return 'mangler';
-  const days = calculateDaysSince(risc.lastPublishedRisc) ?? 0;
-  return days > 365 ? 'utdatert' : 'oppdatert';
+type Props = {
+  data: RiscStatusData[];
+  renderDialog: (args: RenderDialogArgs) => ReactNode;
 };
 
-export const SystemRiscStatuses = ({ data }: SystemRiscStatusesProps) => {
+export const RiscStatusCardBase = ({ data, renderDialog }: Props) => {
   const [openDialogFor, setOpenDialogFor] = useState<RiscCategory | null>(null);
 
   if (!data || data.length === 0) {
@@ -103,12 +71,13 @@ export const SystemRiscStatuses = ({ data }: SystemRiscStatusesProps) => {
                   />
                 </Box>
               </StatusRow>
-              <RiscStatusDialog
-                categoryLabel={label}
-                riscStatuses={statuses}
-                isDialogOpen={openDialogFor === key}
-                setIsDialogOpen={open => setOpenDialogFor(open ? key : null)}
-              />
+              {renderDialog({
+                category: key,
+                label,
+                statuses,
+                isOpen: openDialogFor === key,
+                setOpen: open => setOpenDialogFor(open ? key : null),
+              })}
             </Box>
           );
         })}

--- a/plugins/security-metrics/src/components/RiscStatus/RiscStatusDialog.tsx
+++ b/plugins/security-metrics/src/components/RiscStatus/RiscStatusDialog.tsx
@@ -1,14 +1,8 @@
-import CloseIcon from '@mui/icons-material/Close';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
-import Table from '@mui/material/Table';
-import TableBody from '@mui/material/TableBody';
-import TableCell from '@mui/material/TableCell';
-import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { RiscStatusData } from '../../typesFrontend';
-import { StyledTableRow } from '../shared/StyledTableRow';
-import { riscStatusLabel } from './RiscStatusLabel';
+import { RiscStatusTable } from './RiscStatusTable';
 
 type Props = {
   categoryLabel: string;
@@ -39,28 +33,7 @@ export const RiscStatusDialog = ({
           {categoryLabel.toLowerCase()}
         </Typography>
       ) : (
-        <Table>
-          <TableBody>
-            {riscStatuses.map(status => (
-              <StyledTableRow key={status.repositoryName ?? 'unknown'}>
-                <TableCell>
-                  <Typography variant="body2">
-                    {status.repositoryName ?? 'Ukjent'}
-                  </Typography>
-                </TableCell>
-                <TableCell align="right">
-                  {status.hasRisc ? (
-                    riscStatusLabel(status)
-                  ) : (
-                    <Tooltip title="Mangler operasjonell RoS">
-                      <CloseIcon color="error" />
-                    </Tooltip>
-                  )}
-                </TableCell>
-              </StyledTableRow>
-            ))}
-          </TableBody>
-        </Table>
+        <RiscStatusTable statuses={riscStatuses} />
       )}
     </DialogContent>
   </Dialog>

--- a/plugins/security-metrics/src/components/RiscStatus/RiscStatusTable.tsx
+++ b/plugins/security-metrics/src/components/RiscStatus/RiscStatusTable.tsx
@@ -1,0 +1,38 @@
+import CloseIcon from '@mui/icons-material/Close';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { RiscStatusData } from '../../typesFrontend';
+import { StyledTableRow } from '../shared/StyledTableRow';
+import { riscStatusLabel } from './RiscStatusLabel';
+
+type Props = {
+  statuses: RiscStatusData[];
+};
+
+export const RiscStatusTable = ({ statuses }: Props) => (
+  <Table>
+    <TableBody>
+      {statuses.map(status => (
+        <StyledTableRow key={status.repositoryName ?? 'unknown'}>
+          <TableCell>
+            <Typography variant="body2">
+              {status.repositoryName ?? 'Ukjent'}
+            </Typography>
+          </TableCell>
+          <TableCell align="right">
+            {status.hasRisc ? (
+              riscStatusLabel(status)
+            ) : (
+              <Tooltip title="Mangler operasjonell RoS">
+                <CloseIcon color="error" />
+              </Tooltip>
+            )}
+          </TableCell>
+        </StyledTableRow>
+      ))}
+    </TableBody>
+  </Table>
+);

--- a/plugins/security-metrics/src/components/RiscStatus/RiscStatusTable.tsx
+++ b/plugins/security-metrics/src/components/RiscStatus/RiscStatusTable.tsx
@@ -15,8 +15,8 @@ type Props = {
 export const RiscStatusTable = ({ statuses }: Props) => (
   <Table>
     <TableBody>
-      {statuses.map(status => (
-        <StyledTableRow key={status.repositoryName ?? 'unknown'}>
+      {statuses.map((status, idx) => (
+        <StyledTableRow key={status.repositoryName ?? `unknown-${idx}`}>
           <TableCell>
             <Typography variant="body2">
               {status.repositoryName ?? 'Ukjent'}

--- a/plugins/security-metrics/src/components/RiscStatus/TeamRiscSection.tsx
+++ b/plugins/security-metrics/src/components/RiscStatus/TeamRiscSection.tsx
@@ -1,0 +1,41 @@
+import Skeleton from '@mui/material/Skeleton';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { RiscStatusData } from '../../typesFrontend';
+import { useGroupInfo } from '../../hooks/useUserInfo';
+import { RiscStatusTable } from './RiscStatusTable';
+
+export const UNKNOWN_TEAM = '__unknown__';
+
+type Props = {
+  owner: string;
+  statuses: RiscStatusData[];
+};
+
+export const TeamRiscSection = ({ owner, statuses }: Props) => {
+  const isUnknown = owner === UNKNOWN_TEAM;
+  const { data: group, isLoading } = useGroupInfo(isUnknown ? '' : owner);
+
+  let displayName: string;
+  if (isUnknown) {
+    displayName = 'Ukjent team';
+  } else {
+    const rawName = group?.metadata?.name ?? owner;
+    displayName = `Team ${rawName.charAt(0).toUpperCase() + rawName.slice(1)}`;
+  }
+
+  return (
+    <Stack gap={1}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between">
+        {!isUnknown && isLoading ? (
+          <Skeleton variant="text" width={160} height={24} />
+        ) : (
+          <Typography variant="subtitle1" fontWeight={600}>
+            {displayName}
+          </Typography>
+        )}
+      </Stack>
+      <RiscStatusTable statuses={statuses} />
+    </Stack>
+  );
+};

--- a/plugins/security-metrics/src/components/RiscStatus/categories.ts
+++ b/plugins/security-metrics/src/components/RiscStatus/categories.ts
@@ -1,0 +1,42 @@
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
+import { SvgIconProps } from '@mui/material/SvgIcon';
+import { RiscStatusData } from '../../typesFrontend';
+import { calculateDaysSince } from './utils';
+
+export type RiscCategory = 'mangler' | 'utdatert' | 'oppdatert';
+
+export type CategoryConfig = {
+  key: RiscCategory;
+  label: string;
+  Icon: React.ComponentType<SvgIconProps>;
+  color: SvgIconProps['color'];
+};
+
+export const CATEGORIES: CategoryConfig[] = [
+  {
+    key: 'mangler',
+    label: 'Mangler RoS',
+    Icon: CloseIcon,
+    color: 'error',
+  },
+  {
+    key: 'utdatert',
+    label: 'Utdatert RoS',
+    Icon: CheckIcon,
+    color: 'warning',
+  },
+  {
+    key: 'oppdatert',
+    label: 'Oppdatert RoS',
+    Icon: CheckIcon,
+    color: 'success',
+  },
+];
+
+export const categorise = (risc: RiscStatusData): RiscCategory => {
+  if (!risc.hasRisc) return 'mangler';
+  if (!risc.lastPublishedRisc) return 'mangler';
+  const days = calculateDaysSince(risc.lastPublishedRisc) ?? 0;
+  return days > 365 ? 'utdatert' : 'oppdatert';
+};

--- a/plugins/security-metrics/src/components/Views/GroupPage.tsx
+++ b/plugins/security-metrics/src/components/Views/GroupPage.tsx
@@ -6,7 +6,6 @@ import { SystemScannerStatuses } from '../ScannerStatus/SystemScannerStatuses';
 import { Secrets } from '../SecretsOverview/SecretsAlert';
 import { Trend } from '../Trend/Trend';
 import { VulnerabilityCountsOverview } from '../VulnerabilityCounts/VulnerabilityCountsOverview';
-import { SystemRiscStatuses } from '../RiscStatus/SystemRiscStatuses';
 import Stack from '@mui/material/Stack';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { ErrorBanner } from '../shared/ErrorBanner';
@@ -25,6 +24,8 @@ import { UniqueVulnerabilitiesTable } from '../UniqueVulnerabilitiesTable/Unique
 import { PageHeader } from '../shared/PageHeader';
 import { MetricsGrid } from '../shared/MetricsGrid';
 import { OwnerTable } from '../OwnerTable/OwnerTable';
+import { RiscStatusByTeamCard } from '../RiscStatus/RiscStatusByTeamCard.tsx';
+import { RiscStatusCard } from '../RiscStatus/RiscStatusCard.tsx';
 
 enum TabEnum {
   COMPONENT = 0,
@@ -166,7 +167,11 @@ export const GroupPage = () => {
 
       <MetricsGrid>
         <SystemScannerStatuses data={data?.scannerConfig ?? []} />
-        <SystemRiscStatuses data={data?.riscStatus ?? []} />
+        {entity.spec?.type !== 'team' ? (
+          <RiscStatusByTeamCard data={data?.riscStatus ?? []} />
+        ) : (
+          <RiscStatusCard data={data?.riscStatus ?? []} />
+        )}
         <VulnerabilityCountsOverview
           severityCount={data?.severityCount}
           openSeverityCount={data?.openSeverityCount}

--- a/plugins/security-metrics/src/components/Views/GroupPage.tsx
+++ b/plugins/security-metrics/src/components/Views/GroupPage.tsx
@@ -24,8 +24,8 @@ import { UniqueVulnerabilitiesTable } from '../UniqueVulnerabilitiesTable/Unique
 import { PageHeader } from '../shared/PageHeader';
 import { MetricsGrid } from '../shared/MetricsGrid';
 import { OwnerTable } from '../OwnerTable/OwnerTable';
-import { RiscStatusByTeamCard } from '../RiscStatus/RiscStatusByTeamCard.tsx';
-import { RiscStatusCard } from '../RiscStatus/RiscStatusCard.tsx';
+import { RiscStatusByTeamCard } from '../RiscStatus/RiscStatusByTeamCard';
+import { RiscStatusCard } from '../RiscStatus/RiscStatusCard';
 
 enum TabEnum {
   COMPONENT = 0,

--- a/plugins/security-metrics/src/components/Views/SystemPage.tsx
+++ b/plugins/security-metrics/src/components/Views/SystemPage.tsx
@@ -13,7 +13,7 @@ import { useSecurityMetricsViewSettings } from '../../hooks/useShowTrendTotal';
 import { useFetchComponentNamesFromSystem } from '../../hooks/useFetchComponentNames';
 import { PageHeader } from '../shared/PageHeader';
 import { MetricsGrid } from '../shared/MetricsGrid';
-import { RiscStatusCard } from '../RiscStatus/RiscStatusCard.tsx';
+import { RiscStatusCard } from '../RiscStatus/RiscStatusCard';
 
 export const SystemPage = () => {
   const { entity } = useEntity();

--- a/plugins/security-metrics/src/components/Views/SystemPage.tsx
+++ b/plugins/security-metrics/src/components/Views/SystemPage.tsx
@@ -5,7 +5,6 @@ import { SystemScannerStatuses } from '../ScannerStatus/SystemScannerStatuses';
 import { Secrets } from '../SecretsOverview/SecretsAlert';
 import { Trend } from '../Trend/Trend';
 import { VulnerabilityCountsOverview } from '../VulnerabilityCounts/VulnerabilityCountsOverview';
-import { SystemRiscStatuses } from '../RiscStatus/SystemRiscStatuses';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { ErrorBanner } from '../shared/ErrorBanner';
 import { useOverviewQuery } from '../../hooks/useOverviewQuery';
@@ -14,6 +13,7 @@ import { useSecurityMetricsViewSettings } from '../../hooks/useShowTrendTotal';
 import { useFetchComponentNamesFromSystem } from '../../hooks/useFetchComponentNames';
 import { PageHeader } from '../shared/PageHeader';
 import { MetricsGrid } from '../shared/MetricsGrid';
+import { RiscStatusCard } from '../RiscStatus/RiscStatusCard.tsx';
 
 export const SystemPage = () => {
   const { entity } = useEntity();
@@ -75,7 +75,7 @@ export const SystemPage = () => {
 
       <MetricsGrid>
         <SystemScannerStatuses data={overviewData?.scannerConfig ?? []} />
-        <SystemRiscStatuses data={overviewData?.riscStatus ?? []} />
+        <RiscStatusCard data={overviewData?.riscStatus ?? []} />
         <VulnerabilityCountsOverview
           severityCount={overviewData?.severityCount}
           openSeverityCount={overviewData?.openSeverityCount}

--- a/plugins/security-metrics/src/hooks/useUserInfo.ts
+++ b/plugins/security-metrics/src/hooks/useUserInfo.ts
@@ -36,5 +36,6 @@ export const useGroupInfo = (groupId: string) => {
       return groups.items[0] as GroupEntity | undefined;
     },
     staleTime: 5 * 60 * 1000,
+    enabled: !!groupId,
   });
 };

--- a/plugins/security-metrics/src/typesFrontend.ts
+++ b/plugins/security-metrics/src/typesFrontend.ts
@@ -217,6 +217,7 @@ export interface RiscStatusData {
   hasRisc?: boolean;
   lastPublishedRisc?: string;
   commitsSincePublishedRisc?: number;
+  owner?: string;
 }
 
 export type Severity =


### PR DESCRIPTION
## 🔒 Bakgrunn

Jira: https://kartverket.atlassian.net/jira/software/projects/EDSKVIS/boards/177?filter=&groupBy=none&selectedIssue=EDSKVIS-1076

## 🔑 Løsning

- Grupperer komponenter etter team i "Operasjonell RoS"-kortet på produktområde- og forretningsområdesider. Innenfor hver kategori (mangler/utdatert/oppdatert RoS) vises komponentene nå per team, sortert etter antall.
     - Komponenter uten team havner i "Ukjent team" nederst.
- Refaktorering av komponenter (team- og systemsider er uendret)

## 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| <img width="567" height="326" alt="Screenshot 2026-07-30 at 12 14 32" src="https://github.com/user-attachments/assets/9e5979d9-f059-4bdd-930d-ec357417f61c" /> | <img width="554" height="356" alt="Screenshot 2026-07-30 at 12 17 54" src="https://github.com/user-attachments/assets/5727ed48-d701-4cb1-9411-1fa34c072c65" /> |
