### PR TITLE
remove import of typescript ros plugin

### DIFF
--- a/app-config.local.example.yaml
+++ b/app-config.local.example.yaml
@@ -81,16 +81,3 @@ regelrett:
   baseUrl: http://localhost:8080
   url: http://localhost:8080
   clientId: ${REGELRETT_CLIENT_ID}
-
-# 5c. RiSc / risk-scorecard
-ros:
-  sops:
-    ageKey: ${ROS_SOPS_AGE_KEY}
-    backendPublicKey: ${ROS_SOPS_BACKEND_PUBLIC_KEY}
-    securityTeamPublicKey: ${ROS_SOPS_SECURITY_TEAM_PUBLIC_KEY}
-    securityPlatformPublicKey: ${ROS_SOPS_SECURITY_PLATFORM_PUBLIC_KEY}
-  slack:
-    webhookUrl: ${ROS_SLACK_WEBHOOK_URL}
-  initRiSc:
-    repoOwner: kartverket
-    repoName: initial-riscs-collection

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -63,5 +63,5 @@ backend.add(catalogNotificationsModule);
 backend.add(import('@backstage/plugin-signals-backend'));
 backend.add(import('@internal/plugin-catalog-backend-module-function-kind'));
 
-backend.add(import('@kartverket/backstage-plugin-risk-scorecard-backend'));
+// backend.add(import('@kartverket/backstage-plugin-risk-scorecard-backend'));
 backend.start();


### PR DESCRIPTION
## 🔒 Bakgrunn
Kan ikke kjøre kv.dev uten å configge opp ros, selv om typescript ros backend ikke brukes. 



## 🔑 Løsning
Kommentert ut ros-backend import så man ikke trenger å ha ros-config.
Endret app.config.local.example for å reflektere dette. 

NB: Dette er en midlertidig løsning, hele pluginen skal fjernes. 

## 📸 Bilder

| Før   | Etter |
| ----- | ----- |
| Bilde | Bilde |