### PR TITLE
Synthetic regelrett data

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,8 +59,9 @@ Filen kan mangle eller være tom. Standardoppsettet gir:
 - En midlertidig SQLite-database kjører i minnet.
 - Katalogen leses fra syntetiske YAML-filer under
   [`examples/local/`](examples/local/).
-- Eksterne integrasjoner og backend-plugins som krever Entra ID, GitHub,
-  Google eller interne Kartverket-tjenester er deaktivert.
+- Regelrett bruker en lokal, syntetisk adapter uten Microsoft eller en kjørende
+  Regelrett-tjeneste. Andre eksterne integrasjoner og backend-plugins som krever
+  Entra ID, GitHub, Google eller interne Kartverket-tjenester er deaktivert.
 
 Frontend-rutene er de samme som i produksjon. En deaktivert integrasjon viser en
 forklaring og hvilken lokal konfigurasjon som mangler, i stedet for å kalle en
@@ -132,9 +133,22 @@ regelrett:
   clientId: ${REGELRETT_CLIENT_ID}
 ```
 
-`synthetic` er reservert for integrasjoner som har en implementert syntetisk
-adapter. Inntil adapteren finnes, viser frontend at integrasjonen ikke er
-tilgjengelig.
+Regelrett står på `synthetic` i utviklingsprofilen. Adapteren tilbyr de samme fire
+operasjonene som portalen bruker: skjematyper, oppslag per funksjon, oppslag per
+lag og opprettelse. Opprettede skjemaer lever i minnet frem til backend startes
+på nytt.
+
+| Tilstand | Slik testes den |
+| -------- | --------------- |
+| Populert | Logg inn som Kari Knekk og åpne «Fastslå hva som er spiselig» eller Lag Knekk. |
+| Tom | Logg inn som Mikkel Mellomlag og åpne «Hjelpe innbyggerne med å finne godsakene». |
+| Avvist | Logg inn som Kari Knekk og åpne en funksjon eid av Lag Seig. |
+| Tjenestefeil | Logg inn som Mikkel Mellomlag og åpne «Utgi Lørdagsatlaset» eller Lag Skum. |
+
+Skjemalenker er med hensikt ikke klikkbare i syntetisk modus fordi adapteren
+simulerer API-kontrakten, ikke Regelretts egen brukerflate. Bytt eksplisitt til
+`connected` for å teste den virkelige tjenesten. For andre integrasjoner er
+`synthetic` bare tilgjengelig når en tilsvarende adapter er implementert.
 
 Den syntetiske katalogen forblir aktiv når en ekstern tjeneste kobles til. Hvis
 en ekstern katalog-provider skal erstatte dummydataene, legg også dette i den

--- a/app-config.development.yaml
+++ b/app-config.development.yaml
@@ -53,7 +53,7 @@ sikkerhetsmetrikker:
   mode: disabled
 
 regelrett:
-  mode: disabled
+  mode: synthetic
 
 # The RiSc package requires these fields through its own config schema even
 # while the integration is disabled. They are visibly inert local values.

--- a/packages/app/src/components/catalog/entityPages/FunctionEntityPage.tsx
+++ b/packages/app/src/components/catalog/entityPages/FunctionEntityPage.tsx
@@ -40,7 +40,11 @@ export const FunctionEntityPage = () => {
             <FunctionDependenciesCard />
           </Grid>
           <Grid size={{ xs: 12, md: 6 }}>
-            <IntegrationBoundary configKey="regelrett" title="Regelrett">
+            <IntegrationBoundary
+              configKey="regelrett"
+              title="Regelrett"
+              syntheticAvailable
+            >
               <FunctionSecurityFormsCard />
             </IntegrationBoundary>
           </Grid>

--- a/packages/app/src/components/catalog/entityPages/GroupPage.tsx
+++ b/packages/app/src/components/catalog/entityPages/GroupPage.tsx
@@ -46,7 +46,11 @@ export const groupPage = (
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <Flex direction="column" gap="24px">
-            <IntegrationBoundary configKey="regelrett" title="Regelrett">
+            <IntegrationBoundary
+              configKey="regelrett"
+              title="Regelrett"
+              syntheticAvailable
+            >
               <GroupSecurityFormsCard />
             </IntegrationBoundary>
           </Flex>

--- a/packages/app/src/components/functions/regelrettQueryGate.ts
+++ b/packages/app/src/components/functions/regelrettQueryGate.ts
@@ -5,7 +5,7 @@ export const teamIdsForRegelrettFormsQuery = ({
   regelrettMode?: string;
   teamIds: string[];
 }): string[] => {
-  if (regelrettMode !== 'connected') {
+  if (regelrettMode !== 'connected' && regelrettMode !== 'synthetic') {
     return [];
   }
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -50,7 +50,7 @@ const optionalIntegrations = createBackendFeatureLoader({
     if (getIntegrationMode(config, 'sikkerhetsmetrikker') === 'connected') {
       yield import('@kartverket/backstage-plugin-security-metrics-backend');
     }
-    if (getIntegrationMode(config, 'regelrett') === 'connected') {
+    if (getIntegrationMode(config, 'regelrett') !== 'disabled') {
       yield import('@internal/backstage-plugin-regelrett-schemas-backend');
     }
     if (getIntegrationMode(config, 'ros') === 'connected') {

--- a/plugins/frontend-custom-components/src/components/FunctionSecurityFormsCard/FunctionSecurityFormsCard.tsx
+++ b/plugins/frontend-custom-components/src/components/FunctionSecurityFormsCard/FunctionSecurityFormsCard.tsx
@@ -20,7 +20,6 @@ import {
   InfoCard,
   InfoCardVariants,
   Progress,
-  Link,
 } from '@backstage/core-components';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useRegelrettQuery } from '../../hooks/useRegelrettQuery';
@@ -31,7 +30,7 @@ import { makeStyles } from 'tss-react/mui';
 import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
 import WarningAmberOutlined from '@mui/icons-material/WarningAmberOutlined';
 import { useState, useEffect } from 'react';
-import { configApiRef, useApi } from '@backstage/frontend-plugin-api';
+import { useApi } from '@backstage/frontend-plugin-api';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { Button, Flex } from '@backstage/ui';
 import FormControl from '@mui/material/FormControl';
@@ -40,9 +39,9 @@ import MenuItem from '@mui/material/MenuItem';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { functionLinkCardTranslationRef } from './translation';
 import { useFormTypesQuery } from '../../hooks/useFormTypesQuery';
-import { buildFormUrl } from '../../utils/formUrl';
 import Typography from '@mui/material/Typography';
 import { isUnauthorizedError } from '../../errors';
+import { RegelrettFormLink } from '../RegelrettFormLink';
 
 const useStyles = makeStyles()(theme => ({
   formList: {
@@ -118,12 +117,9 @@ function FunctionSecurityFormsCardItem(props: EntityLinksCardProps) {
   const { variant } = props;
   const { classes } = useStyles();
   const { t } = useTranslationRef(functionLinkCardTranslationRef);
-  const config = useApi(configApiRef);
   const catalogApi = useApi(catalogApiRef);
   const { entity } = useEntity();
   const functionName = entity.metadata.title || entity.metadata.name;
-  const regelrettBaseUrl = config.getString(`regelrett.url`);
-
   const ownerRef = entity.relations?.find(
     rel => rel.type === 'ownedBy',
   )?.targetRef;
@@ -211,13 +207,9 @@ function FunctionSecurityFormsCardItem(props: EntityLinksCardProps) {
             ({ id, formId, answeredCount, expiredCount, totalCount }) => (
               <div key={id} className={classes.formRow}>
                 <DescriptionOutlinedIcon className={classes.formIcon} />
-                <Link
-                  to={buildFormUrl(regelrettBaseUrl, id)}
-                  target="_blank"
-                  rel="noopener"
-                >
+                <RegelrettFormLink contextId={id}>
                   {getFormType(formId)}
-                </Link>
+                </RegelrettFormLink>
                 {answeredCount !== undefined && totalCount !== undefined && (
                   <div className={classes.metricsContainer}>
                     <span className={classes.metricsLabel}>

--- a/plugins/frontend-custom-components/src/components/GroupSecurityFormsCard/FunctionFormsTabContent.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupSecurityFormsCard/FunctionFormsTabContent.tsx
@@ -3,13 +3,12 @@ import { makeStyles } from 'tss-react/mui';
 import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
 import WarningAmberOutlined from '@mui/icons-material/WarningAmberOutlined';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
-import { Link } from '@backstage/core-components';
 import { EntityRefLink } from '@backstage/plugin-catalog-react';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { functionLinkCardTranslationRef } from '../FunctionSecurityFormsCard/translation';
-import { buildFormUrl } from '../../utils/formUrl';
 import { RegelrettForm } from '../../types';
 import { CreateFormSection } from './CreateFormSection';
+import { RegelrettFormLink } from '../RegelrettFormLink';
 import { Entity } from '@backstage/catalog-model';
 
 const useStyles = makeStyles()(theme => ({
@@ -107,7 +106,6 @@ const useStyles = makeStyles()(theme => ({
 
 interface FunctionFormsTabContentProps {
   forms: RegelrettForm[];
-  regelrettBaseUrl: string;
   teamId: string;
   functionEntities: Entity[];
   onFormCreated: () => void;
@@ -116,7 +114,6 @@ interface FunctionFormsTabContentProps {
 
 export function FunctionFormsTabContent({
   forms,
-  regelrettBaseUrl,
   teamId,
   functionEntities,
   onFormCreated,
@@ -181,13 +178,9 @@ export function FunctionFormsTabContent({
                 {funcForms.map(form => (
                   <div key={form.id} className={classes.formRow}>
                     <DescriptionOutlinedIcon className={classes.formIcon} />
-                    <Link
-                      to={buildFormUrl(regelrettBaseUrl, form.id)}
-                      target="_blank"
-                      rel="noopener"
-                    >
+                    <RegelrettFormLink contextId={form.id}>
                       {getFormType(form.formId)}
-                    </Link>
+                    </RegelrettFormLink>
                     {form.answeredCount !== undefined &&
                       form.totalCount !== undefined && (
                         <div className={classes.metricsContainer}>

--- a/plugins/frontend-custom-components/src/components/GroupSecurityFormsCard/GroupSecurityFormsCard.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupSecurityFormsCard/GroupSecurityFormsCard.tsx
@@ -10,7 +10,7 @@ import { useTeamRegelrettQuery } from '../../hooks/useTeamRegelrettQuery';
 import { useFormTypesQuery } from '../../hooks/useFormTypesQuery';
 import { useIsGroupMember } from '../../hooks/useIsGroupMember';
 import Alert from '@mui/material/Alert';
-import { configApiRef, useApi } from '@backstage/frontend-plugin-api';
+import { useApi } from '@backstage/frontend-plugin-api';
 import { makeStyles } from 'tss-react/mui';
 import PeopleIcon from '@mui/icons-material/People';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
@@ -94,11 +94,8 @@ export const GroupSecurityFormsCard = () => {
 function GroupSecurityFormsCardWrapper() {
   const { classes } = useStyles();
   const { t } = useTranslationRef(functionLinkCardTranslationRef);
-  const config = useApi(configApiRef);
   const catalogApi = useApi(catalogApiRef);
   const { entity } = useEntity();
-  const regelrettBaseUrl = config.getString(`regelrett.url`);
-
   const teamId =
     entity.metadata.annotations?.['graph.microsoft.com/group-id'] ?? '';
 
@@ -206,7 +203,6 @@ function GroupSecurityFormsCardWrapper() {
         {activeTab === 'team' ? (
           <TeamFormsTabContent
             forms={teamForms}
-            regelrettBaseUrl={regelrettBaseUrl}
             teamId={teamId}
             onFormCreated={refetch}
             formTypeMap={formTypeMap}
@@ -214,7 +210,6 @@ function GroupSecurityFormsCardWrapper() {
         ) : (
           <FunctionFormsTabContent
             forms={functionForms}
-            regelrettBaseUrl={regelrettBaseUrl}
             teamId={teamId}
             functionEntities={functionEntities?.items ?? []}
             onFormCreated={refetch}

--- a/plugins/frontend-custom-components/src/components/GroupSecurityFormsCard/TeamFormsTabContent.tsx
+++ b/plugins/frontend-custom-components/src/components/GroupSecurityFormsCard/TeamFormsTabContent.tsx
@@ -1,12 +1,11 @@
 import { makeStyles } from 'tss-react/mui';
 import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
 import WarningAmberOutlined from '@mui/icons-material/WarningAmberOutlined';
-import { Link } from '@backstage/core-components';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { functionLinkCardTranslationRef } from '../FunctionSecurityFormsCard/translation';
-import { buildFormUrl } from '../../utils/formUrl';
 import { RegelrettForm } from '../../types';
 import { CreateFormSection } from './CreateFormSection';
+import { RegelrettFormLink } from '../RegelrettFormLink';
 
 const useStyles = makeStyles()(theme => ({
   formList: {
@@ -64,7 +63,6 @@ const useStyles = makeStyles()(theme => ({
 
 interface TeamFormsTabContentProps {
   forms: RegelrettForm[];
-  regelrettBaseUrl: string;
   teamId: string;
   onFormCreated: () => void;
   formTypeMap: Record<string, string>;
@@ -72,7 +70,6 @@ interface TeamFormsTabContentProps {
 
 export function TeamFormsTabContent({
   forms,
-  regelrettBaseUrl,
   teamId,
   onFormCreated,
   formTypeMap,
@@ -94,13 +91,9 @@ export function TeamFormsTabContent({
           {forms.map(form => (
             <div key={form.id} className={classes.formRow}>
               <DescriptionOutlinedIcon className={classes.formIcon} />
-              <Link
-                to={buildFormUrl(regelrettBaseUrl, form.id)}
-                target="_blank"
-                rel="noopener"
-              >
+              <RegelrettFormLink contextId={form.id}>
                 {`${form.name} – ${getFormType(form.formId)}`}
-              </Link>
+              </RegelrettFormLink>
               {form.answeredCount !== undefined &&
                 form.totalCount !== undefined && (
                   <div className={classes.metricsContainer}>

--- a/plugins/frontend-custom-components/src/components/RegelrettFormLink.tsx
+++ b/plugins/frontend-custom-components/src/components/RegelrettFormLink.tsx
@@ -1,0 +1,24 @@
+import { PropsWithChildren } from 'react';
+import { Link } from '@backstage/core-components';
+import { configApiRef, useApi } from '@backstage/frontend-plugin-api';
+import { buildFormUrl } from '../utils/formUrl';
+
+export function RegelrettFormLink({
+  contextId,
+  children,
+}: PropsWithChildren<{ contextId: string }>) {
+  const config = useApi(configApiRef);
+  if (config.getString('regelrett.mode') === 'synthetic') {
+    return <span title="Syntetisk Regelrett-skjema">{children}</span>;
+  }
+
+  return (
+    <Link
+      to={buildFormUrl(config.getString('regelrett.url'), contextId)}
+      target="_blank"
+      rel="noopener"
+    >
+      {children}
+    </Link>
+  );
+}

--- a/plugins/frontend-custom-components/src/hooks/useAllFunctionFormsQuery.ts
+++ b/plugins/frontend-custom-components/src/hooks/useAllFunctionFormsQuery.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { getAuthenticationTokens } from '../utils/authenticationUtils';
+import { getRegelrettRequestHeaders } from '../utils/authenticationUtils';
 import {
   configApiRef,
   identityApiRef,
@@ -40,7 +40,7 @@ export const useAllFunctionFormsQuery = (teamIds: string[]) => {
 
     (async () => {
       try {
-        const { entraIdToken, backstageToken } = await getAuthenticationTokens(
+        const headers = await getRegelrettRequestHeaders(
           config,
           backstageAuthApi,
           microsoftAuthApi,
@@ -55,10 +55,7 @@ export const useAllFunctionFormsQuery = (teamIds: string[]) => {
             url.searchParams.set('teamId', teamId);
             const response = await fetch(url, {
               method: 'GET',
-              headers: {
-                Authorization: `Bearer ${backstageToken}`,
-                EntraId: entraIdToken,
-              },
+              headers,
             });
             if (!response.ok) return [] as RegelrettForm[];
             return (await response.json()) as RegelrettForm[];

--- a/plugins/frontend-custom-components/src/hooks/useFormTypesQuery.ts
+++ b/plugins/frontend-custom-components/src/hooks/useFormTypesQuery.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getAuthenticationTokens } from '../utils/authenticationUtils';
+import { getRegelrettRequestHeaders } from '../utils/authenticationUtils';
 import {
   configApiRef,
   identityApiRef,
@@ -17,7 +17,7 @@ export const useFormTypesQuery = () => {
   return useQuery<FormType[]>({
     queryKey: ['fetch-regelrett-form-types'],
     queryFn: async () => {
-      const { entraIdToken, backstageToken } = await getAuthenticationTokens(
+      const headers = await getRegelrettRequestHeaders(
         config,
         backstageAuthApi,
         microsoftAuthApi,
@@ -29,10 +29,7 @@ export const useFormTypesQuery = () => {
 
       const response = await fetch(url, {
         method: 'GET',
-        headers: {
-          Authorization: `Bearer ${backstageToken}`,
-          EntraId: entraIdToken,
-        },
+        headers,
       });
 
       const data = await response.json();

--- a/plugins/frontend-custom-components/src/hooks/useRegelrettCreateContextMutation.ts
+++ b/plugins/frontend-custom-components/src/hooks/useRegelrettCreateContextMutation.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { getAuthenticationTokens } from '../utils/authenticationUtils';
+import { getRegelrettRequestHeaders } from '../utils/authenticationUtils';
 import {
   configApiRef,
   identityApiRef,
@@ -23,7 +23,7 @@ export const useRegelrettCreateContextMutation = () => {
     { functionName: string; formId: string; teamId: string }
   >({
     mutationFn: async ({ functionName, formId, teamId }) => {
-      const { entraIdToken, backstageToken } = await getAuthenticationTokens(
+      const headers = await getRegelrettRequestHeaders(
         config,
         backstageAuthApi,
         microsoftAuthApi,
@@ -39,10 +39,7 @@ export const useRegelrettCreateContextMutation = () => {
 
       const response = await fetch(url, {
         method: 'POST',
-        headers: {
-          Authorization: `Bearer ${backstageToken}`,
-          EntraId: entraIdToken,
-        },
+        headers,
       });
 
       const data = await response.json();

--- a/plugins/frontend-custom-components/src/hooks/useRegelrettQuery.ts
+++ b/plugins/frontend-custom-components/src/hooks/useRegelrettQuery.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getAuthenticationTokens } from '../utils/authenticationUtils';
+import { getRegelrettRequestHeaders } from '../utils/authenticationUtils';
 import {
   configApiRef,
   identityApiRef,
@@ -21,7 +21,7 @@ export const useRegelrettQuery = (
     queryKey: ['fetch-regelrett-forms', functionName],
     enabled: !!functionName && (options?.enabled ?? true),
     queryFn: async () => {
-      const { entraIdToken, backstageToken } = await getAuthenticationTokens(
+      const headers = await getRegelrettRequestHeaders(
         config,
         backstageAuthApi,
         microsoftAuthApi,
@@ -34,10 +34,7 @@ export const useRegelrettQuery = (
       url.searchParams.set('name', functionName);
       const response = await fetch(url, {
         method: 'GET',
-        headers: {
-          Authorization: `Bearer ${backstageToken}`,
-          EntraId: entraIdToken,
-        },
+        headers,
       });
 
       const data = await response.json();

--- a/plugins/frontend-custom-components/src/hooks/useTeamRegelrettQuery.ts
+++ b/plugins/frontend-custom-components/src/hooks/useTeamRegelrettQuery.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getAuthenticationTokens } from '../utils/authenticationUtils';
+import { getRegelrettRequestHeaders } from '../utils/authenticationUtils';
 import {
   configApiRef,
   identityApiRef,
@@ -25,7 +25,7 @@ export const useTeamRegelrettQuery = (
       if (!groupEntity.metadata.annotations) {
         throw new Error('Group entity does not have annotations');
       }
-      const { entraIdToken, backstageToken } = await getAuthenticationTokens(
+      const headers = await getRegelrettRequestHeaders(
         config,
         backstageAuthApi,
         microsoftAuthApi,
@@ -41,10 +41,7 @@ export const useTeamRegelrettQuery = (
       );
       const response = await fetch(url, {
         method: 'GET',
-        headers: {
-          Authorization: `Bearer ${backstageToken}`,
-          EntraId: entraIdToken,
-        },
+        headers,
       });
 
       const data = await response.json();

--- a/plugins/frontend-custom-components/src/utils/authenticationUtils.ts
+++ b/plugins/frontend-custom-components/src/utils/authenticationUtils.ts
@@ -5,16 +5,25 @@ export async function getAuthenticationTokens(
   config: Config,
   backstageAuthApi: IdentityApi,
   microsoftAuthApi: OAuthApi,
-): Promise<{ entraIdToken: string; backstageToken: string }> {
-  const environment = config.getString('auth.environment');
-  const clientId = config.getString(
-    `auth.providers.microsoft.${environment}.clientId`,
-  );
-
+): Promise<{ entraIdToken?: string; backstageToken: string }> {
   const backstageToken = (await backstageAuthApi.getCredentials()).token;
   if (!backstageToken) {
     throw new Error('Backstage token could not be retrieved.');
   }
+
+  const mode = config.getString('regelrett.mode');
+  const authentication = config.getOptionalString('regelrett.authentication');
+  if (mode === 'synthetic' || authentication === 'synthetic') {
+    return { backstageToken };
+  }
+  if (authentication !== 'entra') {
+    throw new Error("Regelrett must use 'entra' authentication when connected");
+  }
+
+  const environment = config.getString('auth.environment');
+  const clientId = config.getString(
+    `auth.providers.microsoft.${environment}.clientId`,
+  );
 
   let entraIdToken: string;
   try {
@@ -30,4 +39,20 @@ export async function getAuthenticationTokens(
   }
 
   return { entraIdToken, backstageToken };
+}
+
+export async function getRegelrettRequestHeaders(
+  config: Config,
+  backstageAuthApi: IdentityApi,
+  microsoftAuthApi: OAuthApi,
+): Promise<Record<string, string>> {
+  const { entraIdToken, backstageToken } = await getAuthenticationTokens(
+    config,
+    backstageAuthApi,
+    microsoftAuthApi,
+  );
+  return {
+    Authorization: `Bearer ${backstageToken}`,
+    ...(entraIdToken ? { EntraId: entraIdToken } : {}),
+  };
 }

--- a/plugins/regelrett-schemas-backend/README.md
+++ b/plugins/regelrett-schemas-backend/README.md
@@ -13,8 +13,25 @@ backend.add(import('@internal/backstage-plugin-regelrett-schemas-backend'));
 
 ## Konfigurasjon
 
-Pluginen er deaktivert som standard. Aktiver bare Regelrett i den gitignorede
-`app-config.local.yaml`-filen:
+Utviklingsprofilen bruker som standard den syntetiske adapteren:
+
+```yaml
+regelrett:
+  mode: synthetic
+```
+
+Den krever bare en syntetisk Backstage-person. Den bruker de stabile
+Graph-kompatible gruppe-ID-ene fra `examples/local/organization.yaml`, tilbyr
+skjematyper og representative skjemadata, og lar utvikleren opprette skjemaer i
+minnet. Tilstanden tilbakestilles når backend startes på nytt. Den foretar ingen
+nettverkskall til Regelrett eller Microsoft.
+
+Adapteren har dokumenterte, deterministiske tilstander for populert, tomt,
+avvist og tjenestefeil; se
+[`CONTRIBUTING.md`](../../CONTRIBUTING.md#koble-til-én-ekstern-tjeneste).
+
+For å bruke en virkelig Regelrett-instans, overstyr bare Regelrett i den
+gitignorede `app-config.local.yaml`-filen:
 
 ```yaml
 regelrett:
@@ -30,3 +47,5 @@ Dette krever at Regelrett-backend kjører lokalt, typisk på
 en Microsoft-provider under `auth.providers.microsoft.development` og en
 Microsoft Graph-katalog-provider; se
 [`CONTRIBUTING.md`](../../CONTRIBUTING.md#koble-til-én-ekstern-tjeneste).
+
+Produksjon bruker fortsatt `mode: connected` og `authentication: entra`.

--- a/plugins/regelrett-schemas-backend/src/plugin.ts
+++ b/plugins/regelrett-schemas-backend/src/plugin.ts
@@ -16,13 +16,15 @@ export const RegelrettSchemaPlugin = createBackendPlugin({
       deps: {
         httpRouter: coreServices.httpRouter,
         auth: coreServices.auth,
+        userInfo: coreServices.userInfo,
         logger: coreServices.logger,
         config: coreServices.rootConfig,
       },
-      async init({ httpRouter, auth, logger, config }) {
+      async init({ httpRouter, auth, userInfo, logger, config }) {
         httpRouter.use(
           (await createRouter({
             auth,
+            userInfo,
             logger,
             config,
           })) as any,

--- a/plugins/regelrett-schemas-backend/src/router.ts
+++ b/plugins/regelrett-schemas-backend/src/router.ts
@@ -1,256 +1,152 @@
-import express from 'express';
+import express, { Request } from 'express';
+import {
+  AuthService,
+  LoggerService,
+  UserInfoService,
+} from '@backstage/backend-plugin-api';
+import { Config } from '@backstage/config';
 import {
   ApiError,
-  Context,
-  ContextWithMetrics,
-  EntraIdConfiguration,
+  RegelrettRequestIdentity,
+  RegelrettService,
   Result,
-  Form,
 } from './types';
-import { AuthService, LoggerService } from '@backstage/backend-plugin-api';
-import { Config } from '@backstage/config';
-import { EntraIdService } from './services/entraIdService';
-import { ProxyApiService } from './services/proxyApiService';
+import { createRegelrettService } from './services/createRegelrettService';
 
 interface RouterOptions {
   auth: AuthService;
+  userInfo: UserInfoService;
   logger: LoggerService;
   config: Config;
+  service?: RegelrettService;
 }
 
-const formatToken = (token: string | undefined): string | null => {
-  if (!token || !token.startsWith('Bearer')) {
-    return null;
+const formatToken = (authorization: string | undefined): string | undefined => {
+  if (!authorization?.startsWith('Bearer ')) {
+    return undefined;
   }
-  return token.substring(7).trim();
+  return authorization.substring(7).trim();
 };
 
-const validateToken = (
-  token: string | undefined,
+async function getRequestIdentity(
+  req: Request,
   auth: AuthService,
-): string | null => {
-  const formattedToken = formatToken(token);
-  if (!formattedToken) {
-    return null;
+  userInfo: UserInfoService,
+): Promise<RegelrettRequestIdentity | undefined> {
+  const token = formatToken(req.header('Authorization'));
+  if (!token) {
+    return undefined;
   }
-  const credentials = auth.authenticate(formattedToken);
-  if (!credentials) {
-    return null;
+
+  try {
+    const credentials = await auth.authenticate(token);
+    if (!auth.isPrincipal(credentials, 'user')) {
+      return undefined;
+    }
+    const identity = await userInfo.getUserInfo(credentials);
+    return {
+      ...identity,
+      entraIdToken: req.header('Entraid'),
+    };
+  } catch {
+    return undefined;
   }
-  return formattedToken;
-};
+}
+
+function sendResult<Data>(
+  res: express.Response,
+  result: Result<ApiError, Data>,
+) {
+  if (result.ok) {
+    res.status(200).send(result.data);
+    return;
+  }
+  res.status(result.error.statusCode).send({
+    message: result.error.message,
+    frontendMessage: result.error.message,
+  });
+}
+
+function queryString(value: unknown, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`No ${name} parameter provided`);
+  }
+  return value;
+}
 
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const { auth, logger, config } = options;
-  const externalAPI = 'regelrett';
-  const backendBaseUrl = config.getString(`${externalAPI}.baseUrl`);
-  const environment = config.getString('auth.environment');
-  const clientId = config.getString(
-    `auth.providers.microsoft.${environment}.clientId`,
-  );
-  const clientSecret = config.getString(
-    `auth.providers.microsoft.${environment}.clientSecret`,
-  );
-  const tenantId = config.getString(
-    `auth.providers.microsoft.${environment}.tenantId`,
-  );
-  const scope = `${config.getString(`${externalAPI}.clientId`)}/.default`;
-
-  const entraIdConfiguration: EntraIdConfiguration = {
-    tenantId: tenantId,
-    clientId: clientId,
-    clientSecret: clientSecret,
-    scope: scope,
-  };
-
-  logger.info('[Router] Creating router with config:', {
-    hasAuth: !!auth,
-    hasLogger: !!logger,
-    hasConfig: !!config,
-  });
-
-  const entraIdService = new EntraIdService(entraIdConfiguration, logger);
-  const proxyService = new ProxyApiService(
-    backendBaseUrl,
-    entraIdService,
-    logger,
-  );
-
+  const { auth, userInfo, logger, config } = options;
+  const service = options.service ?? createRegelrettService(config, logger);
   const router = express.Router();
   router.use(express.json());
 
-  router.get(
-    '/proxy/fetch-regelrett-form',
-    async (req, res) => {
-      try {
-        const validToken = validateToken(req.header('Authorization'), auth);
-        if (!validToken) {
-          res.status(401).send({
-            frontendMessage: 'Token is not valid',
-          });
-          return;
-        }
-        const eidToken = req.header('Entraid');
-        const name = req.query.name;
-        if (typeof name !== 'string')
-          throw new Error('No name parameter provided');
-        if (!eidToken) throw new Error('No token');
-        const response: Result<ApiError, ContextWithMetrics> =
-          await proxyService.fetchContextByFunctionName(eidToken, name);
-        if (response.ok) {
-          res.status(200).send(response.data);
-        } else {
-          res
-            .status(response.error.statusCode)
-            .send({ frontendMessage: response.error.message });
-          logger.error(
-            `Recieved a ${response.error.statusCode} status code when trying to fetch context by name from Regelrett API.`,
-          );
-        }
-      } catch (error) {
-        if (error instanceof Error) {
-          logger.error(`Failed to fetch context by name: ${error.message}`);
-          res.status(500).send({
-            message: `Failed to fetch context by name: ${error.message}`,
-          });
-        } else {
-          logger.error(`Failed to fetch context by name: ${error}`);
-          res
-            .status(500)
-            .send({ message: `Failed to fetch context by name: ${error}` });
-        }
-      }
-    },
-
-    router.post('/proxy/create-regelrett-form', async (req, res) => {
-      try {
-        const validToken = validateToken(req.header('Authorization'), auth);
-        if (!validToken) {
-          res.status(401).send({
-            frontendMessage: 'Token is not valid',
-          });
-          return;
-        }
-        const eidToken = req.header('Entraid');
-        const name = req.query.name;
-        const formId = req.query.formId;
-        const teamId = req.query.teamId;
-
-        if (typeof name !== 'string')
-          throw new Error('No name parameter provided');
-        if (!eidToken) throw new Error('No token');
-        if (typeof formId !== 'string')
-          throw new Error('No formId parameter provided');
-        if (typeof teamId !== 'string')
-          throw new Error('No teamId parameter provided');
-
-        const response: Result<ApiError, Context> =
-          await proxyService.createRegelrettContext(
-            eidToken,
-            name,
-            formId,
-            teamId,
-          );
-        if (response.ok) {
-          res.status(200).send(response.data);
-        } else {
-          res
-            .status(response.error.statusCode)
-            .send({ frontendMessage: response.error.message });
-          logger.error(
-            `Recieved a ${response.error.statusCode} status code when trying to fetch context by name from Regelrett API.`,
-          );
-        }
-      } catch (error) {
-        if (error instanceof Error) {
-          logger.error(`Failed to fetch context by name: ${error.message}`);
-          res.status(500).send({
-            message: `Failed to fetch context by name: ${error.message}`,
-          });
-        } else {
-          logger.error(`Failed to fetch context by name: ${error}`);
-          res
-            .status(500)
-            .send({ message: `Failed to fetch context by name: ${error}` });
-        }
-      }
-    }),
-  );
-
-  router.get('/proxy/fetch-regelrett-forms-by-team-id', async (req, res) => {
-    try {
-      const validToken = validateToken(req.header('Authorization'), auth);
-      if (!validToken) {
+  const withIdentity =
+    (
+      handler: (
+        req: Request,
+        res: express.Response,
+        identity: RegelrettRequestIdentity,
+      ) => Promise<void>,
+    ) =>
+    async (req: Request, res: express.Response) => {
+      const identity = await getRequestIdentity(req, auth, userInfo);
+      if (!identity) {
         res.status(401).send({
+          message: 'Token is not valid',
           frontendMessage: 'Token is not valid',
         });
         return;
       }
-      const eidToken = req.header('Entraid');
-      const teamId = req.query.teamId;
-      if (typeof teamId !== 'string')
-        throw new Error('No name parameter provided');
-      if (!eidToken) throw new Error('No token');
-      const response: Result<ApiError, ContextWithMetrics[]> =
-        await proxyService.fetchContextByTeamId(eidToken, teamId);
-      if (response.ok) {
-        res.status(200).send(response.data);
-      } else {
-        res
-          .status(response.error.statusCode)
-          .send({ frontendMessage: response.error.message });
-        logger.error(
-          `Recieved a ${response.error.statusCode} status code when trying to fetch context by team id from Regelrett API.`,
-        );
-      }
-    } catch (error) {
-      if (error instanceof Error) {
-        logger.error(`Failed to fetch context by team id: ${error.message}`);
-        res.status(500).send({
-          message: `Failed to fetch context by team id: ${error.message}`,
-        });
-      } else {
-        logger.error(`Failed to fetch context by team id: ${error}`);
-        res
-          .status(500)
-          .send({ message: `Failed to fetch context by team id: ${error}` });
-      }
-    }
-  });
 
-  router.get('/proxy/fetch-regelrett-form-types', async (req, res) => {
-    try {
-      const validToken = validateToken(req.header('Authorization'), auth);
-      if (!validToken) {
-        res.status(401).send({
-          message: 'Token is not valid',
+      try {
+        await handler(req, res, identity);
+      } catch (caught) {
+        const message =
+          caught instanceof Error ? caught.message : String(caught);
+        logger.error(`Regelrett adapter request failed: ${message}`);
+        res.status(500).send({
+          message: `Regelrett adapter request failed: ${message}`,
         });
-        return;
       }
-      const eidToken = req.header('Entraid');
-      if (!eidToken) throw new Error('No token');
-      const response: Result<ApiError, Form[]> =
-        await proxyService.fetchForms(eidToken);
-      if (response.ok) {
-        res.status(200).send(response.data);
-      } else {
-        res
-          .status(response.error.statusCode)
-          .send({ message: response.error.message });
-        logger.error(
-          `Received a ${response.error.statusCode} status code when trying to fetch forms from Regelrett API.`,
-        );
-      }
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : error;
-      logger.error(`Failed to fetch forms: ${errorMessage}`);
-      res
-        .status(500)
-        .send({ message: `Failed to fetch forms: ${errorMessage}` });
-    }
-  });
+    };
+
+  router.get(
+    '/proxy/fetch-regelrett-form',
+    withIdentity(async (req, res, identity) => {
+      const name = queryString(req.query.name, 'name');
+      sendResult(res, await service.fetchContextByFunctionName(identity, name));
+    }),
+  );
+
+  router.post(
+    '/proxy/create-regelrett-form',
+    withIdentity(async (req, res, identity) => {
+      const name = queryString(req.query.name, 'name');
+      const formId = queryString(req.query.formId, 'formId');
+      const teamId = queryString(req.query.teamId, 'teamId');
+      sendResult(
+        res,
+        await service.createRegelrettContext(identity, name, formId, teamId),
+      );
+    }),
+  );
+
+  router.get(
+    '/proxy/fetch-regelrett-forms-by-team-id',
+    withIdentity(async (req, res, identity) => {
+      const teamId = queryString(req.query.teamId, 'teamId');
+      sendResult(res, await service.fetchContextByTeamId(identity, teamId));
+    }),
+  );
+
+  router.get(
+    '/proxy/fetch-regelrett-form-types',
+    withIdentity(async (_req, res, identity) => {
+      sendResult(res, await service.fetchForms(identity));
+    }),
+  );
 
   return router;
 }

--- a/plugins/regelrett-schemas-backend/src/services/createRegelrettService.ts
+++ b/plugins/regelrett-schemas-backend/src/services/createRegelrettService.ts
@@ -1,0 +1,52 @@
+import { LoggerService } from '@backstage/backend-plugin-api';
+import { Config } from '@backstage/config';
+import { RegelrettService } from '../types';
+import { EntraIdService } from './entraIdService';
+import { ProxyApiService } from './proxyApiService';
+import { SyntheticRegelrettService } from './syntheticRegelrettService';
+
+export function createRegelrettService(
+  config: Config,
+  logger: LoggerService,
+): RegelrettService {
+  const mode = config.getString('regelrett.mode');
+  if (mode === 'synthetic') {
+    logger.info('Using deterministic synthetic Regelrett adapter');
+    return new SyntheticRegelrettService();
+  }
+  if (mode !== 'connected') {
+    throw new Error(
+      `The Regelrett backend plugin cannot start in '${mode}' mode`,
+    );
+  }
+
+  const authentication = config.getString('regelrett.authentication');
+  if (authentication !== 'entra') {
+    throw new Error(
+      `Connected Regelrett authentication '${authentication}' is not implemented yet`,
+    );
+  }
+
+  const environment = config.getString('auth.environment');
+  const entraIdService = new EntraIdService(
+    {
+      tenantId: config.getString(
+        `auth.providers.microsoft.${environment}.tenantId`,
+      ),
+      clientId: config.getString(
+        `auth.providers.microsoft.${environment}.clientId`,
+      ),
+      clientSecret: config.getString(
+        `auth.providers.microsoft.${environment}.clientSecret`,
+      ),
+      scope: `${config.getString('regelrett.clientId')}/.default`,
+    },
+    logger,
+  );
+
+  return new ProxyApiService(
+    config.getString('regelrett.baseUrl'),
+    entraIdService,
+    logger,
+  );
+}

--- a/plugins/regelrett-schemas-backend/src/services/proxyApiService.ts
+++ b/plugins/regelrett-schemas-backend/src/services/proxyApiService.ts
@@ -1,9 +1,17 @@
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { EntraIdService } from './entraIdService';
-import { ApiError, Context, ContextWithMetrics, Result, Form } from '../types';
+import {
+  ApiError,
+  Context,
+  ContextWithMetrics,
+  Result,
+  Form,
+  RegelrettRequestIdentity,
+  RegelrettService,
+} from '../types';
 import { errorHandling } from '../Errors';
 
-export class ProxyApiService {
+export class ProxyApiService implements RegelrettService {
   private readonly regelrettBaseUrl: string;
   private entraIdService: EntraIdService;
   private logger: LoggerService;
@@ -19,10 +27,10 @@ export class ProxyApiService {
   }
 
   async fetchContextByFunctionName(
-    clientToken: string,
+    identity: RegelrettRequestIdentity,
     name: string,
-  ): Promise<Result<ApiError, ContextWithMetrics>> {
-    const token = await this.entraIdService.getOboToken(clientToken);
+  ): Promise<Result<ApiError, ContextWithMetrics[]>> {
+    const token = await this.getOboToken(identity);
     if (!token) throw new Error(`Failed to fetch token for Regelrett API`);
 
     try {
@@ -41,7 +49,7 @@ export class ProxyApiService {
       });
 
       if (response.ok) {
-        const context: ContextWithMetrics = await response.json();
+        const context: ContextWithMetrics[] = await response.json();
         return { ok: true, data: context };
       }
       return { ok: false, error: errorHandling(response) };
@@ -61,12 +69,12 @@ export class ProxyApiService {
   }
 
   async createRegelrettContext(
-    clientToken: string,
+    identity: RegelrettRequestIdentity,
     name: string,
     formId: string,
     teamId: string,
   ): Promise<Result<ApiError, Context>> {
-    const token = await this.entraIdService.getOboToken(clientToken);
+    const token = await this.getOboToken(identity);
     if (!token) throw new Error(`Failed to fetch token for Regelrett API`);
 
     try {
@@ -108,8 +116,10 @@ export class ProxyApiService {
     }
   }
 
-  async fetchForms(clientToken: string): Promise<Result<ApiError, Form[]>> {
-    const token = await this.entraIdService.getOboToken(clientToken);
+  async fetchForms(
+    identity: RegelrettRequestIdentity,
+  ): Promise<Result<ApiError, Form[]>> {
+    const token = await this.getOboToken(identity);
     if (!token) throw new Error(`Failed to fetch token for Regelrett API`);
 
     try {
@@ -146,10 +156,10 @@ export class ProxyApiService {
   }
 
   async fetchContextByTeamId(
-    clientToken: string,
+    identity: RegelrettRequestIdentity,
     teamId: string,
   ): Promise<Result<ApiError, ContextWithMetrics[]>> {
-    const token = await this.entraIdService.getOboToken(clientToken);
+    const token = await this.getOboToken(identity);
     if (!token) throw new Error(`Failed to fetch token for Regelrett API`);
 
     try {
@@ -185,5 +195,12 @@ export class ProxyApiService {
         `Failed to fetch context by team id from Regelrett API with an unkown error: ${error}`,
       );
     }
+  }
+
+  private async getOboToken(identity: RegelrettRequestIdentity) {
+    if (!identity.entraIdToken) {
+      throw new Error('No Entra ID token provided for connected Regelrett');
+    }
+    return this.entraIdService.getOboToken(identity.entraIdToken);
   }
 }

--- a/plugins/regelrett-schemas-backend/src/services/syntheticRegelrettService.ts
+++ b/plugins/regelrett-schemas-backend/src/services/syntheticRegelrettService.ts
@@ -1,0 +1,191 @@
+import {
+  ApiError,
+  Context,
+  ContextWithMetrics,
+  Form,
+  RegelrettRequestIdentity,
+  RegelrettService,
+  Result,
+} from '../types';
+
+export const syntheticTeamIds = {
+  knekk: '00000000-0000-4000-8000-000000000004',
+  seig: '00000000-0000-4000-8000-000000000005',
+  skum: '00000000-0000-4000-8000-000000000008',
+} as const;
+
+const forms: Form[] = [
+  { id: 'synthetic-ros', name: 'Syntetisk ROS-analyse' },
+  { id: 'synthetic-privacy', name: 'Syntetisk personvernvurdering' },
+  { id: 'synthetic-readiness', name: 'Syntetisk produksjonsklarering' },
+];
+
+const initialContexts: ContextWithMetrics[] = [
+  {
+    id: '00000000-0000-4000-a000-000000000001',
+    teamId: syntheticTeamIds.knekk,
+    formId: 'synthetic-ros',
+    name: 'Fastslå hva som er spiselig',
+    answeredCount: 6,
+    expiredCount: 1,
+    totalCount: 8,
+  },
+  {
+    id: '00000000-0000-4000-a000-000000000002',
+    teamId: syntheticTeamIds.knekk,
+    formId: 'synthetic-privacy',
+    name: 'Kartlegge sjokolade, skum og gelé',
+    answeredCount: 5,
+    expiredCount: 0,
+    totalCount: 5,
+  },
+  {
+    id: '00000000-0000-4000-a000-000000000003',
+    teamId: syntheticTeamIds.knekk,
+    formId: 'synthetic-readiness',
+    name: 'Lag Knekk sin syntetiske årsrapport',
+    answeredCount: 3,
+    expiredCount: 0,
+    totalCount: 7,
+  },
+  {
+    id: '00000000-0000-4000-a000-000000000004',
+    teamId: syntheticTeamIds.seig,
+    formId: 'synthetic-ros',
+    name: 'Finne den siste favorittbiten',
+    answeredCount: 2,
+    expiredCount: 2,
+    totalCount: 8,
+  },
+];
+
+const functionOwnerTeamIds: Record<string, string> = {
+  'Fastslå hva som er spiselig': syntheticTeamIds.knekk,
+  'Kartlegge sjokolade, skum og gelé': syntheticTeamIds.knekk,
+  'Finne den siste favorittbiten': syntheticTeamIds.seig,
+  'Hjelpe innbyggerne med å finne godsakene': syntheticTeamIds.skum,
+  'Utgi Lørdagsatlaset': syntheticTeamIds.skum,
+};
+
+const groupTeamIds: Record<string, readonly string[]> = {
+  'group:default/lag-knekk': [syntheticTeamIds.knekk],
+  'group:default/lag-seig': [syntheticTeamIds.seig],
+  'group:default/lag-skum': [syntheticTeamIds.skum],
+  'group:default/spiselig-eiendom': [
+    syntheticTeamIds.knekk,
+    syntheticTeamIds.seig,
+  ],
+  'group:default/sjokolade-og-fast-eiendom': [
+    syntheticTeamIds.knekk,
+    syntheticTeamIds.seig,
+  ],
+  'group:default/godteriverket': Object.values(syntheticTeamIds),
+};
+
+const failureFunctionName = 'Utgi Lørdagsatlaset';
+
+const error = (
+  statusCode: number,
+  message: string,
+): Result<ApiError, never> => ({
+  ok: false,
+  error: { statusCode, message },
+});
+
+export class SyntheticRegelrettService implements RegelrettService {
+  private contexts = initialContexts.map(context => ({ ...context }));
+  private nextContextNumber = initialContexts.length + 1;
+
+  async fetchContextByFunctionName(
+    identity: RegelrettRequestIdentity,
+    name: string,
+  ): Promise<Result<ApiError, ContextWithMetrics[]>> {
+    const ownerTeamId = functionOwnerTeamIds[name];
+    if (ownerTeamId && !this.canAccessTeam(identity, ownerTeamId)) {
+      return error(403, 'Den syntetiske personen har ikke tilgang til laget');
+    }
+    if (name === failureFunctionName) {
+      return error(503, 'Syntetisk Regelrett-feil for testing');
+    }
+
+    const contexts = this.contexts
+      .filter(context => context.name === name)
+      .filter(context => this.canAccessTeam(identity, context.teamId))
+      .map(context => ({ ...context }));
+    return { ok: true, data: contexts };
+  }
+
+  async createRegelrettContext(
+    identity: RegelrettRequestIdentity,
+    name: string,
+    formId: string,
+    teamId: string,
+  ): Promise<Result<ApiError, Context>> {
+    if (!this.canAccessTeam(identity, teamId)) {
+      return error(403, 'Den syntetiske personen har ikke tilgang til laget');
+    }
+    if (name === failureFunctionName) {
+      return error(503, 'Syntetisk Regelrett-feil for testing');
+    }
+    if (!forms.some(form => form.id === formId)) {
+      return error(400, `Ukjent syntetisk skjematype '${formId}'`);
+    }
+    if (
+      this.contexts.some(
+        context =>
+          context.name === name &&
+          context.formId === formId &&
+          context.teamId === teamId,
+      )
+    ) {
+      return error(409, 'Skjemaet finnes allerede i syntetisk Regelrett');
+    }
+
+    const context: ContextWithMetrics = {
+      id: `00000000-0000-4000-a000-${String(this.nextContextNumber).padStart(12, '0')}`,
+      teamId,
+      formId,
+      name,
+      answeredCount: 0,
+      expiredCount: 0,
+      totalCount: 6,
+    };
+    this.nextContextNumber += 1;
+    this.contexts.push(context);
+    return { ok: true, data: { id: context.id, teamId, formId, name } };
+  }
+
+  async fetchForms(
+    _identity: RegelrettRequestIdentity,
+  ): Promise<Result<ApiError, Form[]>> {
+    return { ok: true, data: forms.map(form => ({ ...form })) };
+  }
+
+  async fetchContextByTeamId(
+    identity: RegelrettRequestIdentity,
+    teamId: string,
+  ): Promise<Result<ApiError, ContextWithMetrics[]>> {
+    if (!this.canAccessTeam(identity, teamId)) {
+      return error(403, 'Den syntetiske personen har ikke tilgang til laget');
+    }
+    if (teamId === syntheticTeamIds.skum) {
+      return error(503, 'Syntetisk Regelrett-feil for testing');
+    }
+
+    return {
+      ok: true,
+      data: this.contexts
+        .filter(context => context.teamId === teamId)
+        .map(context => ({ ...context })),
+    };
+  }
+
+  private canAccessTeam(
+    identity: RegelrettRequestIdentity,
+    teamId: string,
+  ): boolean {
+    return identity.ownershipEntityRefs.some(ref =>
+      groupTeamIds[ref.toLowerCase()]?.includes(teamId),
+    );
+  }
+}

--- a/plugins/regelrett-schemas-backend/src/types.ts
+++ b/plugins/regelrett-schemas-backend/src/types.ts
@@ -18,6 +18,12 @@ export type ContextWithMetrics = Context & {
   totalCount: number;
 };
 
+export type RegelrettRequestIdentity = {
+  entraIdToken?: string;
+  userEntityRef: string;
+  ownershipEntityRefs: string[];
+};
+
 export type Form = {
   id: string;
   name: string;
@@ -29,6 +35,26 @@ export type ApiError = {
 };
 
 export type Result<ErrorType, DataType> = Err<ErrorType> | Ok<DataType>;
+
+export interface RegelrettService {
+  fetchContextByFunctionName(
+    identity: RegelrettRequestIdentity,
+    name: string,
+  ): Promise<Result<ApiError, ContextWithMetrics[]>>;
+  createRegelrettContext(
+    identity: RegelrettRequestIdentity,
+    name: string,
+    formId: string,
+    teamId: string,
+  ): Promise<Result<ApiError, Context>>;
+  fetchForms(
+    identity: RegelrettRequestIdentity,
+  ): Promise<Result<ApiError, Form[]>>;
+  fetchContextByTeamId(
+    identity: RegelrettRequestIdentity,
+    teamId: string,
+  ): Promise<Result<ApiError, ContextWithMetrics[]>>;
+}
 
 type Err<E> = { ok: false; error: E };
 type Ok<T> = { ok: true; data: T };


### PR DESCRIPTION
## 🔒 Bakgrunn

Ønsker en syntetisk Regelrett-integrasjon som gjør det mulig for utviklere å jobbe med kartverket.dev og tilhørende Regelrett-komponenter i frontend uten å kjøre Regelrett eller koble til Microsoft Entra ID.

## 🧪  Hvordan teste
Kjør opp appen uten app-config.local.yaml. Sjekk at Regelrett-skjemaene fungerer (mockes).
