### PR TITLE
Add status to vulns in uniqueVulns

### DIFF
--- a/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
+++ b/plugins/security-metrics-backend/src/services/ApiService/typesBackend.ts
@@ -125,13 +125,18 @@ export type UniqueVulnerabilities = {
   vulnerabilities: AggregatedVulnerability[];
 };
 
+export type AggregatedAffectedComponent = {
+  componentName: string;
+  status: Status | null;
+};
+
 export type AggregatedVulnerability = {
   vulnerabilityId: string;
   severity: Severity;
   scanners: Scanner[];
   summary: string;
   dateFirstSeen: string;
-  affectedComponents: string[];
+  affectedComponents: AggregatedAffectedComponent[];
 };
 
 export type Severity =

--- a/plugins/security-metrics/src/components/UniqueVulnerabilitiesTable/UniqueVulnerabilitiesTable.tsx
+++ b/plugins/security-metrics/src/components/UniqueVulnerabilitiesTable/UniqueVulnerabilitiesTable.tsx
@@ -25,19 +25,43 @@ import {
 
 type Props = {
   data: AggregatedVulnerability[];
+  showOpen: boolean;
 };
 
-export const UniqueVulnerabilitiesTable = ({ data }: Props) => {
+export const UniqueVulnerabilitiesTable = ({ data, showOpen }: Props) => {
   const [sortType, setSortType] = useState<SortType>('Alvorlighetsgrad');
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
   const [searchQuery, setSearchQuery] = useState('');
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(25);
 
+  const [prevShowOpen, setPrevShowOpen] = useState(showOpen);
+  if (prevShowOpen !== showOpen) {
+    setPrevShowOpen(showOpen);
+    setPage(0);
+  }
+
+  const visibleVulnerabilities = useMemo(() => {
+    if (!showOpen) {
+      return data;
+    }
+
+    return data
+      .map(vulnerability => ({
+        ...vulnerability,
+        affectedComponents: vulnerability.affectedComponents.filter(
+          component => component.status !== 'AKSEPTERT',
+        ),
+      }))
+      .filter(vulnerability => vulnerability.affectedComponents.length > 0);
+  }, [data, showOpen]);
+
   const filteredVulnerabilities = useMemo(
     () =>
-      data.filter(vulnerability => matchesSearch(vulnerability, searchQuery)),
-    [data, searchQuery],
+      visibleVulnerabilities.filter(vulnerability =>
+        matchesSearch(vulnerability, searchQuery),
+      ),
+    [visibleVulnerabilities, searchQuery],
   );
 
   const sortedVulnerabilities = useMemo(() => {
@@ -104,7 +128,9 @@ export const UniqueVulnerabilitiesTable = ({ data }: Props) => {
 
         <Box sx={{ mt: 1 }}>
           <Typography variant="body2" sx={{ opacity: 0.7 }}>
-            Viser {sortedVulnerabilities.length} av {data.length} sårbarheter
+            Viser {sortedVulnerabilities.length} av{' '}
+            {visibleVulnerabilities.length}
+            {showOpen ? ' åpne' : ''} sårbarheter
           </Typography>
         </Box>
       </Paper>

--- a/plugins/security-metrics/src/components/UniqueVulnerabilitiesTable/UniqueVulnerabilitiesTable.tsx
+++ b/plugins/security-metrics/src/components/UniqueVulnerabilitiesTable/UniqueVulnerabilitiesTable.tsx
@@ -35,12 +35,6 @@ export const UniqueVulnerabilitiesTable = ({ data, showOpen }: Props) => {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(25);
 
-  const [prevShowOpen, setPrevShowOpen] = useState(showOpen);
-  if (prevShowOpen !== showOpen) {
-    setPrevShowOpen(showOpen);
-    setPage(0);
-  }
-
   const visibleVulnerabilities = useMemo(() => {
     if (!showOpen) {
       return data;
@@ -86,10 +80,16 @@ export const UniqueVulnerabilitiesTable = ({ data, showOpen }: Props) => {
     });
   }, [filteredVulnerabilities, sortOrder, sortType]);
 
+  const pageCount = Math.max(
+    1,
+    Math.ceil(sortedVulnerabilities.length / rowsPerPage),
+  );
+  const safePage = Math.min(page, pageCount - 1);
+
   const paginatedVulnerabilities = useMemo(() => {
-    const start = page * rowsPerPage;
+    const start = safePage * rowsPerPage;
     return sortedVulnerabilities.slice(start, start + rowsPerPage);
-  }, [page, rowsPerPage, sortedVulnerabilities]);
+  }, [safePage, rowsPerPage, sortedVulnerabilities]);
 
   const handleSearchChange = (value: string) => {
     setSearchQuery(value);
@@ -191,7 +191,7 @@ export const UniqueVulnerabilitiesTable = ({ data, showOpen }: Props) => {
               <TablePagination
                 colSpan={3}
                 count={sortedVulnerabilities.length}
-                page={page}
+                page={safePage}
                 onPageChange={(_, newPage) => setPage(newPage)}
                 rowsPerPage={rowsPerPage}
                 onRowsPerPageChange={event => {

--- a/plugins/security-metrics/src/components/UniqueVulnerabilitiesTable/UniqueVulnerabilitiesTableRow.tsx
+++ b/plugins/security-metrics/src/components/UniqueVulnerabilitiesTable/UniqueVulnerabilitiesTableRow.tsx
@@ -51,15 +51,15 @@ export const UniqueVulnerabilitiesTableRow = ({ vulnerability }: Props) => {
           <Typography variant="body2">
             {components.length} komponenter:{' '}
             {previewComponents.map((component, index) => (
-              <span key={component}>
+              <span key={component.componentName}>
                 {index > 0 && ', '}
                 <Link
                   component="button"
                   underline="hover"
-                  onClick={() => goToComponent(component)}
+                  onClick={() => goToComponent(component.componentName)}
                   sx={{ verticalAlign: 'baseline' }}
                 >
-                  {component}
+                  {component.componentName}
                 </Link>
               </span>
             ))}
@@ -87,13 +87,15 @@ export const UniqueVulnerabilitiesTableRow = ({ vulnerability }: Props) => {
                 <TableBody>
                   {components.map(component => (
                     <StyledTableRow
-                      key={component}
+                      key={component.componentName}
                       hover
                       sx={{ cursor: 'pointer' }}
-                      onClick={() => goToComponent(component)}
+                      onClick={() => goToComponent(component.componentName)}
                     >
                       <TableCell sx={{ borderBottom: 'none' }}>
-                        <Typography variant="body2">{component}</Typography>
+                        <Typography variant="body2">
+                          {component.componentName}
+                        </Typography>
                       </TableCell>
                       <TableCell
                         align="right"

--- a/plugins/security-metrics/src/components/UniqueVulnerabilitiesTable/utils.ts
+++ b/plugins/security-metrics/src/components/UniqueVulnerabilitiesTable/utils.ts
@@ -37,7 +37,7 @@ export const matchesSearch = (
     vulnerability.vulnerabilityId,
     vulnerability.summary,
     vulnerability.severity,
-    ...vulnerability.affectedComponents,
+    ...vulnerability.affectedComponents.map(c => c.componentName),
   ]
     .join(' ')
     .toLowerCase()

--- a/plugins/security-metrics/src/components/Views/GroupPage.tsx
+++ b/plugins/security-metrics/src/components/Views/GroupPage.tsx
@@ -205,14 +205,10 @@ export const GroupPage = () => {
       {selectedTab === TabEnum.VULNERABILITIES &&
         !isUniqueVulnerabilitiesLoading &&
         !uniqueVulnerabilitiesError && (
-          <>
-            {showOpen && (
-              <Alert severity="info">
-                Viser alle sårbarheter, ikke bare åpne
-              </Alert>
-            )}
-            <UniqueVulnerabilitiesTable data={aggregatedVulnerabilities} />
-          </>
+          <UniqueVulnerabilitiesTable
+            data={aggregatedVulnerabilities}
+            showOpen={showOpen}
+          />
         )}
 
       {selectedTab === TabEnum.COMPONENT && isComponentsLoading && <Progress />}

--- a/plugins/security-metrics/src/hooks/useChangeVulnerabilityStatusQuery.ts
+++ b/plugins/security-metrics/src/hooks/useChangeVulnerabilityStatusQuery.ts
@@ -58,6 +58,7 @@ export const useChangeVulnerabilityStatusQuery = () => {
         queryClient.invalidateQueries({ queryKey: ['systems'] }),
         queryClient.invalidateQueries({ queryKey: ['trends'] }),
         queryClient.invalidateQueries({ queryKey: ['ownerMetrics'] }),
+        queryClient.invalidateQueries({ queryKey: ['uniqueVulnerabilities'] }),
       ]);
     },
   });

--- a/plugins/security-metrics/src/typesFrontend.ts
+++ b/plugins/security-metrics/src/typesFrontend.ts
@@ -163,11 +163,16 @@ export type UniqueVulnerabilities = {
   vulnerabilities: AggregatedVulnerability[];
 };
 
+export type AggregatedAffectedComponent = {
+  componentName: string;
+  status: Status | null;
+};
+
 export type AggregatedVulnerability = {
   vulnerabilityId: string;
   severity: Severity;
   summary: string;
-  affectedComponents: string[];
+  affectedComponents: AggregatedAffectedComponent[];
 };
 
 export type ScannerConfig = {


### PR DESCRIPTION
## Bakgrunn 🔒

Jira: https://kartverket.atlassian.net/jira/software/projects/EDSKVIS/boards/177?filter=&groupBy=none&selectedIssue=EDSKVIS-1138

"Unike sårbarheter" fanen skiller ikke på aksepterte og ikke aksepterte sårbarheter, men de andre visningene gjør det.

## Løsning 🔑

Tidligere ignorerte "Unike sårbarheter"-fanen showOpen-innstillingen fra "Tilpass visning" og viste alltid alle sårbarheter. Nå er status-info lagt til på sårbarhetene som returneres fra `/uniqueVulnerabilities`. Når toggle er skrudd på filtreres sårbarheter med status AKSEPTERT bort, og rader uten gjenværende sårbarheter skjules. 

Avhengig av https://github.com/kartverket/sikkerhetsmetrikker/pull/1026

## 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| <img width="611" height="218" alt="Screenshot 2026-08-07 at 09 38 56" src="https://github.com/user-attachments/assets/c6360375-d3fd-400f-8379-fda39a1de42f" /> | <img width="573" height="161" alt="Screenshot 2026-08-07 at 09 39 43" src="https://github.com/user-attachments/assets/d4039e26-a0ef-4b44-93bf-e14a84f7806e" /> |